### PR TITLE
Configurable (and increased) API timeouts

### DIFF
--- a/assets/js/client.es6.js
+++ b/assets/js/client.es6.js
@@ -188,7 +188,7 @@ function sendTimings() {
 
       superagent
         .post('/timings')
-        .timeout(5000)
+        .timeout(constants.DEFAULT_API_TIMEOUT)
         .send({
           rum: timings,
         })

--- a/assets/js/trackingEvents.es6.js
+++ b/assets/js/trackingEvents.es6.js
@@ -2,6 +2,7 @@ import querystring from 'querystring';
 import crypto from 'crypto'
 import superagent from 'superagent';
 import EventTracker from 'event-tracker';
+import constants from '../../src/constants';
 
 function calculateHash (key, string) {
   let hmac = crypto.createHmac('sha1', key);
@@ -19,7 +20,7 @@ function postData(eventInfo) {
     .post(url)
     .set(headers)
     .query(query)
-    .timeout(5000)
+    .timeout(constants.DEFAULT_API_TIMEOUT)
     .send(data)
     .end(function(){});
 }

--- a/src/app-mixin.jsx
+++ b/src/app-mixin.jsx
@@ -12,6 +12,7 @@ import ErrorPage from './views/pages/error';
 import Loading from './views/components/Loading';
 
 import errorLog from './lib/errorLog';
+import constants from './constants';
 
 function logError(err, ctx, config) {
   var userAgent;
@@ -71,6 +72,7 @@ function mixin (App) {
       let app = this;
       // Set up two APIs (until we get non-authed oauth working).
       this.api = new V1Api({
+        timeout: constants.DEFAULT_API_TIMEOUT,
         defaultHeaders: config.apiHeaders,
         debugLevel: config.debugLevel,
         log: app.logRequests.bind(app),

--- a/src/constants.es6.js
+++ b/src/constants.es6.js
@@ -10,5 +10,5 @@ export default {
   SCROLL: 'scroll',
   ICON_SHRUNK_SIZE: 16,
   CACHEABLE_COOKIES: ['compact'],
-  DEFAULT_API_TIMEOUT: 5000,
+  DEFAULT_API_TIMEOUT: 10000,
 };

--- a/src/constants.es6.js
+++ b/src/constants.es6.js
@@ -10,4 +10,5 @@ export default {
   SCROLL: 'scroll',
   ICON_SHRUNK_SIZE: 16,
   CACHEABLE_COOKIES: ['compact'],
+  DEFAULT_API_TIMEOUT: 5000,
 };

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -32,6 +32,7 @@ import RegisterPage from './views/pages/register';
 import MessagesPage from './views/pages/messages';
 import MessageComposePage from './views/pages/messageCompose';
 import SubmitPage from './views/pages/submit';
+import constants from './constants';
 
 import defaultConfig from './config';
 
@@ -577,7 +578,7 @@ function routes(app) {
         let sa = superagent
                   .head(endpoint)
                   .set(options.headers)
-                  .timeout(5000);
+                  .timeout(constants.DEFAULT_API_TIMEOUT);
 
         // bombs in browser
         if (sa.redirects) {

--- a/src/server/oauth.es6.js
+++ b/src/server/oauth.es6.js
@@ -4,9 +4,9 @@ import superagent from 'superagent';
 import uuid from 'uuid';
 import url from 'url';
 import querystring from 'querystring';
+import constants from '../constants';
 
 const SCOPES = 'history,identity,mysubreddits,read,subscribe,vote,submit,save,edit,account,creddits,flair,livemanage,modconfig,modcontributors,modflair,modlog,modothers,modposts,modself,modwiki,privatemessages,report,subscribe,wikiedit,wikiread';
-const DEFAULT_TIMEOUT = 5000;
 
 function nukeTokens(ctx) {
   ctx.cookies.set('token');
@@ -128,7 +128,7 @@ var oauthRoutes = function(app) {
         .set(headers)
         .type('form')
         .send(data)
-        .timeout(DEFAULT_TIMEOUT)
+        .timeout(constants.DEFAULT_API_TIMEOUT)
         .end((err, res) => {
           if (err || !res.ok) {
             if (err.timeout) { err.status = 504; }
@@ -168,7 +168,7 @@ var oauthRoutes = function(app) {
       superagent
         .get(endpoint)
         .set(headers)
-        .timeout(DEFAULT_TIMEOUT)
+        .timeout(constants.DEFAULT_API_TIMEOUT)
         .end((err, res) => {
           if (err || !res.ok) {
             if (err.timeout) { err.status = 504; }
@@ -255,7 +255,7 @@ var oauthRoutes = function(app) {
                 .set(headers)
                 .send(postData)
                 .type('form')
-                .timeout(DEFAULT_TIMEOUT)
+                .timeout(constants.DEFAULT_API_TIMEOUT)
                 .end(function(err, res) {
                   if (err || !res.ok) {
                     if (err.timeout) { err.status = 504; }
@@ -399,7 +399,7 @@ var oauthRoutes = function(app) {
         .set(headers)
         .type('form')
         .send(data)
-        .timeout(DEFAULT_TIMEOUT)
+        .timeout(constants.DEFAULT_API_TIMEOUT)
         .end((err, res) => {
           if (err || !res.ok) {
             if (err.timeout) { res.status = 504; }
@@ -482,7 +482,7 @@ var oauthRoutes = function(app) {
         .set(headers)
         .type('form')
         .send(data)
-        .timeout(DEFAULT_TIMEOUT)
+        .timeout(constants.DEFAULT_API_TIMEOUT)
         .end((err, res) => {
           if (err || !res.ok) {
             if (err.timeout) { res.status = 504; }

--- a/src/server/routes.es6.js
+++ b/src/server/routes.es6.js
@@ -1,5 +1,6 @@
 import superagent from 'superagent';
 import crypto from 'crypto'
+import constants from '../constants';
 
 // set up server-only routes
 let serverRoutes = function(app) {
@@ -57,7 +58,7 @@ let serverRoutes = function(app) {
         .post(statsDomain)
         .type('json')
         .send({ rum: timings })
-        .timeout(5000)
+        .timeout(constants.DEFAULT_API_TIMEOUT)
         .end(function(){ });
   });
 

--- a/src/views/components/Ad.jsx
+++ b/src/views/components/Ad.jsx
@@ -82,7 +82,7 @@ class Ad extends BaseComponent {
         .set(headers)
         .type('form')
         .send(postData)
-        .timeout(5000)
+        .timeout(constants.DEFAULT_API_TIMEOUT)
         .end(function(err, res) {
           if (err) {
             return reject(err);


### PR DESCRIPTION
Put default API timeout (which cancels the request and returns a 504 if exceeded) into constants so that it's defined in one place. (One exception: hivemind requests, which we're okay with failing if they take
over a few seconds.)

Also increase API timeout to 10s to accomodate slow requests, like the google crawler. It was set to 5s previously when we thought that api requests were causing the request queue to back up, which does not appear to be the case.

:eyeglasses: @curioussavage 