### PR TITLE
Bring bullets back to ul default styling; use `list-unstyled`

### DIFF
--- a/assets/less/reset.less
+++ b/assets/less/reset.less
@@ -5,10 +5,6 @@ button {
   padding: 0;
 }
 
-ul {
-  list-style-type: none;
-}
-
 svg:not(:root) {
   overflow: visible;
 }

--- a/src/views/components/Dropdown.jsx
+++ b/src/views/components/Dropdown.jsx
@@ -25,7 +25,7 @@ class Dropdown extends React.Component {
         { this.props.button }
         <div className='Dropdown-tab shadow tween'>
           <div className={'stalagmite' + ( this.props.right ? ' pull-right' : '' )}></div>
-          <ul className='Dropdown-ul'>
+          <ul className='Dropdown-ul list-unstyled'>
             { this.props.children }
           </ul>
         </div>


### PR DESCRIPTION
Fixes lists in parsed markdown.

![screen shot 2015-03-23 at 11 59 12 am](https://cloud.githubusercontent.com/assets/175515/6788027/1396f626-d154-11e4-848f-f66af5ba273e.png)
