### PR TITLE
Separate api errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "semver": "5.0.3",
     "simple-oauth2": "0.2.1",
     "sinon": "1.17.3",
-    "snoode": "1.17.2",
+    "snoode": "1.18.0",
     "statsd-client": "0.2.1",
     "superagent": "1.3.0",
     "uuid": "2.0.1"

--- a/src/server/console.es6.js
+++ b/src/server/console.es6.js
@@ -239,7 +239,8 @@ class Console {
         .get(uri)
         .end(function(err, res) {
           if (err || (res && !res.ok)) {
-            cons.log(`${err || 'TEST FAIL'}: ${res.status}`);
+            const status = res ? res.status : undefined;
+            cons.log(`${err || 'TEST FAIL'}: ${status}`);
           } else {
             cons.log('Test succeeded');
           }


### PR DESCRIPTION
This uses the typed errors from https://github.com/reddit/snoode/pull/78 to report API errors separately from code errors. https://github.com/reddit/hivemind/pull/23 adds the error segment.

:eyeglasses: @schwers 