### PR TITLE
Move referrer to property; clear after first page load

### DIFF
--- a/assets/js/client.es6.js
+++ b/assets/js/client.es6.js
@@ -70,6 +70,8 @@ if (!Object.create || !Array.prototype.map || !Object.freeze) {
   });
 }
 
+var referrer = document.referrer;
+
 function modifyContext (ctx) {
   ctx.loid = this.getState('loid');
   ctx.loidcreated = this.getState('loidcreated');
@@ -77,6 +79,7 @@ function modifyContext (ctx) {
   ctx.user = this.getState('user');
   ctx.useCache = true;
   ctx.experiments = this.getState('experiments');
+  ctx.headers.referer = referrer;
 
   // Is set with a client-side cookie, sometimes hitting 'back' doesn't
   // restore proper state
@@ -269,7 +272,11 @@ function initialize(bindLinks) {
   // Don't re-render tracking pixel on first load. App reads from state
   // (bootstrap) on first load, so override state, and then set the proper
   // config value after render.
-  app.render(app.fullPathName(), true, modifyContext);
+  app.render(app.fullPathName(), true, modifyContext, function() {
+    // Reset the referrer that ctx uses after the first load.
+    referrer = document.location.href;
+  });
+
 
   app.on('route:desktop', function(route) {
     let options = {};

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -221,6 +221,7 @@ function routes(app) {
       query: ctx.query,
       params: ctx.params,
       url: ctx.path,
+      referrer: ctx.headers.referer,
       isGoogleCrawler: ctx.isGoogleCrawler,
       apiOptions: {
         useCache: ctx.useCache,

--- a/src/views/components/TrackingPixel.jsx
+++ b/src/views/components/TrackingPixel.jsx
@@ -9,10 +9,9 @@ class TrackingPixel extends React.Component {
   componentDidMount () {
     if (this.props.url) {
       var trackingUrl = this.props.url + '&r=' + Math.random();
-      var referrer;
 
-      if (document && document.referrer) {
-        let domain = url.parse(document.referrer).host;
+      if (this.props.referrer) {
+        let domain = url.parse(this.props.referrer).host;
         trackingUrl += '&referrer_domain=' + domain;
       }
 

--- a/src/views/pages/index.jsx
+++ b/src/views/pages/index.jsx
@@ -148,6 +148,7 @@ class IndexPage extends React.Component {
     if (this.state.data.meta) {
       tracking = (
         <TrackingPixel
+          referrer={ props.referrer }
           url={ this.state.data.meta.tracking }
           user={ props.user }
           loid={ props.loid }

--- a/src/views/pages/listing.jsx
+++ b/src/views/pages/listing.jsx
@@ -221,6 +221,7 @@ class ListingPage extends React.Component {
     if (this.state.data.meta) {
       tracking = (
         <TrackingPixel
+          referrer={ props.referrer }
           url={ this.state.data.meta.tracking }
           loid={ props.loid }
           loidcreated={ props.loidcreated }

--- a/src/views/pages/search.jsx
+++ b/src/views/pages/search.jsx
@@ -251,6 +251,7 @@ class SearchPage extends React.Component {
     if (state.data.meta) {
       tracking = (
         <TrackingPixel
+          referrer={ props.referrer }
           url={ state.data.meta.tracking }
           user={ this.props.user }
           loid={ this.props.loid }

--- a/src/views/pages/subredditAbout.jsx
+++ b/src/views/pages/subredditAbout.jsx
@@ -50,6 +50,7 @@ class SubredditAboutPage extends React.Component {
     if (this.state.data.meta) {
       tracking = (
         <TrackingPixel
+          referrer={ props.referrer }
           url={ this.state.data.meta.tracking }
           user={ this.props.user }
           loid={ this.props.loid }

--- a/src/views/pages/userActivity.jsx
+++ b/src/views/pages/userActivity.jsx
@@ -80,6 +80,7 @@ class UserActivityPage extends React.Component {
     if (state.data.meta) {
       tracking = (
         <TrackingPixel
+          referrer={ props.referrer }
           url={ state.data.meta.tracking }
           user={ props.user }
           loid={ props.loid }

--- a/src/views/pages/userGild.jsx
+++ b/src/views/pages/userGild.jsx
@@ -54,6 +54,7 @@ class UserGildPage extends React.Component {
     if (this.state.data.meta) {
       tracking = (
         <TrackingPixel
+          referrer={ props.referrer }
           url={ this.state.data.meta.tracking }
           user={ this.props.user }
           loid={ this.props.loid }

--- a/src/views/pages/userProfile.jsx
+++ b/src/views/pages/userProfile.jsx
@@ -64,6 +64,7 @@ class UserProfilePage extends React.Component {
     if (this.state.data.meta) {
       tracking = (
         <TrackingPixel
+          referrer={ props.referrer }
           url={ this.state.data.meta.tracking }
           user={ this.props.user }
           loid={ this.props.loid }

--- a/src/views/pages/userSaved.jsx
+++ b/src/views/pages/userSaved.jsx
@@ -85,6 +85,7 @@ class UserSavedPage extends React.Component {
     if (state.data.meta) {
       tracking = (
         <TrackingPixel
+          referrer={ props.referrer }
           url={ state.data.meta.tracking }
           user={ props.user }
           loid={ props.loid }


### PR DESCRIPTION
:eyeglasses: @danehansen 

Should eventually maybe wrap up TrackingPixel in a way that isn't so copypasty.