### PR TITLE
Rewrite redirects using `param` instead of regexes for koa-router

### DIFF
--- a/src/app-mixin.es6.js
+++ b/src/app-mixin.es6.js
@@ -18,8 +18,8 @@ function mixin (App) {
         defaultHeaders: this.config.apiHeaders,
       });
 
-      routes(this);
       redirects(this);
+      routes(this);
     }
 
     error (e, ctx, app) {

--- a/src/redirects.jsx
+++ b/src/redirects.jsx
@@ -1,27 +1,38 @@
 // Redirect desktop urls to mobile-web urls.
-function routes(app) {
-  app.router.get(/^\/(hot|new|rising|controversial|top|gilded)\b/, function *(next) {
-    this.redirect('/?sort=' + this.params[0]);
-  });
+const SORTS = ['hot', 'new', 'rising', 'controversial', 'top', 'gilded'];
 
-  app.router.get(/^\/r\/(\w+)\/(hot|new|rising|controversial|top|gilded)\b/, function *(next) {
-    this.redirect('/r/' + this.params[0] + '/?sort=' + this.params[1]);
-  });
+function routes(app) {
+  app.router
+    .param('sort', function *(sort, next) {
+      if (SORTS.indexOf(sort) !== -1) {
+        var url = `?sort=${sort}`;
+
+        if (this.params.subreddit) {
+          url = `/r/${this.params.subreddit}${url}`;
+        }
+
+        return this.redirect(url);
+      }
+
+      yield next;
+    })
+    .get('/:sort')
+    .get('/r/:subreddit/:sort');
 
   app.router.get('/user/:user', function *(next) {
-    this.redirect('/u/' + this.params.user);
+    return this.redirect(`/u/${this.params.user}`);
   });
 
   app.router.get('/user/:user/m/:multi', function *(next) {
-    this.redirect('/u/' + this.params.user + '/m/' + this.params.multi);
+    return this.redirect(`/u/${this.params.user}/m/${this.params.multi}`);
   });
 
   app.router.get('/search/:query', function*(next) {
-    this.redirect(`/search?q=${this.params.query}`);
+    return this.redirect(`/search?q=${this.params.query}`);
   });
 
   app.router.get('/r/:subreddit/search/:query', function*(next) {
-    this.redirect(`/r/${this.params.subreddit}/search?q=${this.params.query}`);
+    return this.redirect(`/r/${this.params.subreddit}/search?q=${this.params.query}`);
   });
 }
 


### PR DESCRIPTION
:eyeglasses: @curioussavage 

Also notifying @kjoconnor and @umbrae 

The new version of koa-router doesn't support regexes anymore, which means we need to use `param` filters, as seen below. I also moved redirects above `routes` for higher priority and added `return`s so that multiple route-matching functions don't end up being called.