### PR TITLE
Only run `finish` setstate on the client

### DIFF
--- a/src/views/pages/BasePage.jsx
+++ b/src/views/pages/BasePage.jsx
@@ -110,9 +110,14 @@ class BasePage extends BaseComponent {
   }
 
   finish () {
-    if (this.state.finished === false && this.track) {
-      this.props.app.emit('pageview', { ...this.props, data: this.state.data });
-      this.setState({ finished: true });
+    if (this.props.ctx.env !== 'SERVER') {
+      if (this.state.finished === false && this.track) {
+        this.props.app.emit('pageview', {
+          ...this.props,
+          data: this.state.data,
+        });
+        this.setState({ finished: true });
+      }
     }
   }
 


### PR DESCRIPTION
Avoid extra synchronous setstates on the server by only setting state on
the client once all of the data loads.

:eyeglasses: @schwers 