### PR TITLE
Add theme-color attribute for Android 5.0+

### DIFF
--- a/src/views/layouts/DefaultLayout.jsx
+++ b/src/views/layouts/DefaultLayout.jsx
@@ -55,6 +55,7 @@ class DefaultLayout extends React.Component {
           { canonical }
 
           <meta name='viewport' content='width=device-width, initial-scale=1.0' />
+          <meta name='theme-color' content='#EEEEEE' />
           <meta id='csrf-token-meta-tag' name='csrf-token' content={ this.props.csrf } />
           { metaDescription }
 

--- a/src/views/layouts/DefaultLayout.jsx
+++ b/src/views/layouts/DefaultLayout.jsx
@@ -55,7 +55,7 @@ class DefaultLayout extends React.Component {
           { canonical }
 
           <meta name='viewport' content='width=device-width, initial-scale=1.0' />
-          <meta name='theme-color' content='#EEEEEE' />
+          <meta name='theme-color' content='#336699' />
           <meta id='csrf-token-meta-tag' name='csrf-token' content={ this.props.csrf } />
           { metaDescription }
 


### PR DESCRIPTION
Starting with Chrome 39 (for Android 5.0+ and up), it accepts a meta attribute (theme-color) which tells it what to color the address bar with. It also takes the 700 variant of the color and uses it for the status bar to show a darker version of the address bar.

This can be whatever color Reddit prefers it to be (for branding and such), but I think the presence of any color makes the page feel "more at home" for users who are using Android Lollipop.