### PR TITLE
Add new `icon-inline` class to fix icon color in links

### DIFF
--- a/assets/less/components/text.less
+++ b/assets/less/components/text.less
@@ -1,15 +1,15 @@
 a {
   color: @blue;
-  [class*=" icon-"] { color: @blue; }
+  .icon-inline { color: @blue; }
 
   &:active {
     color: lighten(@blue, 20%);
-    [class*=" icon-"] { color: lighten(@blue, 20%); }
+    .icon-inline { color: lighten(@blue, 20%); }
   }
 
   &:visited {
     color: lighten(@blue, 40%);
-    [class*=" icon-"] { color: lighten(@blue, 40%); }
+    .icon-inline { color: lighten(@blue, 40%); }
   }
 }
 

--- a/src/views/components/Comment.jsx
+++ b/src/views/components/Comment.jsx
@@ -324,7 +324,7 @@ class Comment extends BaseComponent {
                       href={permalink}
                       data-no-route='true'
                       onClick={this.loadMore.bind(this, c)}
-                      ><span className='icon icon-comments' />{ text }</a>
+                      ><span className='icon icon-comments icon-inline' />{ text }</a>
                   </div>
                 );
               }


### PR DESCRIPTION
:eyeglasses: @curioussavage 

To be used when an icon is used inline with text, rather than as a nav / heading / etc.