### PR TITLE
Only nuke broken cookies

### DIFF
--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -448,7 +448,7 @@ class Server {
         // should never have an expires but not a token or a refresh token - but
         // in case their cookies get mangled somehow, we should nuke the invalid
         // ones.
-      } else if (expires) {
+      } else if (expires && (!cookieToken || !rToken)) {
         this.cookies.set('token');
         this.cookies.set('tokenExpires');
         this.cookies.set('refreshToken');


### PR DESCRIPTION
:eyeglasses: @schwers @umbrae

Don't nuke cookies just because expires exists - nuke them because expires exists while one of the required cookies doesn't.