### PR TITLE
GTM add null check in trigger and set methods

### DIFF
--- a/assets/js/gtm.es6.js
+++ b/assets/js/gtm.es6.js
@@ -1,25 +1,23 @@
-'use strict';
-
 import frames from './frames';
 
-let jail = document.getElementById('gtm-jail');
+export default {
+  trigger(eventName, payload) {
+    const jailEl = document.getElementById('gtm-jail');
+    if (jailEl) {
+      if (payload) {
+        this.set(payload);
+      }
 
-let gtm = {
-
-  trigger: function(eventName, payload) {
-    if (payload) {
-      this.set(payload);
+      frames.postMessage(jailEl.contentWindow, 'event.gtm', {
+        event: eventName,
+      });
     }
-
-    frames.postMessage(jail.contentWindow, 'event.gtm', {
-      event: eventName,
-    });
   },
 
-  set: function(data) {
-    frames.postMessage(jail.contentWindow, 'data.gtm', data);
+  set(data) {
+    const jailEl = document.getElementById('gtm-jail');
+    if (jailEl) {
+      frames.postMessage(jailEl.contentWindow, 'data.gtm', data);
+    }
   },
-
 };
-
-export default gtm;


### PR DESCRIPTION
This was causing an error locally when the config variables
aren't set and there is no 'jail' element. The two methods
try to access a property on the element.

also fully es6ified it. and moved `getElementbyId` into the functions so It doesn't run when the file is loaded. 

@dwick @schwers 