### PR TITLE
Fix word break on listing titles

### DIFF
--- a/assets/less/components/Listing.less
+++ b/assets/less/components/Listing.less
@@ -176,8 +176,9 @@
 
     .Listing-title {
       color: @black;
-      word-break: break-all;
-      
+      word-break: break-word;
+      word-wrap: break-word;
+
       &.text-admin {
         color: @admin-text;
       }


### PR DESCRIPTION
:eyeglasses: @curioussavage 

Fixes word break so that it breaks in the middle of long words or at spaces, but not in the middle of short words.