### PR TITLE
Logs: changes separator to |

### DIFF
--- a/src/lib/errorLog.es6.js
+++ b/src/lib/errorLog.es6.js
@@ -34,7 +34,7 @@ function formatLog(details) {
 
   const {
     userAgent,
-    message, 
+    message,
     url,
     line,
     column,
@@ -54,7 +54,7 @@ function formatLog(details) {
     }
   }
 
-  return errorString.join('\t');
+  return errorString.join('|');
 }
 
 function errorLog(details, errorEndpoints, config={}) {


### PR DESCRIPTION
change the separator so we can parse logs easier.

The tabs get stripped out of our log files.