### PR TITLE
Super simple client error logging

### DIFF
--- a/assets/js/client.es6.js
+++ b/assets/js/client.es6.js
@@ -1,27 +1,35 @@
 import 'babel/polyfill';
 
-import '../../src/lib/dnt';
+import superagent from 'superagent';
 
 import errorLog from '../../src/lib/errorLog';
 
+const POST_ERROR_URL = '/error';
 
 function onError(message, url, line, column) {
-  errorLog({
+  const details = {
     userAgent: window.navigator.userAgent,
     message,
     url,
     line,
     column,
-    requestUrl: window.location.toString()
-  }, {
-    hivemind: window.bootstrap && window.bootstrap.config ? window.bootstrap.config.statsURL : undefined,
+    requestUrl: window.location.toString(),
+  };
+
+  const hivemind = window.bootstrap && window.bootstrap.config ?
+    window.bootstrap.config.statsURL : undefined;
+
+  errorLog(details, {
+    hivemind,
+    postErrorURL: POST_ERROR_URL,
   });
 }
 
 // Register as early as possible
 window.onerror = onError;
 
-import React from 'react';
+import '../../src/lib/dnt';
+
 import ReactDOM from 'react-dom';
 import throttle from 'lodash/function/throttle';
 import forOwn from 'lodash/object/forOwn';
@@ -29,8 +37,6 @@ import forOwn from 'lodash/object/forOwn';
 import ClientReactApp from 'horse-react/src/client';
 import attachFastClick from 'fastclick';
 import mixin from '../../src/app-mixin';
-import querystring from 'querystring';
-import superagent from 'superagent';
 
 var App = mixin(ClientReactApp);
 
@@ -56,6 +62,8 @@ var $body = document.body || document.getElementsByTagName('body')[0];
 var $head = document.head || document.getElementsByTagName('head')[0];
 
 var config = defaultConfig();
+// the client should post errors to the /error endpoint.
+config.postErrorURL = POST_ERROR_URL;
 
 function loadShim() {
   var shimScript = document.createElement('script');

--- a/src/app-mixin.jsx
+++ b/src/app-mixin.jsx
@@ -50,6 +50,7 @@ function logError(err, ctx, config) {
     requestUrl: ctx ? ctx.path : null,
   }, {
     hivemind: config.statsURL,
+    log: config.postErrorURL,
   }, {
     level: config.debugLevel || 'error',
   });

--- a/src/lib/errorLog.es6.js
+++ b/src/lib/errorLog.es6.js
@@ -57,6 +57,11 @@ function errorLog(details, errorEndpoints, config={}) {
     }
   }
 
+  // send to local log
+  if (errorEndpoints.log) {
+    sendErrorLog(formattedLog, errorEndpoints.log);
+  }
+
   // send to statsd
   if (errorEndpoints.hivemind) {
     let ua = simpleUA(details.userAgent || '');
@@ -64,6 +69,13 @@ function errorLog(details, errorEndpoints, config={}) {
   }
 
   // log to winston, soon
+}
+
+function sendErrorLog(error, endpoint) {
+  superagent
+    .post(endpoint)
+    .send({ error })
+    .then(()=>{});
 }
 
 function hivemind(ua, endpoint) {

--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -27,7 +27,7 @@ import setLoggedOutCookies from '../lib/loid';
 
 import defaultConfig from '../config';
 
-const ignoreCSRF = ['/timings'];
+const ignoreCSRF = ['/timings', '/error'];
 
 function getBucket(loid) {
   return parseInt(loid.substring(loid.length - 4), 36) % 100;

--- a/src/server/routes.es6.js
+++ b/src/server/routes.es6.js
@@ -1,5 +1,6 @@
 import superagent from 'superagent';
 import crypto from 'crypto';
+
 import constants from '../constants';
 
 // set up server-only routes
@@ -78,6 +79,17 @@ let serverRoutes = function(app) {
           path: r.path,
         };
       });
+  });
+
+  router.post('/error', function* () {
+    // log it out if it's a legit origin
+    if (this.headers.origin &&
+        app.config.origin.indexOf(this.headers.origin) === 0) {
+      console.log(this.body.error.substring(0,1000));
+    }
+
+    this.body = null;
+    return;
   });
 };
 


### PR DESCRIPTION
:eyeglasses: @schwers 

This adds the ability for the client to send error logs to the server, which will be `console.log`. You can then grep the server logs for output to see what's going on on the client. Includes stack traces if available.