### PR TITLE
Bodylayout: include on everypage

### DIFF
--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -552,11 +552,8 @@ function routes(app) {
       return this.redirect('/login?originalUrl=' + submitUrl);
     }
 
-    this.body = function(props) {
-      return (
-        <SubmitPage key={ this.key } {...props}/>
-      );
-    };
+    props.hideTopNav = true;
+    this.body = makeBody(SubmitPage);
   }
 
   router.get('submit', '/submit', submitPage);

--- a/src/views/layouts/BodyLayout.jsx
+++ b/src/views/layouts/BodyLayout.jsx
@@ -11,6 +11,11 @@ import CommunityOverlayMenu from '../components/CommunityOverlayMenu';
 import { userData } from '../../routes';
 
 class BodyLayout extends BasePage {
+  static propTypes = {
+    hideTopNav: React.PropTypes.bool,
+    showEUCookieMessage: React.PropTypes.bool,
+  };
+
   constructor(props) {
     super(props);
 
@@ -35,9 +40,13 @@ class BodyLayout extends BasePage {
     }
   }
 
-  render () {
-    const { user, userSubscriptions } = this.state.data;
-    const { app, globalMessage, showEUCookieMessage } = this.props;
+  renderTopNavIfVisible(props, state) {
+    const { user, userSubscriptions } = state.data;
+    const { app, globalMessage, showEUCookieMessage, hideTopNav } = props;
+
+    if (hideTopNav) {
+      return null;
+    }
 
     let messages = [];
     if (showEUCookieMessage) {
@@ -49,20 +58,31 @@ class BodyLayout extends BasePage {
     }
 
     return (
-      <div className='container-with-betabanner'>
+      <div>
         <CommunityOverlayMenu
           {...this.props}
           user={ user }
           subscriptions={ userSubscriptions }
+          key='communitymenu'
         />
-        <UserOverlayMenu {...this.props} user={ user } />
-        <TopNav {...this.props} user={ user } />
+        <UserOverlayMenu {...this.props} user={ user } key='usermenu' />
+        <TopNav {...this.props} user={ user } key='topnav' />
         <InfoBar
-          key='onlyRenderThisOnceEver'
           messages={ messages }
           app={ app }
           showEUCookieMessage={ showEUCookieMessage }
+          key='onlyRenderThisOnceEver'
         />
+      </div>
+    );
+  }
+
+  render () {
+    const topNavIfVisible = this.renderTopNavIfVisible(this.props, this.state);
+
+    return (
+      <div className='container-with-betabanner'>
+        { topNavIfVisible }
         <main>
           { this.props.children }
         </main>


### PR DESCRIPTION
BodyLayout now takes an optional prop that will hide
the topnav. All pages can now be rendered through body
layout so we can use it for app wide errors and notifications.

@schwers or @nramadas 

For the new login/registration page, which does not have the `topNav` anymore. Instead of rendering it with a custom body function We now pass a flag to indicate the `topNav` should be hidden. 

Also makes it so `bodylayout` can own the toasts since it will always be rendered. 