### PR TITLE
Add request url to errorlog, and fix client-side error pages

### DIFF
--- a/assets/js/client.es6.js
+++ b/assets/js/client.es6.js
@@ -9,6 +9,7 @@ function onError(message, url, line, column) {
     url,
     line,
     column,
+    requestUrl: window.location.toString()
   }, {
     hivemind: window.bootstrap && window.bootstrap.config ? window.bootstrap.config.statsDomain : undefined,
   });
@@ -232,6 +233,10 @@ function initialize(bindLinks) {
 
   var app = new App(config);
   routes(app);
+
+  app.on('error:body', function(ctx) {
+    React.render(ctx.body(ctx.props), app.config.mountPoint);
+  });
 
   app.setState('userSubscriptions', window.bootstrap.dataCache.userSubscriptions);
 

--- a/src/app-mixin.jsx
+++ b/src/app-mixin.jsx
@@ -34,6 +34,7 @@ function logError(err, ctx, config) {
     message: err.message,
     line: line,
     url: url,
+    requestUrl: ctx ? ctx.path : null,
   }, {
     hivemind: config.statsDomain,
   }, {
@@ -72,7 +73,6 @@ function mixin (App) {
     }
 
     error (e, ctx, app, options={}) {
-
       // API error
       if (e.status) {
         // Don't redirect if abort === false
@@ -86,6 +86,7 @@ function mixin (App) {
 
       if (options.replaceBody !== false) {
         ctx.body = this.errorPage(ctx, e.status);
+        app.emit('error:body', ctx);
       }
     }
 
@@ -113,7 +114,7 @@ function mixin (App) {
 
       return function(props) {
         return (
-          <BodyLayout {...props}>
+          <BodyLayout {...props} key='error'>
             <ErrorPage {...props}/>
           </BodyLayout>
         );

--- a/src/lib/errorLog.es6.js
+++ b/src/lib/errorLog.es6.js
@@ -11,10 +11,11 @@ function simpleUA(agent) {
 function formatLog(details) {
   if (!details) { return; }
 
-  let {userAgent, message, url, line, column} = details;
+  let {userAgent, message, url, line, column, requestUrl} = details;
   let errorString = [userAgent || 'UNKNOWN'];
 
   errorString.push(message || 'NO MESSAGE');
+  errorString.push(requestUrl || 'NO REQUEST URL');
 
   if (url) {
     errorString.push(url);
@@ -29,7 +30,6 @@ function formatLog(details) {
 
 function errorLog(details, errorEndpoints, config={}) {
   let formattedLog = formatLog(details);
-
   console.log(formattedLog);
 
   if (config.debugLevel === 'info') {

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -257,7 +257,7 @@ function routes(app) {
       props.metaDescription = `u/${props.multiUser}'s m/${props.multi} multireddit at reddit.com`;
       props.topNavLink = `/u/${props.multiUser}/m/${props.multi}`;
     }
-    
+
     let listingOpts = buildAPIOptions(this, {
       query: {
         after: props.after,

--- a/src/views/pages/BasePage.jsx
+++ b/src/views/pages/BasePage.jsx
@@ -66,6 +66,8 @@ class BasePage extends BaseComponent {
         });
       }
     }.bind(this), function(e) {
+      // circular, so we can render the error page
+      this.props.ctx.props = this.props;
       this.props.app.error(e, this.props.ctx, this.props.app);
     }.bind(this));
   }


### PR DESCRIPTION
* add requestUrl to the error log, so we can see _where_ errors are happening on the server
* also emit a body replacement event on the client; because everything's async, errors were just showing loading spinners forever
* add props to the context on client-side error handling, so we can render error pages properly

:eyeglasses: @curioussavage 