### PR TITLE
Send boolean instead of T/F in event tracking

### DIFF
--- a/assets/js/trackingEvents.es6.js
+++ b/assets/js/trackingEvents.es6.js
@@ -107,7 +107,7 @@ function trackingEvents(app) {
       props.data.subreddit
     );
 
-    data.compact_view = props.compact ? 'T' : 'F';
+    data.compact_view = props.compact;
 
     if (target) {
       // Subreddit ids/names are swapped


### PR DESCRIPTION
:eyeglasses: @curioussavage or @schwers, and @drunken-economist 

Send the boolean instead of 'T' / 'F'.