### PR TITLE
Fix null listing url check (log cleanup)

### DIFF
--- a/src/views/components/ListingContent.jsx
+++ b/src/views/components/ListingContent.jsx
@@ -80,7 +80,7 @@ function _wrapSelftextExpand(fn) {
 
 function _isPlayable(listing) {
   let media = listing.media;
-  if (listing.url.indexOf('.gif') > -1 ||
+  if (listing.url && listing.url.indexOf('.gif') > -1 ||
       (media && media.oembed && media.oembed.type !== 'image')
      ) {
     return true;


### PR DESCRIPTION
:eyeglasses: @ajacksified or @curioussavage or @nramadas 

I've noticed this error popping up in the logs. An alternative would be to provide empty string default via Snoode but this might be the only case where this is an issue