### PR TITLE
Make login/register use real links and redirect back properly.

### DIFF
--- a/src/config.es6.js
+++ b/src/config.es6.js
@@ -20,6 +20,9 @@ if (globalMessage) {
 }
 
 function config() {
+  const loginPath = process.env.LOGIN_PATH || '/oauth2/login';
+  const registerPath = loginPath === '/login' ? '/register' : loginPath;
+
   return {
     https: process.env.HTTPS === 'true',
     httpsProxy: process.env.HTTPS_PROXY === 'true',
@@ -42,7 +45,8 @@ function config() {
     googleAnalyticsId: process.env.GOOGLE_ANALYTICS_ID,
     googleTagManagerId: process.env.GOOGLE_TAG_MANAGER_ID,
 
-    loginPath: process.env.LOGIN_PATH || '/oauth2/login',
+    loginPath,
+    registerPath,
 
     statsURL: process.env.STATS_URL || 'https://stats.redditmedia.com/',
     mediaDomain: process.env.MEDIA_DOMAIN || 'www.redditmedia.com',

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -5,6 +5,7 @@ import querystring from 'querystring';
 import superagent from 'superagent';
 
 import merge from 'lodash/object/merge';
+import url from 'url';
 
 // components
 import BodyLayout from './views/layouts/BodyLayout';
@@ -238,6 +239,23 @@ function * globalMessage(next) {
     }
   }
   yield next;
+}
+
+function loginRegisterOriginalUrl(query, headers) {
+  let redirectUrl;
+
+  if (query && query.originalUrl) {
+    redirectUrl = url.parse(query.originalUrl).path;
+  } else if (!redirectUrl && headers && headers.referer) {
+    const parsedReferrer = url.parse(headers.referer);
+    redirectUrl = parsedReferrer.path;
+  }
+
+  // Make sure redirectUrl is a a relative path. url.parse will accept any
+  // string and return it back as the path. path will be null when parsing empty string
+  if (redirectUrl && redirectUrl[0] === '/') {
+    return redirectUrl;
+  }
 }
 
 // The main entry point to this file is the routes function.
@@ -607,13 +625,15 @@ function routes(app) {
   });
 
   router.get('user.login', '/login', function * () {
-    const { error, message, originalUrl } = this.query;
+    const { error, message } = this.query;
+    const originalUrl = loginRegisterOriginalUrl(this.query, this.headers);
     this.props = {...this.props, error, message, originalUrl };
     this.body = makeBody(LoginPage);
   });
 
   router.get('user.register', '/register', function * () {
-    const { error, message, originalUrl } = this.query;
+    const { error, message } = this.query;
+    const originalUrl = loginRegisterOriginalUrl(this.query, this.headers);
     this.props = {...this.props, error, message, originalUrl };
     this.body = makeBody(RegisterPage);
   });
