### PR TITLE
Don't try to load fresh links when you restore a tab, and alert user about stale next/previous

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,7 +7,8 @@
     // I write for browser
     "browser": true,
     // in CommonJS
-    "node": true
+    "node": true,
+    "mocha": true
   },
 
   "extends": "eslint:recommended",

--- a/assets/js/client.es6.js
+++ b/assets/js/client.es6.js
@@ -429,11 +429,6 @@ function initialize(bindLinks) {
   // config value after render.
   beginRender = Date.now();
 
-  // If we're using an old render cache from a restore, nuke it
-  if ((beginRender - window.bootstrap.render) > 1000 * 60 * 5) {
-    app.setState('dataCache');
-  }
-
   render(app, app.fullPathName(), true, modifyContext).then(function() {
     app.setState('dataCache');
 

--- a/src/app-mixin.jsx
+++ b/src/app-mixin.jsx
@@ -141,6 +141,20 @@ function mixin (App) {
         <Loading />
       );
     }
+
+    setNotification(cookies, message) {
+      const notifications = (cookies.get('notifications') || '').split(',');
+      const app = this;
+
+      notifications.push(message);
+
+      cookies.set('notifications', notifications, {
+        secure: app.getConfig('https'),
+        secureProxy: app.getConfig('httpsProxy'),
+        httpOnly: false,
+        overwrite: true,
+      });
+    }
   }
 
   return MixedInApp;

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -85,6 +85,7 @@ function filterContextProps(ctx) {
     tokenExpires: ctx.tokenExpires,
     redirect: ctx.redirect,
     env: ctx.env,
+    notifications: ctx.notifications,
   };
 }
 
