### PR TITLE
Date-based referrer logic for "new user" setting

### DIFF
--- a/src/server.jsx
+++ b/src/server.jsx
@@ -136,6 +136,17 @@ class Server {
       if (this.cookies.get('loid')) {
         this.loid = this.cookies.get('loid');
         this.loidcreated = this.cookies.get('loidcreated');
+
+        // If user came from desktop, and is a new user, treat them as new for
+        // experiments.
+        if (this.query.ref_source === 'desktop') {
+          let created = new Date(this.loidcreated);
+
+          if (created.setMinutes(created.getMinutes() - 5) < Date.now()) {
+            this.newUser = true;
+          }
+        }
+
         yield next;
         return;
       }


### PR DESCRIPTION
If the user came from the desktop site after visiting the desktop for the first time within the last 5 minutes, treat them as a new user for experiments.

:eyeglasses: @umbrae 