### PR TITLE
Remove popstate safety check

### DIFF
--- a/assets/js/client.es6.js
+++ b/assets/js/client.es6.js
@@ -293,20 +293,17 @@ function initialize(bindLinks) {
 
       window.addEventListener('popstate', function(e) {
         var href = app.fullPathName();
-        // Work around some browsers firing popstate on initial load
-        if (href !== initialUrl) {
-          scrollCache[initialUrl] = window.scrollY;
+        scrollCache[initialUrl] = window.scrollY;
 
-          app.render(href, false, modifyContext).then(function(props) {
-            if(scrollCache[href]) {
-              $body.scrollTop = scrollCache[href];
-            }
+        app.render(href, false, modifyContext).then(function(props) {
+          if(scrollCache[href]) {
+            $body.scrollTop = scrollCache[href];
+          }
 
-            setTitle(props);
-          });
+          setTitle(props);
+        });
 
-          initialUrl = href;
-        }
+        initialUrl = href;
       });
     }
   }


### PR DESCRIPTION
Previously, the 'popstate' event listener checked to see if your url had
changed. This is no longer necessary now that events are not bound until
_after_ the app render, and may fix some issues with prev/next browser
cache reloading.

:eyeglasses: @curioussavage 