### PR TITLE
Increase z-index on top nav, fixes search page.

### DIFF
--- a/assets/less/components/search.less
+++ b/assets/less/components/search.less
@@ -32,11 +32,11 @@
     border-bottom: @gray-border;
     padding-bottom: 10px;
 
-    & + .listings-container {
+    & + .listing-container {
       padding-top: 10px;
     }
 
-    &.hidden + .listings-container {
+    &.hidden + .listing-container {
       padding-top: 0;
     }
 

--- a/src/views/pages/search.jsx
+++ b/src/views/pages/search.jsx
@@ -212,7 +212,7 @@ class SearchPage extends BaseComponent {
                   title="Show more" onClick={this.handleShowMoreClick.bind(this)}>Show more</button>
         </div>,
 
-        <div className={ `container listings-container ${noListResults ? 'hidden' : ''}` }
+        <div className={ `container listing-container ${noListResults ? 'hidden' : ''}` }
              ref="listings" key="search-listings">
 
           <h4 className="text-center">Posts</h4>


### PR DESCRIPTION
:eyeglasses: @danehansen 
fix for [MOBILEWEB-226](https://reddit.atlassian.net/browse/MOBILEWEB-226)

The z index being set on the Listings is hiding the nav on search page. Should this be set higher since we will be doing infinite scroll? or is there a better fix? looked at differences between this and index page can't tell what keeps it from happening there.