### PR TITLE
Unjankify iOS Chrome scrolling again.

### DIFF
--- a/assets/less/components/Listing.less
+++ b/assets/less/components/Listing.less
@@ -22,14 +22,6 @@
 }
 
 .Listing {
-  position: relative;
-  // Chrome on iOS won't pick this up, but only browsers like Safari
-  // and chrome on android will. Chrome on iOS can't handle the memory
-  // usage or something and the scroll janks. They might not be using
-  // WKWebView which would explain the huge performance difference
-  // than iOS Safari
-  will-change: transform;
-
   &.compact {
     @media (min-width: @max-width) {
       border-left: @gray-border;


### PR DESCRIPTION
It looks like scrolling is awry again. No recent changes in the code
would have caused this. In-fact the issue is present when
time-traveling back to 94cda4847f15ea1e4b8a12b42a3b7b42dce6a319

Google Chrome has no updates listed in the App Store, so I think it’s
an issue with either iOS version 9.2 or 9.3 (testing with 9.3)

:eyeglasses: @ajacksified and @curioussavage (not sure what version you're on Adam, but let me know. Let's do a round of more testing in the morning)