### PR TITLE
Set defaultConfig as constant in server

### DIFF
--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -100,9 +100,9 @@ function setCompact(ctx, app) {
   ctx.compact = compact;
 }
 
+// Save a static reference to the config object at startup
+const config = defaultConfig();
 function formatBootstrap(props) {
-  var config = defaultConfig();
-
   for (var p in props.config) {
     if (!config.hasOwnProperty(p)){
       delete props.config[p];


### PR DESCRIPTION
Only get the env vars at startup time; it's unnecessary to get them
every request.

:eyeglasses: @curioussavage 