### PR TITLE
CommentBox: move hidden inputs so we can use + selector.

### DIFF
--- a/assets/less/components/comment.less
+++ b/assets/less/components/comment.less
@@ -195,8 +195,8 @@
       height: 10em;
     }
 
-    &:focus ~ .btn-post,
-    &.has-content ~ .btn-post {
+    &:focus + .btn-post,
+    &.has-content + .btn-post {
       opacity: 1;
       visibility: visible;
     }

--- a/assets/less/components/comment.less
+++ b/assets/less/components/comment.less
@@ -190,11 +190,6 @@
     border-radius: 5px;
     margin-bottom: 15px;
 
-    &:focus {
-      .box-shadow(none);
-      height: 10em;
-    }
-
     &:focus + .btn-post,
     &.has-content + .btn-post {
       opacity: 1;

--- a/src/views/components/CommentBox.jsx
+++ b/src/views/components/CommentBox.jsx
@@ -67,12 +67,12 @@ class CommentBox extends React.Component {
       <div className='row CommentBox'>
         <div className='col-xs-12'>
           <form action={ '/comment' } method='POST' onSubmit={ this.submit.bind(this) }>
+            <input type='hidden' name='thingId' value={ this.props.thingId } />
+            { csrf }
             <label className='sr-only' htmlFor={ 'textarea-' + this.props.thingId }>Comment</label>
             <textarea placeholder='Add your comment!' id={ 'textarea-' + this.props.thingId } rows='2'
                       className={ `form-control ${this.state.inputCssClass}` } name='text' ref='text'
                       onChange={ this.handleInputChange.bind(this) }></textarea>
-            <input type='hidden' name='thingId' value={ this.props.thingId } />
-            { csrf }
             <button type='submit' className='btn-post'>Post</button>
           </form>
         </div>


### PR DESCRIPTION
Fixes issue with android browser which doesnt support the
~ css selector.


:eyeglasses: @ajacksified @danehansen 

Not sure what you guys think. So this fixes the issue with the android browser not showing the button since it doesn't support the `~` selector. But it seems to introduce some strange behavior with the textarea which now only reverts to the smaller size when you tap in another focusable element. I looked at other solutions, no luck. But having it stay large doesn't really affect usability so I thought I would just leave it. thoughts?