### PR TITLE
Fix redirect on expired tokens

### DIFF
--- a/src/oauth.es6.js
+++ b/src/oauth.es6.js
@@ -124,9 +124,11 @@ var oauthRoutes = function(app) {
     return new Promise(function(resolve, reject) {
       let endpoint = app.config.nonAuthAPIOrigin + '/api/me.json';
 
+      let cookie = ctx.headers['cookie'].replace(/__cf_mob_redir=1/, '__cf_mob_redir=0');
+
       let headers = {
         'User-Agent': ctx.headers['user-agent'],
-        cookie: ctx.headers['cookie'].replace(/__cf_mob_redir=1/, '__cf_mob_redir=0'),
+        cookie: cookie,
         'accept-encoding': ctx.headers['accept-encoding'],
         'accept-language': ctx.headers['accept-language'],
       };
@@ -148,9 +150,23 @@ var oauthRoutes = function(app) {
           let modhash = res.body.data.modhash;
           let endpoint = app.config.nonAuthAPIOrigin + '/api/v1/authorize';
 
+          let redirect_uri = app.config.origin + '/oauth2/token';
+
+          let clientId;
+          let clientSecret;
+
+          if (app.config.oauth.secretClientId) {
+            clientId = app.config.oauth.secretClientId;
+            clientSecret = app.config.oauth.secretSecret;
+          } else {
+            clientId = app.config.oauth.clientId;
+            clientSecret = app.config.oauth.secret;
+          }
+
+
           let postParams = {
-            client_id: app.config.oauth.clientId,
-            redirect_uri: app.config.origin + '/oauth2/token',
+            client_id: clientId,
+            redirect_uri: redirect_uri,
             scope: SCOPE,
             state: modhash,
             duration: 'permanent',
@@ -182,11 +198,11 @@ var oauthRoutes = function(app) {
               let postData = {
                 grant_type: 'authorization_code',
                 code: code,
-                redirect_uri: app.config.origin + '/oauth2/token',
+                redirect_uri: redirect_uri,
               };
 
               let b = new Buffer(
-                app.config.oauth.clientId + ':' + app.config.oauth.secret
+                clientId + ':' + clientSecret
               );
 
               let s = b.toString('base64');

--- a/src/server.jsx
+++ b/src/server.jsx
@@ -341,11 +341,11 @@ class Server {
         return;
       }
 
-       let session = this.cookies.get('reddit_session');
+      let session = this.cookies.get('reddit_session');
 
       if (!this.token &&
           !this.cookies.get('token') &&
-          this.cookies.get('reddit_session')) {
+          session) {
 
         try {
           var token = yield app.convertSession(this, session);
@@ -357,7 +357,7 @@ class Server {
         } catch (e) {
           // server errored, continue as logged out for now
           if (app.config.debug) {
-            console.log(e);
+            console.log(e, e.stack);
           }
         }
 
@@ -370,6 +370,7 @@ class Server {
 
   checkToken (app) {
     return function * (next) {
+
       var now = new Date();
       var expires = this.cookies.get('tokenExpires');
 
@@ -396,6 +397,10 @@ class Server {
 
           app.setTokenCookie(this, token);
         } catch (e) {
+          if (app.config.debug) {
+            console.log(e, e.stack);
+          }
+
           this.cookies.set('tokenExpires');
           this.cookies.set('token');
           this.cookies.set('refreshToken');


### PR DESCRIPTION
:eyeglasses: @danehansen or @curioussavage 

The wrong oauth client id was being used for converted sessions, so refreshing the token was failing and redirecting users to the home page.