### PR TITLE
Bug Fix: prevent render on first popstate in safari

### DIFF
--- a/assets/js/client.es6.js
+++ b/assets/js/client.es6.js
@@ -339,6 +339,7 @@ function initialize(bindLinks) {
 
   var scrollCache = {};
 
+  let ignoredInitialPopState = false;
   var initialUrl = app.fullPathName();
 
   function postRender(href) {
@@ -437,6 +438,11 @@ function initialize(bindLinks) {
 
       window.addEventListener('popstate', function() {
         var href = app.fullPathName();
+        if (href === initialUrl && !ignoredInitialPopState) {
+          ignoredInitialPopState = true;
+          return;
+        }
+
         scrollCache[initialUrl] = window.scrollY;
 
         render(app, href, false, app.modifyContext).then(postRender(href));

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -254,6 +254,10 @@ function loginRegisterOriginalUrl(query, headers) {
   // Make sure redirectUrl is a a relative path. url.parse will accept any
   // string and return it back as the path. path will be null when parsing empty string
   if (redirectUrl && redirectUrl[0] === '/') {
+    if (redirectUrl.indexOf('/login') === 0 ||
+        redirectUrl.indexOf('/register') === 0) {
+      return '/';
+    }
     return redirectUrl;
   }
 }

--- a/test/routes/loginRegisterOriginalUrl.es6.js
+++ b/test/routes/loginRegisterOriginalUrl.es6.js
@@ -63,4 +63,22 @@ describe('routes: loginRegisterOriginalUrl', () => {
     // reddit if someone tries to redirect back to their site
     expect(loginRegisterOriginalUrl(null, otherSiteReferer)).to.equal('/');
   });
+
+  it('will not allow redirect loop', () => {
+    const loginReferer = {
+      referer: 'https://m.reddit.com/login',
+    };
+
+    // this should be '/' so it returns to the frontpage of
+    // reddit if someone tries to redirect back to their site
+    expect(loginRegisterOriginalUrl(null, loginReferer)).to.equal('/');
+
+    const registerReferer = {
+      referer: 'https://m.reddit.com/register',
+    };
+
+    // this should be '/' so it returns to the frontpage of
+    // reddit if someone tries to redirect back to their site
+    expect(loginRegisterOriginalUrl(null, registerReferer)).to.equal('/');
+  });
 });


### PR DESCRIPTION
 Safari triggers a popstate event on initial render.
On the login route this was causing it to render the
page again with the wrong referer.