### PR TITLE
Fix indexOf undefined errors when clicking links without an href.

### DIFF
--- a/assets/js/client.es6.js
+++ b/assets/js/client.es6.js
@@ -328,13 +328,31 @@ function initialize(bindLinks) {
     }
   }
 
+  function logMissingHref($link) {
+    const $linkClone = $link.cloneNode(true);
+    const $tmpWrapper = document.createElement('div');
+    $tmpWrapper.appendChild($linkClone);
+    const linkStringified = $tmpWrapper.innerHTML;
+
+    const error = {
+      message: 'A tag missing HREF',
+      linkStringified,
+    };
+
+    const options = {
+      redirect: false,
+      replaceBody: false,
+    };
+
+    app.error(error, app.getState('ctx'), app, options);
+  }
+
   function attachEvents() {
     attachFastClick(document.body);
 
-    if(history && bindLinks) {
-
+    if (history && bindLinks) {
       $body.addEventListener('click', function(e) {
-        var $link = e.target;
+        let $link = e.target;
 
         if ($link.tagName !== 'A') {
           $link = findLinkParent($link);
@@ -344,8 +362,13 @@ function initialize(bindLinks) {
           }
         }
 
-        var href = $link.getAttribute('href');
-        var currentUrl = app.fullPathName();
+        const href = $link.getAttribute('href');
+        if (!href) {
+          logMissingHref($link);
+          return;
+        }
+
+        const currentUrl = app.fullPathName();
 
         // If it has a target=_blank, or an 'external' data attribute, or it's
         // an absolute url, let the browser route rather than forcing a capture.
@@ -372,7 +395,7 @@ function initialize(bindLinks) {
         initialUrl = href;
 
         // Update the referrer before navigation
-        var a = document.createElement('a');
+        const a = document.createElement('a');
         a.href = currentUrl;
         referrer = a.href;
 

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -436,6 +436,7 @@ function routes(app) {
 
     this.props.userName = ctx.params.user;
     this.props.title = `about u/${ctx.params.user}`;
+    this.props.topNavLink = `/u/${ctx.params.user}`;
     this.props.metaDescription = `about u/${ctx.params.user} on reddit.com`;
 
     let userOpts = buildAPIOptions(ctx, {


### PR DESCRIPTION
Noticed these errors popping up, looks like one of the causes is about pages not setting topNavLink.

Also prevents the error from happening in `client.es6.js`. Alternatively we could catch it and log it to see where else it happens. Thoughts? :eyeglasses: @curioussavage or @ajacksified 