### PR TITLE
Begin tracking API 504s and 429s

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "semver": "5.0.3",
     "simple-oauth2": "0.2.1",
     "sinon": "1.17.3",
-    "snoode": "1.19.3",
+    "snoode": "1.19.4",
     "statsd-client": "0.2.1",
     "superagent": "1.3.0",
     "uuid": "2.0.1"

--- a/src/app-mixin.jsx
+++ b/src/app-mixin.jsx
@@ -99,9 +99,7 @@ function mixin (App) {
         }
       }
 
-      if (!e.status || (e.status !== 429 && e.status !== 504)) {
-        logError(e, ctx, app.config);
-      }
+      logError(e, ctx, app.config);
 
       if (options.replaceBody !== false) {
         ctx.body = this.errorPage(ctx, e.status);


### PR DESCRIPTION
:eyeglasses: @schwers

This was previously causing too much noise, but now that API errors are separated out, it would be a good thing to track. We should keep an eye on whether this slows down response times while it waits on logging to stdout if things get busy.

We may also want to track incoming API responses the same way we track outgoing HTTP codes, eventually.