### PR TITLE
Set background to key_color on community header icons

### DIFF
--- a/src/views/components/OverlayMenuRow.jsx
+++ b/src/views/components/OverlayMenuRow.jsx
@@ -14,6 +14,10 @@ function iconOrSpacerFromProps(props) {
       backgroundImage: `url(${props.iconURL})`,
     };
 
+    if (props.iconBackgroundColor) {
+      backgroundStyle.backgroundColor = props.iconBackgroundColor;
+    }
+
     iconContent = (
       <span
         className='OverlayMenu-icon OverlayMenu-icon-img'


### PR DESCRIPTION
Some of the new subreddit icons rely on the transparency of icon images to render properly. Eg r/apple

In this patch:
![image](https://cloud.githubusercontent.com/assets/307983/12470658/e73e957a-bfaa-11e5-9989-3505f24a8aaa.png)

Versus prod:
![image](https://cloud.githubusercontent.com/assets/307983/12470666/f88e7660-bfaa-11e5-86c4-330cbf0b141f.png)

:eyeglasses: @ajacksified or @curioussavage or @nramadas 


