### PR TITLE
Add r/ distinction to subreddit names

### DIFF
--- a/assets/less/components/communities/CommunityRow.less
+++ b/assets/less/components/communities/CommunityRow.less
@@ -44,6 +44,12 @@
     color: @off-black;
   }
 
+  &__rSlash {
+    color: @grey-text;
+    font-size: 12px;
+    margin-right: 2px;
+  }
+
   &__counts {
     font-size: 12px;
     color: @grey-text;

--- a/src/views/components/CommunityOverlayMenu.jsx
+++ b/src/views/components/CommunityOverlayMenu.jsx
@@ -44,7 +44,12 @@ class CommunityOverlayMenu extends BaseComponent {
                 key={ `OverlayMenu-row-subscription-${subreddit.url}` }
                 href={ subreddit.url }
                 icon='OverlayMenu-icon-following-snoo'
-                text={ subreddit.display_name }
+                text={ (
+                  <span>
+                    <span className='CommunityRow__rSlash'>r/</span>
+                    { subreddit.display_name }
+                  </span>
+                ) }
                 iconURL={ subreddit.icon_img }
                 iconBackgroundColor={ subreddit.key_color }
               />

--- a/src/views/components/OverlayMenuRow.jsx
+++ b/src/views/components/OverlayMenuRow.jsx
@@ -2,6 +2,14 @@ import React from 'react';
 
 import BaseComponent from './BaseComponent';
 
+const T = React.PropTypes;
+
+const BaseRowProps = {
+  text: T.string.isRequired,
+  icon: T.string,
+  iconURL: T.string,
+};
+
 function iconOrSpacerFromProps(props) {
   if (props.subtext) {
     return false;
@@ -37,6 +45,11 @@ function iconOrSpacerFromProps(props) {
 }
 
 class ButtonRow extends BaseComponent {
+  static propTypes = {
+    ...BaseRowProps,
+    clickHandler: T.func.isRequired,
+  };
+
   render() {
     return (
       <li className='OverlayMenu-row'>
@@ -52,16 +65,16 @@ class ButtonRow extends BaseComponent {
       </li>
     );
   }
-
-  static propTypes = {
-    icon: React.PropTypes.string,
-    iconURL: React.PropTypes.string,
-    text: React.PropTypes.node.isRequired,
-    clickHandler: React.PropTypes.func.isRequired,
-  };
 }
 
 class LinkRow extends BaseComponent {
+  static propTypes = {
+    ...BaseRowProps,
+    href: T.string.isRequired,
+    noRoute: T.bool,
+    clickHandler: T.func,
+  };
+
   render() {
     return (
       <li className='OverlayMenu-row'>
@@ -77,18 +90,14 @@ class LinkRow extends BaseComponent {
       </li>
     );
   }
-
-  static propTypes = {
-    noRoute: React.PropTypes.bool,
-    clickHandler: React.PropTypes.func,
-    text: React.PropTypes.node.isRequired,
-    href: React.PropTypes.string.isRequired,
-    icon: React.PropTypes.string,
-    iconURL: React.PropTypes.string,
-  };
 }
 
 class ExpandoRow extends BaseComponent {
+  static propTypes = {
+    ...BaseRowProps,
+    subtext: T.string,
+  };
+
   constructor(props) {
     super(props);
 
@@ -141,13 +150,6 @@ class ExpandoRow extends BaseComponent {
       </li>
     );
   }
-
-  static propTypes = {
-    text: React.PropTypes.string.isRequired,
-    subtext: React.PropTypes.string,
-    icon: React.PropTypes.string,
-    iconURL: React.PropTypes.string,
-  };
 }
 
 export { ButtonRow, LinkRow, ExpandoRow };

--- a/src/views/components/OverlayMenuRow.jsx
+++ b/src/views/components/OverlayMenuRow.jsx
@@ -5,7 +5,7 @@ import BaseComponent from './BaseComponent';
 const T = React.PropTypes;
 
 const BaseRowProps = {
-  text: T.string.isRequired,
+  text: T.node.isRequired,
   icon: T.string,
   iconURL: T.string,
 };

--- a/src/views/components/communities/CommunityRow.jsx
+++ b/src/views/components/communities/CommunityRow.jsx
@@ -20,7 +20,10 @@ function renderDetails(data) {
 
   return (
     <a className='CommunityRow__details' href={ url }>
-      <div className='CommunityRow__name'>{ display_name }</div>
+      <div className='CommunityRow__name'>
+        <span className='CommunityRow__rSlash'>r/</span>
+        { display_name }
+      </div>
       <div className='CommunityRow__counts'>
         { [subscribers, accounts_active]
           .filter(x => !!x)


### PR DESCRIPTION
This adds r/ to subredit display names in the community menu and in search results. We're doing this when rendering posts and post dropdrowns, so this makes things consistent. Especially because the r/ makes things feel uniquely Reddit. Both of these cases are lists so the distinction is smaller and lighter than normal font to make scanning the list easier.

![image](https://cloud.githubusercontent.com/assets/307983/13685427/438118bc-e6c5-11e5-98d7-d5921791b9cc.png)

![image](https://cloud.githubusercontent.com/assets/307983/13685421/395f630c-e6c5-11e5-8e43-4c94d7f4cc20.png)
