### PR TITLE
Remove mobile-web-app-capable meta tag to avoid full-screen on iOS

### DIFF
--- a/src/views/layouts/DefaultLayout.jsx
+++ b/src/views/layouts/DefaultLayout.jsx
@@ -110,7 +110,6 @@ function DefaultLayout (props) {
           content='width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no'
         />
         <meta name='theme-color' content={ keyColor } />
-        <meta name='apple-mobile-web-app-capable' content='yes' />
         <meta id='csrf-token-meta-tag' name='csrf-token' content={ props.ctx.csrf } />
         { metaDescription }
 


### PR DESCRIPTION
The mobile-web-app-capable tag makes the app open in full-screen
mode when saved to your home screen, but that's not super ideal as
many URLs link out to other sites on reddit, which brings up the
browser chrome anyway, causing an app switch. I think we should
remove this and let it open up in the browser chrome as normal.

Thoughts?

:eyeglasses: @schwers or @ajacksified 