### PR TITLE
Still decrement requests even if middleware fails

### DIFF
--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -149,7 +149,15 @@ class Server {
 
       statsd.increment('request');
 
-      yield next;
+      try {
+        yield next;
+      } catch (e) {
+        app.error(e, this, app, {
+          replaceBody: false,
+          redirect: false,
+        });
+      }
+
       that.activeRequests--;
 
       statsd.increment(`response.${this.status}`);


### PR DESCRIPTION
:eyeglasses: @curioussavage 

If middleware (such as route handlers) broke on an uncaught exception, it didn't decrement the active requests value, giving us a potentially incorrect `active` count.