### PR TITLE
Add statsd monitoring of servers

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "semver": "^5.0.3",
     "simple-oauth2": "0.2.1",
     "snoode": "1.13.2",
+    "statsd-client": "^0.2.1",
     "superagent": "1.3.0",
     "uuid": "2.0.1"
   },

--- a/src/server/config.es6.js
+++ b/src/server/config.es6.js
@@ -52,6 +52,16 @@ function serverConfig(numCPUs) {
 
   config.keys = [ env.SERVER_SIGNED_COOKIE_KEY || 'lambeosaurus' ];
 
+  if (env.STATSD_HOST) {
+    config.statsd = {
+      host: env.STATSD_HOST,
+      port: env.STATSD_PORT,
+      debug: env.STATSD_DEBUG,
+      prefix: env.STATSD_PREFIX || 'mweb.server',
+      socketTimeout: env.STATSD_TIMEOUT || 100,
+    }
+  }
+
   return config;
 }
 


### PR DESCRIPTION
:eyeglasses: @umbrae, @spladug

This adds:
* Total requests
* Request timings
* Total active requests
* Response code

Buffered to a 100ms timeout by default, configurable.

Questions:
* Should I sample?