### PR TITLE
Comment minor improvements

### DIFF
--- a/assets/less/components/comment.less
+++ b/assets/less/components/comment.less
@@ -50,8 +50,7 @@
 }
 
 .comment-article {
-  .transition(.2s all ease);
-  padding-left: .5em;
+  padding-left: 3px;
 
   &.comment-highlighted {
     background-color: darken(@brand-primary-bg-lightest, 2.5%);
@@ -66,15 +65,23 @@
   margin-left: .4em;
 }
 
+.comment-loadmore {
+  margin-bottom: 1em;
+
+  a:active, a:hover {
+    text-decoration: none;
+  }
+}
+
 .linkbar.comment-title-list {
   width: 100%;
 
   &.linkbar-compact li.twirly {
-    left: -14px;
-    width: 19px;
+    left: -10px;
+    width: 12px;
     padding-bottom: 0;
     margin-right: 0;
-    height: 17px;
+    height: 18px;
 
     &:before {
       display: inline-block;
@@ -99,7 +106,11 @@
 }
 
 .comment-timestamp {
-  margin-right: 1em;
+  &:after {
+    content: "•";
+    color: @light-gray;
+    padding: 0 .5em;
+  }
 }
 
 .comment-title-vote-icon.glyphicon {
@@ -129,7 +140,10 @@
 .comment-submitted {
   color: @gray;
   font-size: @font-size-small;
-  margin-bottom: 5px;
+}
+
+.comment-body {
+  padding: .5em 0;
 }
 
 .comment-vote {
@@ -161,8 +175,7 @@
 }
 
 .CommentBox-textarea-holder {
-    margin-bottom: 15px;
-    height: 4em;
+  height: 4em;
 
   .form-control {
     .transition(height .2s ease);
@@ -172,15 +185,6 @@
   &.has-content + .btn-post {
     opacity: 1;
     visibility: visible;
-  }
-}
-
-.comment-textarea-holder {
-  height: 300px;
-
-  .form-control {
-    resize: none;
-    height: 100%;
   }
 }
 

--- a/assets/less/components/text.less
+++ b/assets/less/components/text.less
@@ -1,23 +1,32 @@
 a {
   color: @blue;
+  [class*=" icon-"] { color: @blue; }
 
   &:active {
     color: lighten(@blue, 20%);
+    [class*=" icon-"] { color: lighten(@blue, 20%); }
   }
 
   &:visited {
     color: lighten(@blue, 40%);
+    [class*=" icon-"] { color: lighten(@blue, 40%); }
   }
+}
+
+.text-muted:hover [class*="icon-"] {
+  color: @light-gray;
 }
 
 a.voted.text-upvote:hover,
 a.voted.text-upvote:focus,
+button.upvoted:hover .icon-upvote-circled,
 .text-upvote {
   color: @orangered;
 }
 
 a.voted.text-downvote:hover,
 a.voted.text-downvote:focus,
+button.downvoted:hover .icon-downvote-circled,
 .text-downvote {
   color: @periwinkle;
 }
@@ -140,7 +149,8 @@ a.voted.text-downvote:focus,
 
 .text-muted a,
 .text-muted a:visited,
-.text-muted a:hover {
+.text-muted a:hover,
+{
   &:extend(.text-muted);
 }
 
@@ -198,6 +208,14 @@ blockquote {
 p {
   word-wrap: break-word;
   word-break: keep-all;
+}
+
+.text-small {
+  font-size: 12px;
+
+  [class*=" icon-"] {
+    line-height: 13px;
+  }
 }
 
 .text-super-large {

--- a/src/views/components/Comment.jsx
+++ b/src/views/components/Comment.jsx
@@ -300,9 +300,9 @@ class Comment extends BaseComponent {
         <div className='comment-children comment-content'>
           {
             comment.replies.map((c, i) => {
-              if (c && c.bodyHtml !== undefined) {
-                var key = 'page-comment-' + c.name + '-' + i;
+              var key = 'page-comment-' + c.name + '-' + i;
 
+              if (c && c.bodyHtml !== undefined) {
                 return (
                   <Comment
                     {...this.props}
@@ -316,13 +316,15 @@ class Comment extends BaseComponent {
                 let numChildren = c.children.length;
                 let word = numChildren > 1 ? 'replies' : 'reply';
                 let permalink = permalinkBase + c.parent_id.substring(3) + '?context=0';
-                let text = loadingMoreComments ? 'Loading...' : `load more comments (${numChildren} ${word})`;
+                let text = loadingMoreComments ? 'Loading...' : `Load ${numChildren}  ${word}`;
                 return (
-                  <a
-                    href={permalink}
-                    data-no-route='true'
-                    onClick={this.loadMore.bind(this, c)}
-                  >{ text }</a>
+                  <div className='comment-content comment-loadmore text-small' key={key}>
+                    <a
+                      href={permalink}
+                      data-no-route='true'
+                      onClick={this.loadMore.bind(this, c)}
+                      ><span className='icon icon-comments' />{ text }</a>
+                  </div>
                 );
               }
             })
@@ -397,7 +399,7 @@ class Comment extends BaseComponent {
                 <li className='comment-timestamp-score'>
                   <span className='comment-timestamp'>{ submitted }</span>
                   <span className='comment-title-score'>
-                    { comment.score_hidden ? '[score hidden]' : score }
+                    { comment.score_hidden ? '' : score }
                   </span>
                 </li>
               </ul>

--- a/src/views/pages/listing.jsx
+++ b/src/views/pages/listing.jsx
@@ -169,9 +169,12 @@ class ListingPage extends BasePage {
     let commentsList;
     if (comments) {
       commentsList = comments.map((comment, i) => {
+        var key = `comment-${i}`
+
         if (comment && comment.bodyHtml !== undefined) {
           return (
             <Comment
+              key={key}
               ctx={ ctx }
               app={ app }
               subredditName={ subredditName }
@@ -195,6 +198,7 @@ class ListingPage extends BasePage {
           let text = loadingMoreComments ? 'Loading...' : `load more comments (${numChildren} ${word})`;
           return (
             <a 
+              key={key}
               href={ permalink }
               data-no-route='true'
               onClick={this.loadMore.bind(this, comment)}


### PR DESCRIPTION
On the ferry this morning, I made some small tweaks:

* Change `[score hidden]` to `[?]` to save space
* Change `Load more comments (57 replies)` to `Load 47 replies`
* Reduce horizontal padding for nested comments by a couple pixels per nesting level
* Increase vertical padding slightly for individual comments
* Reduce vertical padding after comment box
* Increased hit area on text (which shows upvote/downvote/reply/etc)
* Fixed bug where the color won't change on vote icons until you click something else, after voting

New (left) vs Old (right)

![screen shot 2015-10-15 at 10 24 31 am](https://cloud.githubusercontent.com/assets/175515/10521876/f41c8f5c-7326-11e5-88e9-571cf06b856b.png)
![screen shot 2015-10-15 at 10 19 50 am](https://cloud.githubusercontent.com/assets/175515/10521747/5c99a7e6-7326-11e5-95cf-bad742531f58.png)

:eyeglasses: @curioussavage, @tdohz 