### PR TITLE
Fix loid caching issue

### DIFF
--- a/assets/js/client.es6.js
+++ b/assets/js/client.es6.js
@@ -72,9 +72,13 @@ if (!Object.create || !Array.prototype.map || !Object.freeze) {
 var referrer = document.referrer;
 
 function modifyContext (ctx) {
-  ctx.loid = this.getState('loid');
-  ctx.loidcreated = this.getState('loidcreated');
   ctx.token = this.getState('token');
+
+  if (!ctx.token) {
+    ctx.loid = cookies.get('loid');
+    ctx.loidcreated = cookies.get('loidcreated');
+  }
+
   ctx.user = this.getState('user');
   ctx.useCache = true;
   ctx.experiments = this.getState('experiments');

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -232,9 +232,6 @@ function routes(app) {
       props.tokenExpires = ctx.tokenExpires;
       props.apiOptions.origin = app.getConfig('authAPIOrigin');
       props.apiOptions.headers['Authorization'] = `bearer ${props.token}`;
-    } else {
-      props.loid = ctx.loid;
-      props.loidcreated = ctx.loidcreated;
     }
 
     props.apiOptions = globals().api.buildOptions(props.apiOptions);


### PR DESCRIPTION
`loid` was being grabbed from the bootstraped data which in some
cases is cached by the cdn.  This properly takes it from the user's
cookies.

:eyeglasses: @ajacksified 

https://m.staging.wireddit.com/

lgtm