### PR TITLE
Fix: Scroll in the menu on Safari on iOS 8.3

### DIFF
--- a/assets/less/components/SideNav.less
+++ b/assets/less/components/SideNav.less
@@ -30,7 +30,12 @@
       }
 
       &.opened {
-        max-height: 300px;
+        max-height: none;
+
+        > .SideNav-ul {
+          max-height: 280px;
+          overflow-y: auto;
+        }
       }
     }
 


### PR DESCRIPTION
:eyeglasses: @danehansen 