@@ -284,6 +285,17 @@ function routes(app) {
   function * indexPage () {
     let props = this.props;
     var sort = this.query.sort || 'hot';
+
+    this.preServerRender = function indexPagePreRender() {
+      // If we're on a next/prev for an invalid thing_id, so that no results are
+      // sent back, we have a stale cache. Redirect back to the first page of
+      // the sub, multi, or other.
+      if (IndexPage.isStalePage(this.query, this.props.dataCache.listings)) {
+        app.setNotification(this.cookies, 'stalePage');
+        this.redirect(IndexPage.stalePageRedirectUrl(this.path, this.query));
+        return false;
+      }
+    };
 
     Object.assign(this.props, {
       sort,

--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -361,6 +361,10 @@ class Server {
       this.body = this.request.body;
       this.userAgent = this.headers['user-agent'] || '';
       this.country = this.headers['cf-ipcountry'];
+      this.notifications = (this.cookies.get('notifications') || '').split(',');
+
+      // reset notifications after read
+      this.cookies.set('notifications');
 
       if (!this.token) {
         this.token = this.cookies.get('token');

--- a/src/views/components/ListingContainer.jsx
+++ b/src/views/components/ListingContainer.jsx
@@ -55,6 +55,7 @@ class ListingContainer extends BaseComponent {
       prevUrl,
       nextUrl,
       listingClassName,
+      pageSize,
     } = this.props;
 
     const compact = this.state.compact;
@@ -71,6 +72,7 @@ class ListingContainer extends BaseComponent {
           ctx={ ctx }
           prevUrl={ prevUrl }
           nextUrl={ nextUrl }
+          pageSize={ pageSize }
         />
       );
     }

--- a/src/views/components/ListingPaginationButtons.jsx
+++ b/src/views/components/ListingPaginationButtons.jsx
@@ -92,15 +92,13 @@ class ListingPaginationButtons extends BaseComponent {
       );
     }
 
-    if (listings.length >= pageSize) {
-      if (nextUrl) {
-        nextButton = (
-          <a href={ nextUrl } rel='next' className='btn btn-sm btn-primary IndexPage-button next'>
-            Next Page
-            <span className='glyphicon glyphicon-chevron-right'></span>
-          </a>
-        );
-      }
+    if (listings.length >= pageSize && nextUrl) {
+      nextButton = (
+        <a href={ nextUrl } rel='next' className='btn btn-sm btn-primary IndexPage-button next'>
+          Next Page
+          <span className='glyphicon glyphicon-chevron-right'></span>
+        </a>
+      );
     }
 
     return (

--- a/src/views/components/ListingPaginationButtons.jsx
+++ b/src/views/components/ListingPaginationButtons.jsx
@@ -8,6 +8,7 @@ class ListingPaginationButtons extends BaseComponent {
     compact: React.PropTypes.bool,
     prevUrl: React.PropTypes.string,
     nextUrl: React.PropTypes.string,
+    pageSize: React.PropTypes.number,
   };
   
   constructor(props) {
@@ -63,7 +64,12 @@ class ListingPaginationButtons extends BaseComponent {
 
     // Allow overriding for special cases, like search. Otherwise, fall back to
     // the default logic for building next/previous urls.
-    let { prevUrl, nextUrl } = this.props;
+    let {
+      prevUrl,
+      nextUrl,
+      listings,
+      pageSize = 25,
+    } = this.props;
 
     if (!prevUrl) {
       prevUrl = this.buildPrevUrl();
@@ -72,6 +78,7 @@ class ListingPaginationButtons extends BaseComponent {
     if (!nextUrl) {
       nextUrl = this.buildNextUrl();
     }
+
 
     let prevButton;
     let nextButton;
@@ -85,13 +92,15 @@ class ListingPaginationButtons extends BaseComponent {
       );
     }
 
-    if (nextUrl) {
-      nextButton = (
-        <a href={ nextUrl } rel='next' className='btn btn-sm btn-primary IndexPage-button next'>
-          Next Page
-          <span className='glyphicon glyphicon-chevron-right'></span>
-        </a>
-      );
+    if (listings.length >= pageSize) {
+      if (nextUrl) {
+        nextButton = (
+          <a href={ nextUrl } rel='next' className='btn btn-sm btn-primary IndexPage-button next'>
+            Next Page
+            <span className='glyphicon glyphicon-chevron-right'></span>
+          </a>
+        );
+      }
     }
 
     return (

--- a/src/views/components/NotificationBar.jsx
+++ b/src/views/components/NotificationBar.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+function NotificationBar (props) {
+  return (
+    <div className={ `alert alert-${props.type} alert-bar` } role='alert'>
+      { props.message }
+    </div>
+  );
+}
+
+export default NotificationBar;

--- a/src/views/pages/index.jsx
+++ b/src/views/pages/index.jsx
@@ -47,6 +47,15 @@ class IndexPage extends BasePage {
     return 'listings';
   }
 
+  noListingsPage (url='/') {
+    return (
+      <div>
+        <h1>Whoops! There are no links here.</h1>
+        <h2><a href={ url }>Return to first page for fresh links?</a></h2>
+      </div>
+    );
+  }
+
   render() {
     var loading;
     var props = this.props;
@@ -56,7 +65,7 @@ class IndexPage extends BasePage {
     var fakeSubs = ['mod', 'all', 'friends'];
     var isFakeSub = fakeSubs.indexOf(subredditName) !== -1;
 
-    if (!data || !data.listings ||
+    if (!data || typeof data.listings === 'undefined' ||
         (subredditName && (!data.subreddit && !isFakeSub))) {
       return (
         <Loading />
@@ -64,11 +73,13 @@ class IndexPage extends BasePage {
     }
 
     let bypassInterstitial = data.preferences && data.preferences.over_18;
+
     if (!bypassInterstitial) {
       if (data.subreddit && data.subreddit.over18 && props.showOver18Interstitial) {
         return (<Interstitial  {...props} loggedIn={ data.preferences } type='over18' />);
       }
     }
+
     var listings = this.state.data.listings;
 
     var hideSubredditLabel = props.subredditName &&
@@ -79,7 +90,7 @@ class IndexPage extends BasePage {
 
     var user = this.state.data.user;
 
-    let pagingPrefix = '';
+    let pagingPrefix = '/';
 
     if (props.subredditName) {
       pagingPrefix = '/r/' + props.subredditName;
@@ -87,6 +98,10 @@ class IndexPage extends BasePage {
 
     if (props.multi) {
       pagingPrefix = '/u/' + props.multiUser + '/m/' + props.multi;
+    }
+
+    if (listings.length === 0 && props.page !== 0) {
+      return this.noListingsPage(pagingPrefix);
     }
 
     // Use the same logic for the url and for the subreddit name display

--- a/src/views/pages/search.jsx
+++ b/src/views/pages/search.jsx
@@ -260,6 +260,7 @@ class SearchPage extends BasePage {
           compact={ compact }
           prevUrl={ prevUrl }
           nextUrl={ nextUrl }
+          pageSize={ 22 }
         />,
       ];
     }

--- a/test/views/pages/Index.jsx
+++ b/test/views/pages/Index.jsx
@@ -1,21 +1,21 @@
 import chai from 'chai';
-import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import TestUtils from 'react-addons-test-utils';
 
 import shallowHelpers from 'react-shallow-renderer-helpers';
 import renderWithProps from '../../helpers/renderWithProps';
 
-import { IndexPage, Loading, TopSubnav, ListingContainer } from '../../helpers/components';
+import { IndexPage, Loading, ListingContainer } from '../../helpers/components';
 
-var expect = chai.expect;
+const expect = chai.expect;
 chai.use(sinonChai);
 
 describe('index page', () => {
   var ctx;
 
   beforeEach('render and find element', () => {
-    ctx = renderWithProps({}, IndexPage);
+    ctx = renderWithProps({
+      ctx: { query: {} },
+    }, IndexPage);
   });
 
   it('is a thing', () => {
@@ -28,11 +28,10 @@ describe('index page', () => {
 
   describe('With data', () => {
     beforeEach('render and find element', () => {
-
       ctx.instance.setState({
         data: {
-          listings: [{ }]
-        }
+          listings: [{ }],
+        },
       });
       ctx.result = ctx.renderer.getRenderOutput();
     });
@@ -40,9 +39,50 @@ describe('index page', () => {
     it('renders a ListingList copmonent when listings are loaded', () => {
       let listingContainer = shallowHelpers.findType(ctx.result, ListingContainer);
       expect(listingContainer).to.not.equal(undefined);
-    })
-
+    });
   });
 
+  describe('Static methods', () => {
+    describe('next/prev listings staleness', function() {
+      it('before query with no before/after in response headers is stale', function() {
+        const query = { before: 't3_abcd' };
+        const listings = { body: [], headers: { }};
+
+        expect(IndexPage.isStalePage(query, listings)).to.be.true;
+      });
+
+      it('after query with no before/after in response headers is stale', function() {
+        const query = { after: 't3_abcd' };
+        const listings = { body: [], headers: { }};
+
+        expect(IndexPage.isStalePage(query, listings)).to.be.true;
+      });
+
+      it('after query with before in response headers with no listings is not stale', function() {
+        const query = { after: 't3_abcd' };
+        const listings = { body: [], headers: { before: 't3_efgh' }};
+
+        expect(IndexPage.isStalePage(query, listings)).to.not.be.true;
+      });
+    });
+
+    describe('next/prev listings stale redirect url', function() {
+      it('returns a path without before, after, or page', function() {
+        const path = '/r/science';
+        const query = { before: 't3_abcd', after: 't3_efgh', page: 2 };
+
+        const redirect = IndexPage.stalePageRedirectUrl(path, query);
+        expect(redirect).to.equal('/r/science');
+      });
+
+      it('maintains non-paging querystrings', function() {
+        const path = '/r/science';
+        const query = { sort: 'hot', after: 't3_efgh', page: 2 };
+
+        const redirect = IndexPage.stalePageRedirectUrl(path, query);
+        expect(redirect).to.equal('/r/science?sort=hot');
+      });
+    });
+  });
 });
 

--- a/test/views/pages/Index.jsx
+++ b/test/views/pages/Index.jsx
@@ -31,7 +31,7 @@ describe('index page', () => {
 
       ctx.instance.setState({
         data: {
-          listings: []
+          listings: [{ }]
         }
       });
       ctx.result = ctx.renderer.getRenderOutput();


### PR DESCRIPTION
Instead, use the old ones, and implement a more user-friendly "no links" error message, helping the user load fresh links.

Obviously needs design help, but is this what you were thinking about, @umbrae?

:eyeglasses: @umbrae and @curioussavage or @schwers 