### PR TITLE
Client oauth refresh improvements

### DIFF
--- a/src/app-mixin.jsx
+++ b/src/app-mixin.jsx
@@ -49,13 +49,7 @@ function mixin (App) {
 
       // API error
       if (e.status) {
-        if (ctx.token && e.status === 401) {
-          // Improper token or does not have access.
-          // Should be a refresh token instead of a login redirect, but this
-          // will at least fix issues for currently logged-in users.
-          // TODO: change to refresh
-          return ctx.redirect(app.config.loginPath);
-        } else if (e.status === 403) {
+        if (!ctx.token && e.status === 403) {
           // Missing authorization
           return ctx.redirect(app.config.loginPath);
         }
@@ -230,6 +224,12 @@ function mixin (App) {
           </BodyLayout>
         );
       }
+    }
+
+    loadingpage (props) {
+      return (
+        <Loading />
+      );
     }
   }
 


### PR DESCRIPTION
* Don't route the app if we're in the middle of refreshing the token,
cutting down on unnecessary auth errors
* Show a loading screen while oauth is being refreshed, if you try to
change the route in the middle, so things don't freeze
* Fixes a current bug where if you're away for a while, then come back,
you're taken to a login screen

:eyeglasses: @curioussavage or @umbrae 

To test:  set `expires = Date.now()` right after `var expires = new Date(app.getState('tokenExpires'));` in `client.es6.js`, watch for the token to change on the next api request. woo :tada: 