### PR TITLE
Fix performance issue in iOS chrome from transform

### DIFF
--- a/assets/less/components/Listing.less
+++ b/assets/less/components/Listing.less
@@ -15,7 +15,12 @@
 
 .Listing {
   position: relative;
-  .transform(translateZ(0));
+  // Chrome on iOS won't pick this up, but only browsers like Safari
+  // and chrome on android will. Chrome on iOS can't handle the memory
+  // usage or something and the scroll janks. They might not be using
+  // WKWebView which would explain the huge performance difference
+  // than iOS Safari
+  will-change: transform;
 
   &.compact {
     @media (min-width: @max-width) {
@@ -48,7 +53,7 @@
     }
   }
 
-  &:not(.compact) {
+  &.card {
     @radius: 3px;
     margin-bottom: @row-spacing-base;
     border-radius: @radius;

--- a/src/views/components/Listing.jsx
+++ b/src/views/components/Listing.jsx
@@ -278,7 +278,7 @@ class Listing extends BaseComponent {
       );
     }
 
-    var listingClass = `Listing ${(compact ? 'compact' : '')}` +
+    var listingClass = `Listing ${(compact ? 'compact' : 'card')}` +
       `${(listing.promoted ? ' Listing-sponsored' : '')}`;
 
     return (


### PR DESCRIPTION
:eyeglasses: @ajacksified @curioussavage @umbrae 

Code review pass for now. Seems like Chrome on iOS has performance problems when the transform is applied to `.Listing` cards.  I added `will-change` transform as fallback.

edit: I originally removed z-index as it seemed unnecessary and seems to fix the bug transform was supposed to fix (compact menus). But that breaks modals on debug on desktop chrome. So I've left z-index in for debugging / future-proofing.

[my local install](http://192.168.129.24:4444/) has these changes

https://reddit.atlassian.net/browse/MOBILEWEB-367