### PR TITLE
ListingList: get rid of extra resize

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ require('babel/register')({
   only: /.+(?:(?:\.es6\.js)|(?:.jsx))$/,
   extensions: ['.js', '.es6.js', '.jsx' ],
   sourceMap: true,
+  stage: 0,
 });
 
 var config;

--- a/src/views/components/Ad.jsx
+++ b/src/views/components/Ad.jsx
@@ -34,20 +34,6 @@ class Ad extends BaseComponent {
     return listing.checkPos.apply(listing, arguments);
   }
 
-  resize() {
-    if (this.state.unavailable) {
-      return;
-    }
-
-    var listing = this.refs.listing;
-
-    if (!listing) {
-      return;
-    }
-
-    listing.resize.apply(listing, arguments);
-  }
-
   getAd() {
     var srnames = this.props.srnames;
 

--- a/src/views/components/Listing.jsx
+++ b/src/views/components/Listing.jsx
@@ -328,11 +328,11 @@ class Listing extends BaseComponent {
     return false;
   }
 
-  resize(width) {
+  resize() {
     var state = this.state;
     var node = this.refs.root.getDOMNode();
     var newState = {};
-    newState.width = width || node.offsetWidth;
+    newState.width = node.offsetWidth;
     if (state.compact && state.loaded) {
       var height = node.offsetHeight;
       if (height > this.state.tallestHeight) {

--- a/src/views/components/ListingContent.jsx
+++ b/src/views/components/ListingContent.jsx
@@ -3,11 +3,13 @@ import MyMath from '../../lib/danehansen/utils/MyMath';
 import mobilify from '../../lib/mobilify';
 import propTypes from '../../propTypes';
 
+const PropTypes = React.PropTypes;
+
 import BaseComponent from './BaseComponent';
 
-var _gifMatch = /\.(?:gif)/gi;
-var _gfyRegex = /https?:\/\/(?:.+)\.gfycat.com\/(.+)\.gif/;
-var _httpsRegex = /^https:\/\//;
+const _gifMatch = /\.(?:gif)/gi;
+const _gfyRegex = /https?:\/\/(?:.+)\.gfycat.com\/(.+)\.gif/;
+const _httpsRegex = /^https:\/\//;
 const _DEFAULT_ASPECT_RATIO = 16 / 9;
 
 function _gifToHTML5(url) {
@@ -465,53 +467,48 @@ class ListingContent extends BaseComponent {
   }
 
   _aspectRatio() {
-    var props = this.props;
-    var listing = props.listing;
+    let { listing, single } = this.props;
 
-    try {
-      var oembed = listing.media.oembed;
-      var ratio = oembed.width / oembed.height;
-      return props.single ? ratio : _limitAspectRatio(ratio);
-    } catch (err) {
+    if (listing.media) {
+      let oembed = listing.media.oembed;
+      let ratio = oembed.width / oembed.height;
+      return single ? ratio : _limitAspectRatio(ratio);
+    } else if (listing.preview && (listing.preview.images || []).length) {
+      let source = listing.preview.images[0].source || 
+        listing.preview.images[0].resolutions[0];
+      let ratio = source.width / source.height;
+      return single ? ratio : _limitAspectRatio(ratio);
+    } else {
+      return false;
     }
 
-    try {
-      var source = listing.preview.images[0].source;
-      ratio = source.width / source.height;
-      return props.single ? ratio : _limitAspectRatio(ratio);
-    } catch (err) {
+  }
+
+  static isNSFW(listing) {
+    if (!listing) {
+      return;
     }
-    // TODO: this doesn't work
-    // if (this.props.app.config.debug) {
-      // console.log('ListingContent._aspectRatio: missed a case', listing);
-    // }
+    return listing.title.match(/nsf[wl]/gi) || listing.over_18;
+  }
+
+  static imgMatch = /\.(?:gif|jpe?g|png)/gi
+
+  static propTypes = {
+    compact: PropTypes.bool,
+    editError: PropTypes.arrayOf(PropTypes.string),
+    editing: PropTypes.bool,
+    expand: PropTypes.func.isRequired,
+    expanded: PropTypes.bool.isRequired,
+    expandedCompact: PropTypes.bool,
+    isThumbnail: PropTypes.bool,
+    listing: propTypes.listing.isRequired,
+    loaded: PropTypes.bool.isRequired,
+    saveUpdatedText: PropTypes.func,
+    single: PropTypes.bool,
+    tallestHeight: PropTypes.number.isRequired,
+    toggleEdit: PropTypes.func,
+    width: PropTypes.number.isRequired,
   }
 }
-
-ListingContent.imgMatch = /\.(?:gif|jpe?g|png)/gi;
-
-ListingContent.isNSFW = function(listing) {
-  if (!listing) {
-    return;
-  }
-  return listing.title.match(/nsf[wl]/gi) || listing.over_18;
-}
-
-ListingContent.propTypes = {
-  compact: React.PropTypes.bool,
-  editError: React.PropTypes.arrayOf(React.PropTypes.string),
-  editing: React.PropTypes.bool,
-  expand: React.PropTypes.func.isRequired,
-  expanded: React.PropTypes.bool.isRequired,
-  expandedCompact: React.PropTypes.bool,
-  isThumbnail: React.PropTypes.bool,
-  listing: propTypes.listing.isRequired,
-  loaded: React.PropTypes.bool.isRequired,
-  saveUpdatedText: React.PropTypes.func,
-  single: React.PropTypes.bool,
-  tallestHeight: React.PropTypes.number.isRequired,
-  toggleEdit: React.PropTypes.func,
-  width: React.PropTypes.number.isRequired,
-};
 
 export default ListingContent;

--- a/src/views/components/ListingList.jsx
+++ b/src/views/components/ListingList.jsx
@@ -8,6 +8,8 @@ import BaseComponent from './BaseComponent';
 import CommentPreview from '../components/CommentPreview';
 import Listing from '../components/Listing';
 
+const Proptypes = React.PropTypes;
+
 const _AD_LOCATION = 11;
 
 class ListingList extends BaseComponent {
@@ -20,21 +22,17 @@ class ListingList extends BaseComponent {
     };
 
     this._lazyLoad = this._lazyLoad.bind(this);
-    this._resize = this._resize.bind(this);
+    this._onCompactToggle = this._onCompactToggle.bind(this);
   }
 
   componentDidMount() {
-    this.props.app.on(constants.RESIZE, this._resize);
     this._addListeners();
-    this._resize();
 
-    this._onCompactToggle = this._onCompactToggle.bind(this);
     this.props.app.on(constants.COMPACT_TOGGLE, this._onCompactToggle);
   }
 
   componentWillUnmount() {
     this._removeListeners();
-    this.props.app.off(constants.RESIZE, this._resize);
 
     this.props.app.off(constants.COMPACT_TOGGLE, this._onCompactToggle);
   }
@@ -104,19 +102,6 @@ class ListingList extends BaseComponent {
     }
   }
 
-  _resize() {
-    var width = this.refs.root.getDOMNode().offsetWidth;
-    for (var i = 0; i < this.props.listings.length; i++) {
-      var ref = this.refs['listing' + i];
-
-      ref.resize && ref.resize(width);
-    }
-
-    if (this.refs.ad) {
-      this.refs.ad.resize(width);
-    }
-  }
-
   buildAd() {
     var srnames = uniq(this.props.listings.map(function(l) {
       return l.subreddit;
@@ -183,7 +168,6 @@ class ListingList extends BaseComponent {
 
   componentDidUpdate(prevProps, prevState) {
     if (prevState.compact !== this.state.compact) {
-      this._resize();
       this._lazyLoad();
     }
     if (prevProps.listings !== this.props.listings) {
@@ -201,17 +185,17 @@ class ListingList extends BaseComponent {
   _onCompactToggle(compact) {
     this.setState({ compact });
   }
-}
 
-ListingList.propTypes = {
-  compact: React.PropTypes.bool,
-  firstPage: React.PropTypes.number,
-  listings: React.PropTypes.arrayOf(React.PropTypes.oneOfType([
-    propTypes.comment,
-    propTypes.listing,
-  ])).isRequired,
-  showAds: React.PropTypes.bool,
-  showHidden: React.PropTypes.bool,
-};
+  static propTypes = {
+    compact: Proptypes.bool,
+    firstPage: Proptypes.number,
+    listings: Proptypes.arrayOf(Proptypes.oneOfType([
+      propTypes.comment,
+      propTypes.listing,
+    ])).isRequired,
+    showAds: Proptypes.bool,
+    showHidden: Proptypes.bool,
+  }
+}
 
 export default ListingList;


### PR DESCRIPTION
Each Listing was already calling its resize method.
Also fixes ad thumbnail aspect ratios

:eyeglasses: @ajacksified @madbook 

both the listinglist and listing components were listening to the resize event and firing the resize methods on the listings.

The change to listingContent also fixes ad image aspect ratio, that really needs some more refactoring but I wanted to get that out since there are paid ads running and it looks crappy. 