### PR TITLE
Preserve scroll position in smarter ways

### DIFF
--- a/assets/js/client.es6.js
+++ b/assets/js/client.es6.js
@@ -312,10 +312,7 @@ function initialize(bindLinks) {
 
     // Set to the browser's interpretation of the current name (to make
     // relative paths easier), and send in the old url.
-    render(app, app.fullPathName(), false, app.modifyContext).then(function(props) {
-      setTitle(props);
-      postRender(path);
-    });
+    render(app, app.fullPathName(), false, app.modifyContext).then(postRender(path));
   };
 
   // Redirects to the proper register path if the user isn't logged in.


### PR DESCRIPTION
Depends on:
* [Snoode Pr 75](https://github.com/reddit/snoode/pull/75) that fixes api.hydrate so we wait less for the pageview event
Which depends on  [RestCache Pr 4](https://github.com/reddit/restcache/pull/4) That makes Cache.generateHash work in a deterministic way

This patches first commit fixes the improper way we call postRender right now. I introduced this in [login/register](https://github.com/reddit/reddit-mobile/commit/28fef9da2b97e428d58a10ae2eadde9e92b76505) :(

The second commit makes postRender update scroll position in a second pass after data loads in, _iff_ the page hasn't been manually scrolled. This way if things take a while to come out of the cache (i.e. they're evicted or because Promise.resolve is in a new callstack), the scroll position is updated as expected