### PR TITLE
Set a flag on promises so all `then`s do not log

### DIFF
--- a/src/views/pages/BasePage.jsx
+++ b/src/views/pages/BasePage.jsx
@@ -67,7 +67,9 @@ class BasePage extends BaseComponent {
   }
 
   watch (property) {
-    this.props.data.get(property).then((p) => {
+    const promise = this.props.data.get(property);
+
+    promise.then((p) => {
       let data;
       if (p.body) {
         data = Object.assign({}, this.state.data);
@@ -106,8 +108,13 @@ class BasePage extends BaseComponent {
         this.finish();
       }
     }, (e) => {
-      this.props.app.error(e, this.props.ctx, this.props.app);
-      this.props.app.forceRender(this.props.ctx.body, this.props);
+      // keep every listener from error logging - only log the first failure on
+      // the promise.
+      if (!promise.failed) {
+        promise.failed = true;
+        this.props.app.error(e, this.props.ctx, this.props.app);
+        this.props.app.forceRender(this.props.ctx.body, this.props);
+      }
     });
   }
 


### PR DESCRIPTION
I noticed a strange anomaly: error logs were multiplying on pages with
single errors. For example, a failed API request would turn into four -
and pages with five API requests would turn into twenty. I tracked it
down to basepage, and with some debugging, noticed that error logging
was called by: layout, indexpage, layout (again), and errorpage.
This is due to layout, indexpage, and error page inheriting from
basepage, which sets up watchers on the promises. This is used to run
setState on pages, but *also* logs on errors - and as they share the
same promises, it also means that both layout and page will error, and
then again when redirected with a clone of the properties from the
previous page.

This sets a flag on the shared promise so that it won't re-log after the
first failure.

That's a lot of explanation for a 7-line change.

:eyeglasses: @curioussavage 