@@ -812,3 +832,4 @@ function routes(app) {
 export default routes;
 export var buildProps = buildProps;
 export var userData = userData;
+export var loginRegisterOriginalUrl = loginRegisterOriginalUrl;

--- a/src/views/components/CommentBox.jsx
+++ b/src/views/components/CommentBox.jsx
@@ -13,7 +13,7 @@ class CommentBox extends BaseComponent {
     thingId: PropTypes.string.isRequired,
     token: PropTypes.string,
   };
-  
+
   constructor(props) {
     super(props);
 
@@ -50,16 +50,12 @@ class CommentBox extends BaseComponent {
       return;
     }
 
+    if (this.props.app.needsToLogInUser()) { return; }
+
     this.setState({error: ''});
 
-    const { apiOptions, app, token, thingId, onSubmit } = this.props;
-    const { requireLogin, config, api } = app;
-
-    if (!token) {
-      requireLogin(config.loginPath);
-
-      return;
-    }
+    const { apiOptions, app, thingId, onSubmit } = this.props;
+    const { api } = app;
 
     const comment = new models.Comment({
       thingId,

--- a/src/views/components/CommunityHeader.jsx
+++ b/src/views/components/CommunityHeader.jsx
@@ -129,11 +129,7 @@ class CommunityHeader extends BaseComponent {
   }
 
   _onSubscribeToggle() {
-    if (!this.props.token) {
-      // hard redirect: we need to make sure the CSRF token is fresh
-      window.location = '/register';
-      return;
-    }
+    if (this.props.app.needsToLogInUser()) { return; }
 
     const subreddit = this.state.subreddit;
     const props = this.props;

--- a/src/views/components/TopSubnav.jsx
+++ b/src/views/components/TopSubnav.jsx
@@ -20,7 +20,6 @@ function TopSubnav (props) {
       <a
         className='TopSubnav-a'
         href={ props.app.config.loginPath }
-        data-no-route='true'
       >
         Log in / Register
       </a>

--- a/src/views/components/UserActivitySubnav.jsx
+++ b/src/views/components/UserActivitySubnav.jsx
@@ -32,7 +32,7 @@ class UserActivitySubnav extends BaseComponent {
     name: React.PropTypes.string.isRequired,
     sort: React.PropTypes.string,
   };
-  
+
   constructor(props) {
     super(props);
 
@@ -113,7 +113,6 @@ class UserActivitySubnav extends BaseComponent {
         <a
           className='TopSubnav-a'
           href={ this.props.app.config.loginPath }
-          data-no-route='true'
         >Log in / Register</a>
       );
     }

--- a/src/views/components/UserOverlayMenu.jsx
+++ b/src/views/components/UserOverlayMenu.jsx
@@ -94,10 +94,9 @@ class UserOverlayMenu extends BaseComponent {
       userBasedRows = (
         <LinkRow
           key='login-row'
-          noRoute={ true }
           text={ 'Log in / sign up' }
           icon={ userIconClassName }
-          href={ this.props.app.config.loginPath }
+          href={ config.loginPath }
         />);
     }
 

--- a/src/views/components/Vote.jsx
+++ b/src/views/components/Vote.jsx
@@ -14,7 +14,7 @@ class Vote extends BaseComponent {
       propTypes.listing,
     ]).isRequired,
   };
-  
+
   constructor(props) {
     super(props);
 
@@ -90,10 +90,7 @@ class Vote extends BaseComponent {
   }
 
   submitVote(direction) {
-    if (!this.props.token) {
-      window.location = this.props.app.config.loginPath;
-      return;
-    }
+    if (this.props.app.needsToLogInUser()) { return; }
 
     if (this.state.localScore === direction) {
       direction = 0;

--- a/test/index.js
+++ b/test/index.js
@@ -25,3 +25,6 @@ require('./views/layouts/BodyLayout');
 // pages
 require('./views/pages/Index');
 require('./views/pages/userSaved');
+
+// functions from routes
+require('./routes/loginRegisterOriginalUrl.es6.js');

--- a/test/routes/loginRegisterOriginalUrl.es6.js
+++ b/test/routes/loginRegisterOriginalUrl.es6.js
@@ -1,0 +1,66 @@
+import chai from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+
+const expect = chai.expect;
+
+chai.use(sinonChai);
+
+import { loginRegisterOriginalUrl } from '../../src/routes';
+
+describe('routes: loginRegisterOriginalUrl', () => {
+  it('is a function', () => {
+    expect(loginRegisterOriginalUrl).to.be.a('function');
+  });
+
+  it('returns nothing when given invalid input', () => {
+    expect(loginRegisterOriginalUrl(null, null)).to.equal(undefined);
+
+    const invalidPathQueryParam = {
+      originalUrl: 'someInvalidPath',
+    };
+
+    expect(loginRegisterOriginalUrl(invalidPathQueryParam, null)).to.equal(undefined);
+
+    const invalidReferrer = {
+      referer: 'someapp://listingspage',
+    };
+
+    expect(loginRegisterOriginalUrl(null, invalidReferrer)).to.equal(undefined);
+  });
+
+  it('uses originalUrl from the queryParam even when there\'s a valid header', () => {
+    const queryParamReferer = {
+      originalUrl: '/r/pics',
+    };
+
+    const headerRefer = {
+      referer: 'https://m.reddit.com/register?originalUrl=foobar',
+    };
+
+    expect(loginRegisterOriginalUrl(queryParamReferer, headerRefer)).to.equal(queryParamReferer.originalUrl);
+  });
+
+  it('turns absolute urls into relative paths', () => {
+    const relativePath = '/r/DestinyTheGame';
+    const queryParamReferer = {
+      originalUrl: `https://m.reddit.com${relativePath}`,
+    };
+
+    expect(loginRegisterOriginalUrl(queryParamReferer, null)).to.equal(relativePath);
+
+    const headerReferer = {
+      referer: `https://somebadwebsite.com${relativePath}`,
+    };
+
+    expect(loginRegisterOriginalUrl(null, headerReferer)).to.equal(relativePath);
+
+    const otherSiteReferer = {
+      referer: 'https://www.fakereddit.com',
+    };
+
+    // this should be '/' so it returns to the frontpage of
+    // reddit if someone tries to redirect back to their site
+    expect(loginRegisterOriginalUrl(null, otherSiteReferer)).to.equal('/');
+  });
+});


### PR DESCRIPTION
This changes login/register to be regular links. They no longer require
setting `data-no-route={ true }` or setting the originalUrl. Cleans up
`app.redirect` in `client.es6.js` and removes duplicated logic in the
click handlers to make this possible.

Adds a `REGISTER_PATH` that automatically is `/register` for apps that
use `/login`.

The app links to `LOGIN_PATH` when there’s a good  chance the user is
intending to log in to an existing account. eg if they click ‘log in’
on the top of the page or user menu. Otherwise when an action that
requires having an account is performed `app.needsToLogInUser` will
properly redirect to `REGISTER_PATH`

For testing: Should be tested in staging to make sure the non-development `originalUrl` validation is working as intended