### PR TITLE
Make properties on BodyLayout pages update correctly.

### DIFF
--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -200,7 +200,11 @@ function makeBody() {
     });
 
     return (
-      <BodyLayout { ...props } key='layout'>
+      // Note: please don't set a key here, as it will make React re-use the
+      // component when it really shouldn't. Properties that are promises,
+      // whose result is based on the state of the cache, won't be picked up
+      // as new props. Setting a key will break state when the cache has updated.
+      <BodyLayout { ...props }>
         { content }
       </BodyLayout>
     );

--- a/src/views/components/InfoBar.jsx
+++ b/src/views/components/InfoBar.jsx
@@ -13,6 +13,8 @@ const EU_COOKIE_MESSAGE = 'Cookies help us deliver our Services. By ' +
   'using our Services, you agree to our use of cookies. ' +
   '[Learn More](https://www.reddit.com/help/privacypolicy)';
 
+let InfoBarEUCookieFirstShow = true;
+
 class InfoBar extends BaseComponent {
   constructor(props) {
     super(props);
@@ -34,7 +36,10 @@ class InfoBar extends BaseComponent {
 
     if (hasEUCookie) {
       app.on('route:start', this.incrementCookieNoticeSeen);
-      this.incrementCookieNoticeSeen();
+      if (InfoBarEUCookieFirstShow) {
+        this.incrementCookieNoticeSeen();
+        InfoBarEUCookieFirstShow = false;
+      }
     }
   }
 

--- a/src/views/layouts/BodyLayout.jsx
+++ b/src/views/layouts/BodyLayout.jsx
@@ -29,7 +29,12 @@ class BodyLayout extends BasePage {
       <div className='container-with-betabanner'>
         <SideNav {...this.props} user={ user } subscriptions={ userSubscriptions } />
         <TopNav {...this.props}/>
-        <InfoBar messages={ messages } app={ app } showEUCookieMessage={ showEUCookieMessage }/>
+        <InfoBar
+          key='onlyRenderThisOnceEver'
+          messages={ messages }
+          app={ app }
+          showEUCookieMessage={ showEUCookieMessage }
+        />
         <main>
           { this.props.children }
         </main>


### PR DESCRIPTION
`routes.jsx` was setting a key on the `BodyLayout` it created to wrap
pages. This was to make `InfoBar` be reused for tracking reasons. This
broke properties set on `BodyLayout` from updating correctly across pages
(when those properties are promises who’s result depends on the state
of rest-cache). This change makes `InfoBar`’s tracking independent of
it’s parent and allows promise based props on `BodyLayout` update
correctly.

:eyeglasses: @curioussavage @ajacksified 