### PR TITLE
Fix userProfile loading from `user` instead of `userProfile

### DIFF
--- a/src/views/pages/userProfile.jsx
+++ b/src/views/pages/userProfile.jsx
@@ -9,13 +9,13 @@ import UserProfile from '../components/UserProfile';
 
 class UserProfilePage extends BasePage {
   render() {
-    if (!this.state.data || !this.state.data.user) {
+    if (!this.state.data || !this.state.data.userProfile) {
       return (
         <Loading />
       );
     }
 
-    var userProfile = this.state.data.user;
+    var userProfile = this.state.data.userProfile;
     var name = this.props.userName;
 
     return (


### PR DESCRIPTION
:eyeglasses: @curioussavage 

This is currently loading the logged-in user's data instead of the
profile you are attempting to view. This uses the correct property.