### PR TITLE
Allow gulp in npm-scripts to be found on the path.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "src/app.es6.js",
   "scripts": {
     "start": "node --harmony index.js",
-    "build": "./node_modules/gulp/bin/gulp.js",
-    "watch": "./node_modules/gulp/bin/gulp.js watch",
+    "build": "gulp",
+    "watch": "gulp watch",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "reddit <jack@reddit.com>",


### PR DESCRIPTION
In a regular install, the executables are automatically linked into
node_modules/.bin/ by `npm install` and `npm run` will add that
directory onto the PATH, so this should work out of the box.

This allows us some flexibility in where `node_modules` actually exists
which will make production deployment easier.

You can verify that the path will work with `npm run env | grep PATH`.

:eyeglasses: @ajacksified 