### PR TITLE
Fix 'load more comments" link

### DIFF
--- a/src/views/pages/listing.jsx
+++ b/src/views/pages/listing.jsx
@@ -137,9 +137,10 @@ class ListingPage extends BasePage {
         .concat(res.body);
 
       this.setState({
-        data,
+        data: newData,
         loadingMoreComments: false,
       });
+
     } catch (e) {
       app.error(e, this, app, { redirect: false, replaceBody: false });
       this.setState({loadingMoreComments: false});
@@ -233,6 +234,7 @@ class ListingPage extends BasePage {
         const contextPermalink = `${permalink}${comment.parent_id.substring(3)}?context=0`;
         const text = loadingMoreComments ? 'Loading...' :
                                          `load more comments (${numChildren} ${word})`;
+
         return (
           <a
             key={ key }


### PR DESCRIPTION
Addresses: https://reddit.atlassian.net/browse/MOBILEWEB-393

The issue was pretty simple. When we received new data, we chose not to use it (derp). This patch fixes that by actually replacing `data` with `newData`.