### PR TITLE
Show the no results warning correctly

### DIFF
--- a/src/views/pages/search.jsx
+++ b/src/views/pages/search.jsx
@@ -129,6 +129,21 @@ class SearchPage extends BasePage {
     this.props.app.redirect(url);
   }
 
+  shouldShowNoResultsMessage(data) {
+    if (!data.search) {
+      return true;
+    }
+
+    const props = this.props;
+
+    // If we're searching within a subreddit and have no results don't
+    // render the banner. The generic case will handle linking to the
+    // site-wide search
+    const searchingInSubreddit = !!(props.subredditName && props.ctx.query.q);
+    return !data.search.links ||
+      (data.search.links.length === 0 && !searchingInSubreddit);
+  }
+
   render() {
     const state = this.state;
     const data = state.data;
@@ -141,7 +156,7 @@ class SearchPage extends BasePage {
       controls = (
         <Loading />
       );
-    } else if (!data.search || data.search.links.length === 0) {
+    } else if (this.shouldShowNoResultsMessage(data)) {
       const noResClass = props.ctx.query.q ? '' : 'hidden';
       controls = (
         <div

--- a/src/views/pages/search.jsx
+++ b/src/views/pages/search.jsx
@@ -131,18 +131,18 @@ class SearchPage extends BasePage {
 
   render() {
     const state = this.state;
+    const data = state.data;
     const props = this.props;
     const app = this.props.app;
     const apiOptions = props.apiOptions;
     let controls;
-    let noResult;
 
     if (!state.loaded && props.ctx.query && props.ctx.query.q) {
       controls = (
         <Loading />
       );
-    } else if (!this.state.data.search) {
-      const noResClass = noResult && props.ctx.query.q ? '' : 'hidden';
+    } else if (!data.search || data.search.links.length === 0) {
+      const noResClass = props.ctx.query.q ? '' : 'hidden';
       controls = (
         <div
           className={ `container no-results text-right text-special ${noResClass}` }
@@ -159,7 +159,6 @@ class SearchPage extends BasePage {
       const listings = searchResults.links || [];
       const noListResults = listings.length === 0;
       const noSubResults = subreddits.length === 0;
-      noResult = noSubResults && noListResults;
       const subredditResultsOnly = props.subredditName && props.ctx.query.q;
       const compact = this.state.compact;
 


### PR DESCRIPTION
Fixes `search.jsx` to show the no results message when expected.

Removed the var `noResult` as it was impossible for it have any value where it was being used. Cleans up the checks a little.

:eyeglasses: @ajacksified or @curioussavage 