### PR TITLE
Add timeouts for superagent requests

### DIFF
--- a/assets/js/client.es6.js
+++ b/assets/js/client.es6.js
@@ -186,6 +186,7 @@ function sendTimings() {
       timings.mountTiming = (Date.now() - beginRender) / 1000;
 
       superagent
+        .timeout(5000)
         .post('/timings')
         .send({
           rum: timings,

--- a/assets/js/trackingEvents.es6.js
+++ b/assets/js/trackingEvents.es6.js
@@ -16,6 +16,7 @@ function postData(eventInfo) {
   const { url, data, query, headers } = eventInfo;
 
   superagent
+    .timeout(5000)
     .post(url)
     .set(headers)
     .query(query)

--- a/src/lib/errorLog.es6.js
+++ b/src/lib/errorLog.es6.js
@@ -55,10 +55,11 @@ function hivemind(ua, endpoint) {
   data.mwebError[ua] = 1;
 
   superagent
-      .post(endpoint)
-      .type('json')
-      .send(data)
-      .end(function(){ });
+    .timeout(3000)
+    .post(endpoint)
+    .type('json')
+    .send(data)
+    .end(function(){ });
 }
 
 export default errorLog;

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -630,6 +630,7 @@ function routes(app) {
     return new Promise(function(resolve, reject) {
       try {
         let sa = superagent
+                  .timeout(5000)
                   .head(endpoint)
                   .set(options.headers);
 

--- a/src/server/oauth.es6.js
+++ b/src/server/oauth.es6.js
@@ -6,6 +6,7 @@ import url from 'url';
 import querystring from 'querystring';
 
 const SCOPES = 'history,identity,mysubreddits,read,subscribe,vote,submit,save,edit,account,creddits,flair,livemanage,modconfig,modcontributors,modflair,modlog,modothers,modposts,modself,modwiki,privatemessages,report,subscribe,wikiedit,wikiread';
+const DEFAULT_TIMEOUT = 5000;
 
 function nukeTokens(ctx) {
   ctx.cookies.set('token');
@@ -123,12 +124,14 @@ var oauthRoutes = function(app) {
       Object.assign(headers, app.config.apiHeaders || {});
 
       superagent
+        .timeout(DEFAULT_TIMEOUT)
         .post(endpoint)
         .set(headers)
         .type('form')
         .send(data)
         .end((err, res) => {
           if (err || !res.ok) {
+            if (err.timeout) { err.status = 504; }
             return reject(err || res);
           }
 
@@ -163,10 +166,12 @@ var oauthRoutes = function(app) {
       Object.assign(headers, app.config.apiHeaders || {});
 
       superagent
+        .timeout(DEFAULT_TIMEOUT)
         .get(endpoint)
         .set(headers)
         .end((err, res) => {
           if (err || !res.ok) {
+            if (err.timeout) { err.status = 504; }
             return reject(err || res);
           }
 
@@ -246,12 +251,14 @@ var oauthRoutes = function(app) {
               Object.assign(headers, app.config.apiHeaders || {});
 
               superagent
+                .timeout(DEFAULT_TIMEOUT)
                 .post(endpoint)
                 .set(headers)
                 .send(postData)
                 .type('form')
                 .end(function(err, res) {
-                  if (!res.ok) {
+                  if (err || !res.ok) {
+                    if (err.timeout) { err.status = 504; }
                     reject(err);
                   }
 
@@ -388,12 +395,14 @@ var oauthRoutes = function(app) {
       Object.assign(headers, app.config.apiHeaders || {});
 
       superagent
+        .timeout(DEFAULT_TIMEOUT)
         .post(endpoint)
         .set(headers)
         .type('form')
         .send(data)
         .end((err, res) => {
           if (err || !res.ok) {
+            if (err.timeout) { res.status = 504; }
             return resolve(res.status || 500);
           }
 
@@ -469,12 +478,14 @@ var oauthRoutes = function(app) {
       assignPassThroughHeaders(headers, ctx, app);
 
       superagent
+        .timeout(DEFAULT_TIMEOUT)
         .post(endpoint)
         .set(headers)
         .type('form')
         .send(data)
         .end((err, res) => {
           if (err || !res.ok) {
+            if (err.timeout) { res.status = 504; }
             return resolve(ctx.redirect('/register?error=' + (res.status || 500)));
           }
 

--- a/src/server/routes.es6.js
+++ b/src/server/routes.es6.js
@@ -54,6 +54,7 @@ let serverRoutes = function(app) {
     timings.verification = hash;
 
     superagent
+        .timeout(5000)
         .post(statsDomain)
         .type('json')
         .send({ rum: timings })

--- a/src/views/components/Ad.jsx
+++ b/src/views/components/Ad.jsx
@@ -78,6 +78,7 @@ class Ad extends BaseComponent {
 
     return new Promise((resolve, reject) => {
       superagent.post(origin + this.props.config.adsPath)
+        .timeout(5000)
         .set(headers)
         .type('form')
         .send(postData)


### PR DESCRIPTION
:eyeglasses: @umbrae, @curioussavage 

This covers all of our superagent requests. Bad hivemind and oauth requests will hang for 4 minutes each, without timeouts set.

Next step: fork superagent and allow setting a default timeout. Also, implement response timeouts in the http server that will send back a timeout if the server's taking to long (although we still need to kill the open http requests using superagent timeouts.)