### PR TITLE
Move static properties to the top of the class

### DIFF
--- a/src/views/components/Ad.jsx
+++ b/src/views/components/Ad.jsx
@@ -1,13 +1,18 @@
 import React from 'react';
-
-import constants from '../../constants';
 import { models } from 'snoode';
 import superagent from 'superagent';
 
+import constants from '../../constants';
 import BaseComponent from './BaseComponent';
 import Listing from './Listing';
 
 class Ad extends BaseComponent {
+  static propTypes = {
+    afterLoad: React.PropTypes.func.isRequired,
+    compact: React.PropTypes.bool.isRequired,
+    token: React.PropTypes.string,
+  };
+  
   constructor (props) {
     super(props);
 
@@ -185,11 +190,5 @@ class Ad extends BaseComponent {
     );
   }
 }
-
-Ad.propTypes = {
-  afterLoad: React.PropTypes.func.isRequired,
-  compact: React.PropTypes.bool.isRequired,
-  token: React.PropTypes.string,
-};
 
 export default Ad;

--- a/src/views/components/BaseComponent.jsx
+++ b/src/views/components/BaseComponent.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { findDOMNode } from 'react-dom';
-
 import isEqual from 'lodash/lang/isEqual';
 
 class BaseComponent extends React.Component {

--- a/src/views/components/CaptchaBox.jsx
+++ b/src/views/components/CaptchaBox.jsx
@@ -1,7 +1,19 @@
 import React from 'react';
+
 import BaseComponent from './BaseComponent';
 
 class CaptchaBox extends BaseComponent {
+  // TODO: someone more familiar with this component could eventually fill this out better
+  static propTypes = {
+    action: React.PropTypes.func.isRequired,
+    actionName: React.PropTypes.string.isRequired,
+    answer: React.PropTypes.string.isRequired,
+    // apiOptions: React.PropTypes.object,
+    cb: React.PropTypes.func.isRequired,
+    // error: React.PropTypes.bool.isRequired,
+    // iden: React.PropTypes.string.isRequired,
+  };
+  
   constructor(props) {
     super(props);
 
@@ -118,16 +130,5 @@ class CaptchaBox extends BaseComponent {
   }
 
 }
-
-// TODO: someone more familiar with this component could eventually fill this out better
-CaptchaBox.propTypes = {
-  action: React.PropTypes.func.isRequired,
-  actionName: React.PropTypes.string.isRequired,
-  answer: React.PropTypes.string.isRequired,
-  // apiOptions: React.PropTypes.object,
-  cb: React.PropTypes.func.isRequired,
-  // error: React.PropTypes.bool.isRequired,
-  // iden: React.PropTypes.string.isRequired,
-};
 
 export default CaptchaBox;

--- a/src/views/components/Comment.jsx
+++ b/src/views/components/Comment.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
+import { models } from 'snoode';
 
 import mobilify from '../../lib/mobilify';
-import { models } from 'snoode';
 import propTypes from '../../propTypes';
 import short from '../../lib/formatDifference';
 import savedReply from '../../lib/savedReply';
@@ -17,6 +17,16 @@ var replyIcon = (
 );
 
 class Comment extends BaseComponent {
+  static propTypes = {
+    apiOptions: React.PropTypes.object.isRequired,
+    comment: propTypes.comment.isRequired,
+    highlight: React.PropTypes.string,
+    nestingLevel: React.PropTypes.number.isRequired,
+    op: React.PropTypes.string.isRequired,
+    permalinkBase: React.PropTypes.string.isRequired,
+    subredditName: React.PropTypes.string.isRequired,
+  };
+  
   constructor(props) {
     super(props);
 
@@ -428,15 +438,5 @@ class Comment extends BaseComponent {
     );
   }
 }
-
-Comment.propTypes = {
-  apiOptions: React.PropTypes.object.isRequired,
-  comment: propTypes.comment.isRequired,
-  highlight: React.PropTypes.string,
-  nestingLevel: React.PropTypes.number.isRequired,
-  op: React.PropTypes.string.isRequired,
-  permalinkBase: React.PropTypes.string.isRequired,
-  subredditName: React.PropTypes.string.isRequired,
-};
 
 export default Comment;

--- a/src/views/components/CommentBox.jsx
+++ b/src/views/components/CommentBox.jsx
@@ -1,12 +1,19 @@
 import React from 'react';
-const PropTypes = React.PropTypes;
-
 import { models } from 'snoode';
-import savedReply from '../../lib/savedReply';
 
+import savedReply from '../../lib/savedReply';
 import BaseComponent from './BaseComponent';
 
+const PropTypes = React.PropTypes;
+
 class CommentBox extends BaseComponent {
+  static propTypes = {
+    apiOptions: PropTypes.object,
+    onSubmit: PropTypes.func.isRequired,
+    thingId: PropTypes.string.isRequired,
+    token: PropTypes.string,
+  };
+  
   constructor(props) {
     super(props);
 
@@ -125,12 +132,5 @@ class CommentBox extends BaseComponent {
     );
   }
 }
-
-CommentBox.propTypes = {
-  apiOptions: PropTypes.object,
-  onSubmit: PropTypes.func.isRequired,
-  thingId: PropTypes.string.isRequired,
-  token: PropTypes.string,
-};
 
 export default CommentBox;

--- a/src/views/components/CommentPreview.jsx
+++ b/src/views/components/CommentPreview.jsx
@@ -5,7 +5,7 @@ import short from '../../lib/formatDifference';
 
 const subredditRegex = /\/\/www.reddit.com\/r\/([^/]*)/;
 
-function CommentPreview  (props) {
+function CommentPreview(props) {
   const comment = props.comment;
   const submitted = short(comment.created_utc * 1000);
 

--- a/src/views/components/Dropdown.jsx
+++ b/src/views/components/Dropdown.jsx
@@ -1,10 +1,17 @@
 import React from 'react';
 
 import constants from '../../constants';
-
 import BaseComponent from './BaseComponent';
 
 class Dropdown extends BaseComponent {
+  static propTypes = {
+    className: React.PropTypes.string,
+    button: React.PropTypes.element.isRequired,
+    id: React.PropTypes.number.isRequired,
+    right: React.PropTypes.bool,
+    reversed: React.PropTypes.bool,
+  };
+  
   constructor(props) {
     super(props);
 
@@ -75,13 +82,5 @@ class Dropdown extends BaseComponent {
     this.props.app.emit(constants.DROPDOWN_OPEN + ':' + this.props.id, false);
   }
 }
-
-Dropdown.propTypes = {
-  className: React.PropTypes.string,
-  button: React.PropTypes.element.isRequired,
-  id: React.PropTypes.number.isRequired,
-  right: React.PropTypes.bool,
-  reversed: React.PropTypes.bool,
-};
 
 export default Dropdown;

--- a/src/views/components/GoogleCarouselMetadata.jsx
+++ b/src/views/components/GoogleCarouselMetadata.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import mobilify from '../../lib/mobilify';
 import moment from 'moment';
+
+import mobilify from '../../lib/mobilify';
 import propTypes from '../../propTypes';
 
 function formatComments (comments, origin) {

--- a/src/views/components/Inbox.jsx
+++ b/src/views/components/Inbox.jsx
@@ -4,6 +4,13 @@ import MessagePreview from './MessagePreview';
 import BaseComponent from './BaseComponent';
 
 class Inbox extends BaseComponent {
+  //TODO: someone more familiar with this component could eventually fill this out better
+  static propTypes = {
+    // apiOptions: React.PropTypes.object,
+    // isReply: React.PropTypes.bool.isRequired,
+    // messages: React.PropTypes.array.isRequired,
+  };
+  
   constructor(props) {
     super(props);
 
@@ -60,12 +67,5 @@ class Inbox extends BaseComponent {
     );
   }
 }
-
-//TODO: someone more familiar with this component could eventually fill this out better
-Inbox.propTypes = {
-  // apiOptions: React.PropTypes.object,
-  // isReply: React.PropTypes.bool.isRequired,
-  // messages: React.PropTypes.array.isRequired,
-};
 
 export default Inbox;

--- a/src/views/components/InfoBar.jsx
+++ b/src/views/components/InfoBar.jsx
@@ -4,7 +4,6 @@ import cookies from 'cookies-js';
 import { find as _find, filter as _filter } from 'lodash/collection';
 
 import BaseComponent from './BaseComponent';
-
 import constants from '../../constants';
 
 const PropTypes = React.PropTypes;
@@ -16,6 +15,12 @@ const EU_COOKIE_MESSAGE = 'Cookies help us deliver our Services. By ' +
 let InfoBarEUCookieFirstShow = true;
 
 class InfoBar extends BaseComponent {
+  static propTypes = {
+    messages: PropTypes.array.isRequired,
+    app: PropTypes.object.isRequired,
+    showEUCookieMessage: PropTypes.bool.isRequired,
+  };
+  
   constructor(props) {
     super(props);
 
@@ -152,12 +157,6 @@ class InfoBar extends BaseComponent {
         <div className='infobar-placeholder'></div>
       );
     }
-  }
-
-  static propTypes = {
-    messages: PropTypes.array.isRequired,
-    app: PropTypes.object.isRequired,
-    showEUCookieMessage: PropTypes.bool.isRequired,
   }
 }
 

--- a/src/views/components/Interstitial.jsx
+++ b/src/views/components/Interstitial.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import BaseComponent from './BaseComponent';
 import { models } from 'snoode';
+
+import BaseComponent from './BaseComponent';
 import constants from '../../constants';
 
 const message = 'You must be at least eighteen years old to view this content.' +
@@ -15,6 +16,12 @@ const contentMap = {
 };
 
 class Interstitial extends BaseComponent {
+  static propTypes = {
+    subredditName: React.PropTypes.string.isRequired,
+    type: React.PropTypes.string.isRequired,
+    customText: React.PropTypes.string,
+  };
+  
   constructor(props) {
     super(props);
 
@@ -96,11 +103,5 @@ class Interstitial extends BaseComponent {
     );
   }
 }
-
-Interstitial.propTypes = {
-  subredditName: React.PropTypes.string.isRequired,
-  type: React.PropTypes.string.isRequired,
-  customText: React.PropTypes.string,
-};
 
 export default Interstitial;

--- a/src/views/components/Listing.jsx
+++ b/src/views/components/Listing.jsx
@@ -22,6 +22,23 @@ function _isCompact(props) {
 }
 
 class Listing extends BaseComponent {
+  static propTypes = {
+    apiOptions: PropTypes.object,
+    compact: PropTypes.bool,
+    editError: PropTypes.arrayOf(PropTypes.string),
+    editing: PropTypes.bool,
+    hideComments: PropTypes.bool,
+    hideDomain: PropTypes.bool,
+    hideSubredditLabel: PropTypes.bool,
+    hideWhen: PropTypes.bool,
+    listing: propTypes.listing.isRequired,
+    onDelete: PropTypes.func,
+    saveUpdatedText: PropTypes.func,
+    single: PropTypes.bool,
+    toggleEdit: PropTypes.func,
+    z: PropTypes.number,
+  };
+  
   constructor(props) {
     super(props);
 
@@ -375,23 +392,6 @@ class Listing extends BaseComponent {
 
   _loadContent() {
     this.setState({loaded: true}, this.resize);
-  }
-
-  static propTypes = {
-    apiOptions: PropTypes.object,
-    compact: PropTypes.bool,
-    editError: PropTypes.arrayOf(PropTypes.string),
-    editing: PropTypes.bool,
-    hideComments: PropTypes.bool,
-    hideDomain: PropTypes.bool,
-    hideSubredditLabel: PropTypes.bool,
-    hideWhen: PropTypes.bool,
-    listing: propTypes.listing.isRequired,
-    onDelete: PropTypes.func,
-    saveUpdatedText: PropTypes.func,
-    single: PropTypes.bool,
-    toggleEdit: PropTypes.func,
-    z: PropTypes.number,
   }
 }
 

--- a/src/views/components/ListingContainer.jsx
+++ b/src/views/components/ListingContainer.jsx
@@ -18,11 +18,11 @@ class ListingContainer extends BaseComponent {
     pagingPrefix: Proptypes.string,
     prevUrl: Proptypes.string,
     nextUrl: Proptypes.string,
-  }
+  };
 
   static defaultProps = {
     shouldPage: true,
-  }
+  };
 
   constructor(props) {
     super(props);
@@ -86,8 +86,6 @@ class ListingContainer extends BaseComponent {
       </div>
     );
   }
-
-
 }
 
 export default ListingContainer;

--- a/src/views/components/ListingContent.jsx
+++ b/src/views/components/ListingContent.jsx
@@ -1,13 +1,12 @@
 import React from 'react';
+import has from 'lodash/object/has';
+import URL from 'url';
 
 import mobilify from '../../lib/mobilify';
 import propTypes from '../../propTypes';
-import has from 'lodash/object/has';
-import URL from 'url';
-const PropTypes = React.PropTypes;
-
 import BaseComponent from './BaseComponent';
 
+const PropTypes = React.PropTypes;
 const _gfyRegex = /https?:\/\/(?:.+)\.gfycat.com\/(.+)\.gif/;
 const _DEFAULT_ASPECT_RATIO = 16 / 9;
 
@@ -96,6 +95,23 @@ function forceProtocol(url, https) {
 }
 
 class ListingContent extends BaseComponent {
+  static propTypes = {
+    compact: PropTypes.bool,
+    editError: PropTypes.arrayOf(PropTypes.string),
+    editing: PropTypes.bool,
+    expand: PropTypes.func.isRequired,
+    expanded: PropTypes.bool.isRequired,
+    expandedCompact: PropTypes.bool,
+    isThumbnail: PropTypes.bool,
+    listing: propTypes.listing.isRequired,
+    loaded: PropTypes.bool.isRequired,
+    saveUpdatedText: PropTypes.func,
+    single: PropTypes.bool,
+    tallestHeight: PropTypes.number.isRequired,
+    toggleEdit: PropTypes.func,
+    width: PropTypes.number.isRequired,
+  };
+  
   constructor(props) {
     super(props);
 
@@ -559,23 +575,6 @@ class ListingContent extends BaseComponent {
     }
 
     return listing.title.match(/nsf[wl]/gi) || listing.over_18;
-  }
-
-  static propTypes = {
-    compact: PropTypes.bool,
-    editError: PropTypes.arrayOf(PropTypes.string),
-    editing: PropTypes.bool,
-    expand: PropTypes.func.isRequired,
-    expanded: PropTypes.bool.isRequired,
-    expandedCompact: PropTypes.bool,
-    isThumbnail: PropTypes.bool,
-    listing: propTypes.listing.isRequired,
-    loaded: PropTypes.bool.isRequired,
-    saveUpdatedText: PropTypes.func,
-    single: PropTypes.bool,
-    tallestHeight: PropTypes.number.isRequired,
-    toggleEdit: PropTypes.func,
-    width: PropTypes.number.isRequired,
   }
 }
 

--- a/src/views/components/ListingDropdown.jsx
+++ b/src/views/components/ListingDropdown.jsx
@@ -7,6 +7,22 @@ import BaseComponent from './BaseComponent';
 import SeashellsDropdown from '../components/SeashellsDropdown';
 
 class ListingDropdown extends BaseComponent {
+  static propTypes = {
+    // apiOptions: React.PropTypes.object,
+    listing: React.PropTypes.oneOfType([
+      propTypes.comment,
+      propTypes.listing,
+    ]).isRequired,
+    onDelete: React.PropTypes.func,
+    onEdit: React.PropTypes.func,
+    onHide: React.PropTypes.func,
+    onSave: React.PropTypes.func,
+    onReport: React.PropTypes.func.isRequired,
+    permalink: React.PropTypes.string,
+    showEditAndDel: React.PropTypes.bool,
+    showHide: React.PropTypes.bool,
+  };
+  
   constructor(props) {
     super(props);
 
@@ -338,21 +354,5 @@ class ListingDropdown extends BaseComponent {
     }
   }
 }
-
-ListingDropdown.propTypes = {
-  // apiOptions: React.PropTypes.object,
-  listing: React.PropTypes.oneOfType([
-    propTypes.comment,
-    propTypes.listing,
-  ]).isRequired,
-  onDelete: React.PropTypes.func,
-  onEdit: React.PropTypes.func,
-  onHide: React.PropTypes.func,
-  onSave: React.PropTypes.func,
-  onReport: React.PropTypes.func.isRequired,
-  permalink: React.PropTypes.string,
-  showEditAndDel: React.PropTypes.bool,
-  showHide: React.PropTypes.bool,
-};
 
 export default ListingDropdown;

--- a/src/views/components/ListingList.jsx
+++ b/src/views/components/ListingList.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import uniq from 'lodash/array/uniq';
+
 import constants from '../../constants';
 import propTypes from '../../propTypes';
-import uniq from 'lodash/array/uniq';
 
 import Ad from '../components/Ad';
 import BaseComponent from './BaseComponent';
@@ -13,6 +14,17 @@ const Proptypes = React.PropTypes;
 const _AD_LOCATION = 11;
 
 class ListingList extends BaseComponent {
+  static propTypes = {
+    compact: Proptypes.bool,
+    firstPage: Proptypes.number,
+    listings: Proptypes.arrayOf(Proptypes.oneOfType([
+      propTypes.comment,
+      propTypes.listing,
+    ])).isRequired,
+    showAds: Proptypes.bool,
+    showHidden: Proptypes.bool,
+  };
+  
   constructor(props) {
     super(props);
 
@@ -180,17 +192,6 @@ class ListingList extends BaseComponent {
     if (compact !== 'undefined' && compact !==this.state.compact) {
       this.setState({compact});
     }
-  }
-
-  static propTypes = {
-    compact: Proptypes.bool,
-    firstPage: Proptypes.number,
-    listings: Proptypes.arrayOf(Proptypes.oneOfType([
-      propTypes.comment,
-      propTypes.listing,
-    ])).isRequired,
-    showAds: Proptypes.bool,
-    showHidden: Proptypes.bool,
   }
 }
 

--- a/src/views/components/ListingPaginationButtons.jsx
+++ b/src/views/components/ListingPaginationButtons.jsx
@@ -4,6 +4,12 @@ import querystring from 'querystring';
 import BaseComponent from './BaseComponent';
 
 class ListingPaginationButtons extends BaseComponent {
+  static propTypes = {
+    compact: React.PropTypes.bool,
+    prevUrl: React.PropTypes.string,
+    nextUrl: React.PropTypes.string,
+  };
+  
   constructor(props) {
     super(props);
 
@@ -97,12 +103,6 @@ class ListingPaginationButtons extends BaseComponent {
         </div>
       </div>
     );
-  }
-
-  static propTypes = {
-    compact: React.PropTypes.bool,
-    prevUrl: React.PropTypes.string,
-    nextUrl: React.PropTypes.string,
   }
 }
 

--- a/src/views/components/MessagePreview.jsx
+++ b/src/views/components/MessagePreview.jsx
@@ -9,6 +9,14 @@ import Inbox from '../components/Inbox';
 const subredditRegex = /\/r\/([^/]*)/;
 
 class MessagePreview extends BaseComponent {
+  //TODO: someone more familiar with this component could eventually fill this out better
+  static propTypes = {
+    // apiOptions: React.PropTypes.object,
+    // lastReply: React.PropTypes.bool.isRequired,
+    // message: React.PropTypes.object.isRequired,
+    onSubmit: React.PropTypes.func.isRequired,
+  };
+  
   constructor(props) {
     super(props);
 
@@ -250,13 +258,5 @@ class MessagePreview extends BaseComponent {
     );
   }
 }
-
-//TODO: someone more familiar with this component could eventually fill this out better
-MessagePreview.propTypes = {
-  // apiOptions: React.PropTypes.object,
-  // lastReply: React.PropTypes.bool.isRequired,
-  // message: React.PropTypes.object.isRequired,
-  onSubmit: React.PropTypes.func.isRequired,
-};
 
 export default MessagePreview;

--- a/src/views/components/Modal.jsx
+++ b/src/views/components/Modal.jsx
@@ -2,6 +2,10 @@ import React from 'react';
 import BaseComponent from './BaseComponent';
 
 class Modal extends BaseComponent {
+  static propTypes = {
+    open: React.PropTypes.bool,
+  };
+  
   constructor(props) {
     super(props);
 
@@ -59,9 +63,5 @@ class Modal extends BaseComponent {
   }
 
 }
-
-Modal.propTypes = {
-  open: React.PropTypes.bool,
-};
 
 export default Modal;

--- a/src/views/components/SearchBar.jsx
+++ b/src/views/components/SearchBar.jsx
@@ -2,6 +2,13 @@ import React from 'react';
 import BaseComponent from './BaseComponent';
 
 class SearchBar extends BaseComponent {
+  //TODO: someone more familiar with this component could eventually fill this out better
+  static propTypes = {
+    action: React.PropTypes.string.isRequired,
+    defaultValue: React.PropTypes.string,
+    onSearch: React.PropTypes.func,
+  };
+  
   constructor(props) {
     super(props);
 
@@ -47,12 +54,5 @@ class SearchBar extends BaseComponent {
     );
   }
 }
-
-//TODO: someone more familiar with this component could eventually fill this out better
-SearchBar.propTypes = {
-  action: React.PropTypes.string.isRequired,
-  defaultValue: React.PropTypes.string,
-  onSearch: React.PropTypes.func,
-};
 
 export default SearchBar;

--- a/src/views/components/SeashellsDropdown.jsx
+++ b/src/views/components/SeashellsDropdown.jsx
@@ -1,10 +1,15 @@
 import React from 'react';
+
 import constants from '../../constants';
 
 import BaseComponent from './BaseComponent';
 import Dropdown from '../components/Dropdown';
 
 class SeashellsDropdown extends BaseComponent {
+  static propTypes = {
+    reversed: React.PropTypes.bool,
+  };
+  
   constructor(props) {
     super(props);
 
@@ -51,9 +56,5 @@ class SeashellsDropdown extends BaseComponent {
     this.setState({opened: bool});
   }
 }
-
-SeashellsDropdown.propTypes = {
-  reversed: React.PropTypes.bool,
-};
 
 export default SeashellsDropdown;

--- a/src/views/components/SortDropdown.jsx
+++ b/src/views/components/SortDropdown.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import constants from '../../constants';
 import querystring from 'querystring';
+
+import constants from '../../constants';
 import titleCase from '../../lib/titleCase';
 
 import Dropdown from '../components/Dropdown';
@@ -58,6 +59,15 @@ var _LISTS = {
 };
 
 class SortDropdown extends BaseComponent {
+  static propTypes = {
+    baseUrl: React.PropTypes.string,
+    className: React.PropTypes.string,
+    excludedSorts: React.PropTypes.arrayOf(React.PropTypes.string),
+    list: React.PropTypes.string.isRequired,
+    sort: React.PropTypes.string.isRequired,
+    sortParam: React.PropTypes.string,
+  };
+  
   constructor(props) {
     super(props);
 
@@ -143,14 +153,5 @@ class SortDropdown extends BaseComponent {
     this.setState({opened: bool});
   }
 }
-
-SortDropdown.propTypes = {
-  baseUrl: React.PropTypes.string,
-  className: React.PropTypes.string,
-  excludedSorts: React.PropTypes.arrayOf(React.PropTypes.string),
-  list: React.PropTypes.string.isRequired,
-  sort: React.PropTypes.string.isRequired,
-  sortParam: React.PropTypes.string,
-};
 
 export default SortDropdown;

--- a/src/views/components/SubredditSelectionButton.jsx
+++ b/src/views/components/SubredditSelectionButton.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import process from 'reddit-text-js';
+
 import propTypes from '../../propTypes';
 
 import BaseComponent from './BaseComponent';
@@ -10,6 +11,17 @@ import SeashellsDropdown from '../components/SeashellsDropdown';
 const _searchLimit = 25;
 
 class SubredditSelectionButton extends BaseComponent {
+  static propTypes = {
+    // apiOptions: React.PropTypes.object,
+    changeSubreddit: React.PropTypes.func.isRequired,
+    errorClass: React.PropTypes.string.isRequired,
+    goToAboutPage: React.PropTypes.func,
+    open: React.PropTypes.bool.isRequired,
+    subreddit: React.PropTypes.string.isRequired,
+    subscriptions: propTypes.subscriptions,
+    toggleOpen: React.PropTypes.func.isRequired,
+  };
+  
   constructor(props) {
     super(props);
 
@@ -202,16 +214,5 @@ class SubredditSelectionButton extends BaseComponent {
     }
   }
 }
-
-SubredditSelectionButton.propTypes = {
-  // apiOptions: React.PropTypes.object,
-  changeSubreddit: React.PropTypes.func.isRequired,
-  errorClass: React.PropTypes.string.isRequired,
-  goToAboutPage: React.PropTypes.func,
-  open: React.PropTypes.bool.isRequired,
-  subreddit: React.PropTypes.string.isRequired,
-  subscriptions: propTypes.subscriptions,
-  toggleOpen: React.PropTypes.func.isRequired,
-};
 
 export default SubredditSelectionButton;

--- a/src/views/components/TopNav.jsx
+++ b/src/views/components/TopNav.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import constants from '../../constants';
 import propTypes from '../../propTypes';
 
@@ -10,6 +11,11 @@ const UserMenuButton = 'userMenuButton';
 const CommunityMenuButton = 'communityMenuButton';
 
 class TopNav extends BaseComponent {
+  static propTypes = {
+    user: propTypes.user,
+    subredditName: React.PropTypes.string,
+  };
+  
   constructor(props) {
     super(props);
 
@@ -144,11 +150,6 @@ class TopNav extends BaseComponent {
 
   _onCommunityMenuToggle(bool) {
     this.setState({ communityMenuOpen: bool});
-  }
-
-  static propTypes = {
-    user: propTypes.user,
-    subredditName: React.PropTypes.string,
   }
 }
 

--- a/src/views/components/UserActivitySubnav.jsx
+++ b/src/views/components/UserActivitySubnav.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import constants from '../../constants';
 import querystring from 'querystring';
+
+import constants from '../../constants';
 
 import BaseComponent from './BaseComponent';
 import Dropdown from '../components/Dropdown';
@@ -26,6 +27,12 @@ const dropdownList = [
 ];
 
 class UserActivitySubnav extends BaseComponent {
+  static propTypes = {
+    activity: React.PropTypes.string,
+    name: React.PropTypes.string.isRequired,
+    sort: React.PropTypes.string,
+  };
+  
   constructor(props) {
     super(props);
 
@@ -155,11 +162,5 @@ class UserActivitySubnav extends BaseComponent {
     );
   }
 }
-
-UserActivitySubnav.propTypes = {
-  activity: React.PropTypes.string,
-  name: React.PropTypes.string.isRequired,
-  sort: React.PropTypes.string,
-};
 
 export default UserActivitySubnav;

--- a/src/views/components/Vote.jsx
+++ b/src/views/components/Vote.jsx
@@ -1,11 +1,21 @@
 import React from 'react';
 import { models } from 'snoode';
+
 import constants from '../../constants';
 import propTypes from '../../propTypes';
 
 import BaseComponent from '../components/BaseComponent';
 
 class Vote extends BaseComponent {
+  static propTypes = {
+    // apiOptions: React.PropTypes.object,
+    setScore: React.PropTypes.func,
+    thing: React.PropTypes.oneOfType([
+      propTypes.comment,
+      propTypes.listing,
+    ]).isRequired,
+  };
+  
   constructor(props) {
     super(props);
 
@@ -174,14 +184,5 @@ class Vote extends BaseComponent {
     );
   }
 }
-
-Vote.propTypes = {
-  // apiOptions: React.PropTypes.object,
-  setScore: React.PropTypes.func,
-  thing: React.PropTypes.oneOfType([
-    propTypes.comment,
-    propTypes.listing,
-  ]).isRequired,
-};
 
 export default Vote;

--- a/src/views/pages/BasePage.jsx
+++ b/src/views/pages/BasePage.jsx
@@ -6,6 +6,12 @@ import TrackingPixel from '../../lib/TrackingPixel';
 import constants from '../../constants';
 
 class BasePage extends BaseComponent {
+  static propTypes = {
+    ctx: React.PropTypes.object.isRequired,
+    data: React.PropTypes.object.isRequired,
+    app: React.PropTypes.object.isRequired,
+  };
+  
   constructor (props) {
     super(props);
 
@@ -136,11 +142,5 @@ class BasePage extends BaseComponent {
     this.props.app.emit('page:update', this.props);
   }
 }
-
-BasePage.propTypes = {
-  ctx: React.PropTypes.object.isRequired,
-  data: React.PropTypes.object.isRequired,
-  app: React.PropTypes.object.isRequired,
-};
 
 export default BasePage;

--- a/src/views/pages/error.jsx
+++ b/src/views/pages/error.jsx
@@ -7,6 +7,14 @@ const TRANSIENT_ERROR_MESSAGE = 'Try again?';
 const IDEMPOTENT_ERROR_MESSAGE = 'Go back?';
 
 class ErrorPage extends BasePage {
+  // TODO: someone more familiar with this component could eventually fill this out
+  static propTypes = {
+    status: React.PropTypes.number.isRequired,
+    originalUrl: React.PropTypes.string.isRequired,
+    title: React.PropTypes.string.isRequired,
+    referrer: React.PropTypes.string,
+  };
+  
   constructor(props) {
     super(props);
     this._desktopSite = this._desktopSite.bind(this);
@@ -77,13 +85,5 @@ class ErrorPage extends BasePage {
     );
   }
 }
-
-// TODO: someone more familiar with this component could eventually fill this out
-ErrorPage.propTypes = {
-  status: React.PropTypes.number.isRequired,
-  originalUrl: React.PropTypes.string.isRequired,
-  title: React.PropTypes.string.isRequired,
-  referrer: React.PropTypes.string,
-};
 
 export default ErrorPage;

--- a/src/views/pages/index.jsx
+++ b/src/views/pages/index.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import constants from '../../constants';
 
 import BasePage from './BasePage';
@@ -9,6 +10,20 @@ import Interstitial from '../components/Interstitial';
 import CommunityHeader from '../components/CommunityHeader';
 
 class IndexPage extends BasePage {
+  static propTypes = {
+    before: React.PropTypes.string,
+    after: React.PropTypes.string,
+    data: React.PropTypes.object,
+    multi: React.PropTypes.string,
+    multiUser: React.PropTypes.string,
+    page: React.PropTypes.number,
+    prefs: React.PropTypes.shape({
+      hide_ads: React.PropTypes.bool.isRequired,
+    }),
+    sort: React.PropTypes.string,
+    subredditName: React.PropTypes.string,
+  };
+  
   constructor(props) {
     super(props);
     this.state.compact = props.compact;
@@ -125,19 +140,5 @@ class IndexPage extends BasePage {
     );
   }
 }
-
-IndexPage.propTypes = {
-  before: React.PropTypes.string,
-  after: React.PropTypes.string,
-  data: React.PropTypes.object,
-  multi: React.PropTypes.string,
-  multiUser: React.PropTypes.string,
-  page: React.PropTypes.number,
-  prefs: React.PropTypes.shape({
-    hide_ads: React.PropTypes.bool.isRequired,
-  }),
-  sort: React.PropTypes.string,
-  subredditName: React.PropTypes.string,
-};
 
 export default IndexPage;

--- a/src/views/pages/listing.jsx
+++ b/src/views/pages/listing.jsx
@@ -11,6 +11,15 @@ import Loading from '../components/Loading';
 import TopSubnav from '../components/TopSubnav';
 
 class ListingPage extends BasePage {
+  static propTypes = {
+    commentId: React.PropTypes.string,
+    data: React.PropTypes.object,
+    isGoogleCrawler: React.PropTypes.bool,
+    listingId: React.PropTypes.string.isRequired,
+    sort: React.PropTypes.string,
+    subredditName: React.PropTypes.string,
+  };
+  
   constructor(props) {
     super(props);
     this.state.editing = false;
@@ -281,14 +290,5 @@ class ListingPage extends BasePage {
     );
   }
 }
-
-ListingPage.propTypes = {
-  commentId: React.PropTypes.string,
-  data: React.PropTypes.object,
-  isGoogleCrawler: React.PropTypes.bool,
-  listingId: React.PropTypes.string.isRequired,
-  sort: React.PropTypes.string,
-  subredditName: React.PropTypes.string,
-};
 
 export default ListingPage;

--- a/src/views/pages/messages.jsx
+++ b/src/views/pages/messages.jsx
@@ -6,6 +6,13 @@ import Inbox from '../components/Inbox';
 import Loading from '../components/Loading';
 
 class MessagesPage extends BasePage {
+  //TODO: someone more familiar with this component could eventually fill this out better
+  static propTypes = {
+    // apiOptions: React.PropTypes.object,
+    data: React.PropTypes.object,
+    view: React.PropTypes.string.isRequired,
+  };
+  
   get track () {
     return 'messages';
   }
@@ -44,12 +51,5 @@ class MessagesPage extends BasePage {
     );
   }
 }
-
-//TODO: someone more familiar with this component could eventually fill this out better
-MessagesPage.propTypes = {
-  // apiOptions: React.PropTypes.object,
-  data: React.PropTypes.object,
-  view: React.PropTypes.string.isRequired,
-};
 
 export default MessagesPage;

--- a/src/views/pages/search.jsx
+++ b/src/views/pages/search.jsx
@@ -14,6 +14,24 @@ const _searchLimit = 25;
 const _searchLimitWithRecommendations = _searchLimit - 3;
 
 class SearchPage extends BasePage {
+  static isNoRecordsFound(data) {
+    return ((data || {}).links || []).length === 0 &&
+           ((data || {}).subreddits || []).length === 0;
+  }
+  
+  //TODO: someone more familiar with this component could eventually fill this out better
+  static propTypes = {
+    after: React.PropTypes.string,
+    // apiOptions: React.PropTypes.object,
+    before: React.PropTypes.string,
+    data: React.PropTypes.object,
+    page: React.PropTypes.number.isRequired,
+    sort: React.PropTypes.string.isRequired,
+    subredditName: React.PropTypes.string,
+    subreddits: React.PropTypes.object,
+    time: React.PropTypes.string.isRequired,
+  };
+  
   constructor(props) {
     super(props);
 
@@ -259,24 +277,6 @@ class SearchPage extends BasePage {
       </div>
     );
   }
-
-  static isNoRecordsFound(data) {
-    return ((data || {}).links || []).length === 0 &&
-           ((data || {}).subreddits || []).length === 0;
-  }
 }
-
-//TODO: someone more familiar with this component could eventually fill this out better
-SearchPage.propTypes = {
-  after: React.PropTypes.string,
-  // apiOptions: React.PropTypes.object,
-  before: React.PropTypes.string,
-  data: React.PropTypes.object,
-  page: React.PropTypes.number.isRequired,
-  sort: React.PropTypes.string.isRequired,
-  subredditName: React.PropTypes.string,
-  subreddits: React.PropTypes.object,
-  time: React.PropTypes.string.isRequired,
-};
 
 export default SearchPage;

--- a/src/views/pages/submit.jsx
+++ b/src/views/pages/submit.jsx
@@ -25,6 +25,16 @@ function _determineKind(body) {
 var debouncedDetermineKind = throttle(_determineKind, 1000);
 
 class SubmitPage extends BasePage {
+  //TODO: someone more familiar with this component could eventually fill this out better
+  static propTypes = {
+    // apiOptions: React.PropTypes.object,
+    kind: React.PropTypes.string,
+    resubmit: React.PropTypes.bool,
+    subredditName: React.PropTypes.string,
+    thingId: React.PropTypes.string,
+    type: React.PropTypes.string,
+  };
+  
   constructor(props) {
     super(props);
 
@@ -394,15 +404,5 @@ class SubmitPage extends BasePage {
     );
   }
 }
-
-//TODO: someone more familiar with this component could eventually fill this out better
-SubmitPage.propTypes = {
-  // apiOptions: React.PropTypes.object,
-  kind: React.PropTypes.string,
-  resubmit: React.PropTypes.bool,
-  subredditName: React.PropTypes.string,
-  thingId: React.PropTypes.string,
-  type: React.PropTypes.string,
-};
 
 export default SubmitPage;

--- a/src/views/pages/subredditAbout.jsx
+++ b/src/views/pages/subredditAbout.jsx
@@ -8,6 +8,11 @@ import Loading from '../components/Loading';
 import TopSubnav from '../components/TopSubnav';
 
 class SubredditAboutPage extends BasePage {
+  static propTypes = {
+    // apiOptions: React.PropTypes.object,
+    subredditName: React.PropTypes.string.isRequired,
+  };
+  
   get track () {
     return 'subreddit';
   }
@@ -68,10 +73,5 @@ class SubredditAboutPage extends BasePage {
     );
   }
 }
-
-SubredditAboutPage.propTypes = {
-  // apiOptions: React.PropTypes.object,
-  subredditName: React.PropTypes.string.isRequired,
-};
 
 export default SubredditAboutPage;

--- a/src/views/pages/userActivity.jsx
+++ b/src/views/pages/userActivity.jsx
@@ -6,6 +6,17 @@ import Loading from '../components/Loading';
 import UserActivitySubnav from '../components/UserActivitySubnav';
 
 class UserActivityPage extends BasePage {
+  //TODO: someone more familiar with this component could eventually fill this out better
+  static propTypes = {
+    activity: React.PropTypes.string.isRequired,
+    after: React.PropTypes.string,
+    before: React.PropTypes.string,
+    data: React.PropTypes.object,
+    page: React.PropTypes.number,
+    sort: React.PropTypes.string,
+    userName: React.PropTypes.string.isRequired,
+  };
+  
   get track() {
     return 'activity';
   }
@@ -62,16 +73,5 @@ class UserActivityPage extends BasePage {
     );
   }
 }
-
-//TODO: someone more familiar with this component could eventually fill this out better
-UserActivityPage.propTypes = {
-  activity: React.PropTypes.string.isRequired,
-  after: React.PropTypes.string,
-  before: React.PropTypes.string,
-  data: React.PropTypes.object,
-  page: React.PropTypes.number,
-  sort: React.PropTypes.string,
-  userName: React.PropTypes.string.isRequired,
-};
 
 export default UserActivityPage;

--- a/src/views/pages/userGild.jsx
+++ b/src/views/pages/userGild.jsx
@@ -4,6 +4,10 @@ import BasePage from './BasePage';
 import TopSubnav from '../components/TopSubnav';
 
 class UserGildPage extends BasePage {
+  static propTypes = {
+    userName: React.PropTypes.string.isRequired,
+  };
+  
   render() {
     return (
       <div className="user-page user-gild">
@@ -22,9 +26,5 @@ class UserGildPage extends BasePage {
     );
   }
 }
-
-UserGildPage.propTypes = {
-  userName: React.PropTypes.string.isRequired,
-};
 
 export default UserGildPage;

--- a/src/views/pages/userProfile.jsx
+++ b/src/views/pages/userProfile.jsx
@@ -6,6 +6,10 @@ import TopSubnav from '../components/TopSubnav';
 import UserProfile from '../components/UserProfile';
 
 class UserProfilePage extends BasePage {
+  static propTypes = {
+    userName: React.PropTypes.string.isRequired,
+  };
+  
   get track () {
     return 'userProfile';
   }
@@ -39,9 +43,5 @@ class UserProfilePage extends BasePage {
     );
   }
 }
-
-UserProfilePage.propTypes = {
-  userName: React.PropTypes.string.isRequired,
-};
 
 export default UserProfilePage;

--- a/src/views/pages/userSaved.jsx
+++ b/src/views/pages/userSaved.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import constants from '../../constants';
 
 import BasePage from './BasePage';
@@ -8,6 +9,15 @@ import Loading from '../components/Loading';
 const PropTypes = React.PropTypes;
 
 class UserSavedPage extends BasePage {
+  static propTypes = {
+    actionName: PropTypes.string.isRequired,
+    apiOptions: PropTypes.object,
+    data: PropTypes.object,
+    page: PropTypes.number,
+    sort: PropTypes.string,
+    userName: PropTypes.string.isRequired,
+  }
+  
   get track () {
     return 'activities';
   }
@@ -59,15 +69,6 @@ class UserSavedPage extends BasePage {
       );
 
     }
-  }
-
-  static propTypes = {
-    actionName: PropTypes.string.isRequired,
-    apiOptions: PropTypes.object,
-    data: PropTypes.object,
-    page: PropTypes.number,
-    sort: PropTypes.string,
-    userName: PropTypes.string.isRequired,
   }
 }
 

--- a/src/views/pages/wikiPage.jsx
+++ b/src/views/pages/wikiPage.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import process from 'reddit-text-js';
+import moment from 'moment';
+
 import mobilify from '../../lib/mobilify';
 
 import BasePage from './BasePage';
 import Loading from '../components/Loading';
 import ListingContainer from '../components/ListingContainer';
 import TextSubNav from '../components/TextSubNav';
-
-import moment from 'moment';
 
 const PAGETYPES = {
   LISTING: 't3',
@@ -18,6 +18,11 @@ const PAGETYPES = {
 };
 
 class WikiPageComp extends BasePage {
+  static propTypes = {
+    subredditName: React.PropTypes.string,
+    ctx: React.PropTypes.object.isRequired,
+  };
+  
   makeContent(props, data) {
     const compact = props.compact;
     let content;
@@ -146,10 +151,5 @@ class WikiPageComp extends BasePage {
     );
   }
 }
-
-WikiPageComp.propTypes = {
-  subredditName: React.PropTypes.string,
-  ctx: React.PropTypes.object.isRequired,
-};
 
 export default WikiPageComp;


### PR DESCRIPTION
Since we talked about it, I figured I would make a patch to address it.

I tried to preserve comments as best as I could. Addressing all the todos is out of the scope of this patch.

I also fixed up the import grouping. I noticed that you guys are trying to do "1) Third party / node modules, 2) Constants / propTypes, 3) everything else" so if I caught something breaking that convention, I fixed it.

Checklist:
* [x] Move all the static props in `/components`
* [x] Move all the static props in `/pages`

:eyeglasses: @ajacksified @schwers 