### PR TITLE
Session conversion does not like * scope

### DIFF
--- a/src/server/oauth.es6.js
+++ b/src/server/oauth.es6.js
@@ -5,7 +5,7 @@ import uuid from 'uuid';
 import url from 'url';
 import querystring from 'querystring';
 
-const SCOPES = '*';
+const SCOPES = 'history,identity,mysubreddits,read,subscribe,vote,submit,save,edit,account,creddits,flair,livemanage,modconfig,modcontributors,modflair,modlog,modothers,modposts,modself,modwiki,privatemessages,report,subscribe,wikiedit,wikiread';
 
 function nukeTokens(ctx) {
   ctx.cookies.set('token');


### PR DESCRIPTION
The post to password flow works (`/api/fp/1/auth/access_token`) but the post to session conversion / modhash list (`api/v1/authorize`) isn't happy.

:eyeglasses: @umbrae 