### PR TITLE
Fix match of undefined error (log cleanup)

### DIFF
--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -74,10 +74,10 @@ function setCompact(ctx, app) {
     maxAge: 1000 * 60 * 60 * 24 * 365 * 2,
   };
 
-  let ua = ctx.headers['user-agent'];
+  const ua = ctx.headers['user-agent'];
 
   // Set compact for opera mini
-  if (ua.match(/(opera mini|android 2)/i)) {
+  if (ua && ua.match(/(opera mini|android 2)/i)) {
     compact = true;
   }
 


### PR DESCRIPTION
Been noticing this error in the log. It looks like some of the requests don’t have a userAgent so that could be the real underlying issue. But in a lot of cases it looks like we check for user-agent not being null so this seems like a valid fix.

:eyeglasses: @ajacksified 