### PR TITLE
Don't set ref on CommentPreviews

### DIFF
--- a/src/views/components/ListingList.jsx
+++ b/src/views/components/ListingList.jsx
@@ -67,6 +67,11 @@ class ListingList extends BaseComponent {
     for (var i = 0; i < listings.length; i++) {
       var listing = this.refs['listing' + i];
 
+      // commentpreviews are stateless, so the ref won't exist.
+      if (!listing) {
+        return;
+      }
+
       // Check ad first since it'll be before the `i`th listing.
       if (this._isIndexOfAd(i) && !this._checkAdPos()) {
         return;
@@ -135,7 +140,6 @@ class ListingList extends BaseComponent {
               comment={listing}
               key={'page-comment-' + index}
               page={page}
-              ref={'listing' + i}
             />
           );
         } else {

--- a/src/views/components/TextSubNav.jsx
+++ b/src/views/components/TextSubNav.jsx
@@ -33,6 +33,7 @@ class TextSubNav extends BaseComponent {
   }
 
   _moveIndicator() {
+    const ul = this.refs.ul;
     const active = this.refs.ul.querySelector('.active');
 
     if (active) {


### PR DESCRIPTION
You cannot set a `ref` on a stateless component - this was throwing
warnings. This commit also fixes the ref to `ul` on TextSubNav, which
was throwing errors on the same page.

:eyeglasses: @curioussavage 