### PR TITLE
Support manual multis, random, and randnsfw

### DIFF
--- a/src/lib/isFakeSubreddit.es6.js
+++ b/src/lib/isFakeSubreddit.es6.js
@@ -1,0 +1,8 @@
+const randomSubs = ['random', 'randnsfw', 'myrandom'];
+const fakeSubs = ['all', 'mod', 'friends'].concat(randomSubs);
+
+export { fakeSubs, randomSubs };
+
+export default function isFakeSubreddit(subredditName) {
+  return !!subredditName && (subredditName.indexOf('+') > -1 || fakeSubs.includes(subredditName));
+}

--- a/src/views/pages/index.jsx
+++ b/src/views/pages/index.jsx
@@ -11,7 +11,7 @@ import Interstitial from '../components/Interstitial';
 import CommunityHeader from '../components/CommunityHeader';
 import NotificationBar from '../components/NotificationBar';
 
-const FAKE_SUBS = ['mod', 'all', 'friends'];
+import isFakeSubreddit from '../../lib/isFakeSubreddit';
 
 const NOTIFICATIONS = {
   stalePage: {
@@ -99,7 +99,7 @@ class IndexPage extends BasePage {
     const { app } = props;
 
     const subredditName = props.subredditName;
-    const isFakeSub = FAKE_SUBS.indexOf(subredditName) !== -1;
+    const isFakeSub = isFakeSubreddit(subredditName);
 
     if (!data || typeof data.listings === 'undefined' ||
         (subredditName && (!data.subreddit && !isFakeSub))) {

--- a/test/index.js
+++ b/test/index.js
@@ -13,6 +13,7 @@ require('./lib/formatNumber');
 require('./lib/extractErrorMsg');
 require('./lib/rootDomain');
 require('./lib/gifToHTML5Sources');
+require('./lib/isFakeSubreddit');
 
 // src
 require('./src/featureflags');

--- a/test/lib/isFakeSubreddit.es6.js
+++ b/test/lib/isFakeSubreddit.es6.js
@@ -1,0 +1,28 @@
+import chai from 'chai';
+import sinonChai from 'sinon-chai';
+import isFakeSubreddit from '../../src/lib/isFakeSubreddit';
+import { fakeSubs } from '../../src/lib/isFakeSubreddit';
+
+chai.use(sinonChai);
+const expect = chai.expect;
+
+describe('lib: isFakeSubreddit', () => {
+  it('is a function', () => {
+    expect(isFakeSubreddit).to.be.a('function');
+  });
+
+  it('returns false for normal subreddits', () => {
+    expect(isFakeSubreddit('askreddit')).to.be.false;
+  });
+
+  it('returns true for manual multi reddits', () => {
+    expect(isFakeSubreddit('javascript+reactjs')).to.be.true;
+    expect(isFakeSubreddit('destinythegame+division+halo')).to.be.true;
+  });
+
+  it('returns true for any of the special fake fubs', () => {
+    fakeSubs.forEach((fakeSub) => {
+      expect(isFakeSubreddit(fakeSub)).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
Right now manual multis (like `/r/destinythegame+halo+division` fetch
links but are never rendered by the ListingPage because there were two
different definitions of fake subs in the code. Along the way adds
support for random and randnsfw