### PR TITLE
Events: add track getter to the pages that did not have it

### DIFF
--- a/src/views/layouts/BodyLayout.jsx
+++ b/src/views/layouts/BodyLayout.jsx
@@ -16,6 +16,10 @@ class BodyLayout extends BasePage {
     showEUCookieMessage: React.PropTypes.bool,
   };
 
+  get track() {
+    return false;
+  }
+
   constructor(props) {
     super(props);
 

--- a/src/views/pages/BasePage.jsx
+++ b/src/views/pages/BasePage.jsx
@@ -14,6 +14,10 @@ class BasePage extends BaseComponent {
     app: React.PropTypes.object.isRequired,
   };
 
+  get track() {
+    return true;
+  }
+
   constructor (props) {
     super(props);
 


### PR DESCRIPTION
In basePage the  method is not called unless
there is a  property. This is a hack to make sure
finish is called once since bodyLayout extends basePage.
Since chariot will fix the issue with basePage code running
twice this is an easy way to make sure pageview events fire on
every page.