### PR TITLE
Replace env variables with strings

### DIFF
--- a/buildTasks/js.js
+++ b/buildTasks/js.js
@@ -13,6 +13,7 @@ var streamqueue = require('streamqueue');
 var browserify = require('browserify');
 var watchify = require('watchify');
 var babelify = require('babelify');
+var envify = require('envify/custom');
 var exorcist = require('exorcist');
 var path = require('path');
 var gulpIf = require('gulp-if');
@@ -67,6 +68,11 @@ module.exports = function buildJS(gulp, options) {
         ignore: /.+node_modules\/(moment|q|react|reddit-text-js|superagent|gsap|lodash)\/.+/i,
         extensions: ['.js', '.es6.js', '.jsx' ],
         sourceMap: !options.debug,
+      }), {
+        global: true,
+      })
+      .transform(envify({
+        NODE_ENV: options.debug ? 'development' : 'production',
       }), {
         global: true,
       });

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "dom-serializer": "git://github.com/ajacksified/dom-serializer.git#c999b029caa6d4a9f1fbeb512b48ec7c75c1dddb",
     "browserify": "9.0.7",
     "del": "1.1.1",
+    "envify": "3.4.0",
     "exorcist": "0.1.6",
     "fastclick": "1.0.6",
     "glob": "5.0.10",


### PR DESCRIPTION
Example:

```js
// This:
if (process.env.NODE_ENV === 'development') {
  console.log('dev!');
}

// Turns into this:
if ('production' === 'development') {
  console.log('dev!');
}
```

Uglify is able to strip the latter via dead code removal, but not
the former.

See https://github.com/reddit/reddit-mobile/issues/247#issuecomment-118551305 and https://facebook.github.io/react/downloads.html#npm for more info.

:eyeglasses: @ajacksified 