### PR TITLE
Impression tracking

### DIFF
--- a/src/views/components/Ad.jsx
+++ b/src/views/components/Ad.jsx
@@ -18,7 +18,7 @@ class Ad extends BaseComponent {
       unavailable: false,
     };
 
-    this._scroll = this._scroll.bind(this);
+    this._checkImpression = this._checkImpression.bind(this);
 
     this._removeListeners = this._removeListeners.bind(this);
   }
@@ -114,11 +114,11 @@ class Ad extends BaseComponent {
       });
     });
 
-    globals().app.on(constants.SCROLL, this._scroll);
-    globals().app.on(constants.RESIZE, this._scroll);
+    globals().app.on(constants.SCROLL, this._checkImpression);
+    globals().app.on(constants.RESIZE, this._checkImpression);
 
     this._hasListeners = true;
-    this._scroll();
+    this._checkImpression();
   }
 
   componentDidUpdate (prevProps, prevState) {
@@ -133,13 +133,13 @@ class Ad extends BaseComponent {
 
   _removeListeners() {
     if (this._hasListeners) {
-      globals().app.off(constants.SCROLL, this._scroll);
-      globals().app.off(constants.RESIZE, this._scroll);
+      globals().app.off(constants.SCROLL, this._checkImpression);
+      globals().app.off(constants.RESIZE, this._checkImpression);
       this._hasListeners = false;
     }
   }
 
-  _scroll() {
+  _checkImpression() {
     var adObject = this.state.ad;
     if (adObject) {
       var node = React.findDOMNode(this);

--- a/src/views/components/Ad.jsx
+++ b/src/views/components/Ad.jsx
@@ -124,6 +124,7 @@ class Ad extends BaseComponent {
   componentDidUpdate (prevProps, prevState) {
     if (!prevState.loaded && this.state.loaded) {
       this.props.afterLoad();
+      this._checkImpression();
     }
   }
 


### PR DESCRIPTION
Impressions are only being checked on scroll/resize.  This also checks immediately after the ad is loaded.

The problem before is that I could refresh the page over and over and never have the impression counted so long as I didn't scroll.

:eyeglasses: @curioussavage @zeantsoi 