### PR TITLE
Node.js and IO.js README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Plugins register themselves via two interfaces:
 Getting Up and Running
 ----------------------
 
-0. Install [node.js](https://nodejs.org/download/) or [io.js](https://iojs.org).
+0. Install [node.js](https://nodejs.org/download/) v0.12+ or [io.js](https://iojs.org) v1.8.1+.
 1. [Fork](https://github.com/reddit/switcharoo/fork) and clone
   this project.
 2. Also fork and clone any plugins you plan on developing. In these, run

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Plugins register themselves via two interfaces:
 Getting Up and Running
 ----------------------
 
-0. Install node.js or io.js.
+0. Install [node.js](https://nodejs.org/download/) or [io.js](https://iojs.org).
 1. [Fork](https://github.com/reddit/switcharoo/fork) and clone
   this project.
 2. Also fork and clone any plugins you plan on developing. In these, run


### PR DESCRIPTION
Update to the README file in which the two options for tooling / running
the app and setup "node.js" and "io.js" now have an easily accessible
link to download directly from "Getting Up and Running" instructions
section.