### PR TITLE
Ads: Request ad as an authenticated user if logged in

### DIFF
--- a/src/views/components/Ad.jsx
+++ b/src/views/components/Ad.jsx
@@ -17,7 +17,6 @@ class Ad extends BaseComponent {
     config: T.object.isRequired,
     apiOptions: T.object.isRequired,
     ctx: T.object.isRequired,
-    token: T.string,
     loid: T.string,
     compact: T.bool.isRequired,
     site: T.string.isRequired,
@@ -78,7 +77,8 @@ class Ad extends BaseComponent {
     }
 
     const app = this.props.app;
-    const loggedIn = !!this.props.token;
+    const token = this.props.ctx.token;
+    const loggedIn = !!token;
     const origin = (loggedIn ? app.config.authAPIOrigin : app.config.nonAuthAPIOrigin);
     const headers = {};
     const postData = {
@@ -89,7 +89,7 @@ class Ad extends BaseComponent {
 
     // If user is not logged in, send the loid in the promo request
     if (loggedIn) {
-      headers.authorization = `Bearer ${this.props.token}`;
+      headers.authorization = `Bearer ${token}`;
     } else {
       postData.loid = this.props.loid;
     }

--- a/src/views/components/listings/PostAndCommentList.jsx
+++ b/src/views/components/listings/PostAndCommentList.jsx
@@ -255,7 +255,6 @@ export default class PostAndCommentList extends BaseComponent {
         compact={ compact }
         app={ app }
         user={ user }
-        token={ token }
         apiOptions={ apiOptions }
         winWidth={ winWidth }
         hideSubredditLabel={ hideSubredditLabel }


### PR DESCRIPTION
`props.token` was undefined.  It seems like a lot of components specify `token` as a `propType` and in some of them it's not used, but there might be issues elsewhere.  Would it be cleaner to reference it from the `ctx` always instead of passing it through to all these components?

```
Searching 690 files for "token: T.string," (case sensitive)

/Users/dwick/work/code/reddit-mobile/src/views/components/LinkTools.jsx:
   16      onNewComment: T.func,
   17      onSortChange: T.func,
   18:     token: T.string,
   19      isLocked: T.bool,
   20      sort: T.string,

/Users/dwick/work/code/reddit-mobile/src/views/components/comment/Comment.jsx:
   41      user: T.object,
   42      sort: T.string,
   43:     token: T.string,
   44      op: T.string,
   45      nestingLevel: T.number,

/Users/dwick/work/code/reddit-mobile/src/views/components/listings/NewListing.jsx:
   17      ctx: T.object.isRequired,
   18      user: propTypes.user,
   19:     token: T.string,
   20      showAds: T.bool,
   21      loid: T.string,

/Users/dwick/work/code/reddit-mobile/src/views/components/listings/Post.jsx:
   25      apiOptions: T.object.isRequired,
   26      user: propTypes.user,
   27:     token: T.string,
   28      compact: T.bool.isRequired,
   29      hideComments: T.bool,

/Users/dwick/work/code/reddit-mobile/src/views/components/listings/PostAndCommentList.jsx:
   25      ctx: T.object.isRequired,
   26      user: propTypes.user,
   27:     token: T.string,
   28      apiOptions: T.object.isRequired,
   29      compact: T.bool.isRequired,

/Users/dwick/work/code/reddit-mobile/src/views/components/listings/PostFooter.jsx:
   16      post: propTypes.listing.isRequired,
   17      app: T.object.isRequired,
   18:     token: T.string,
   19      apiOptions: T.object.isRequired,
   20      viewComments: T.bool.isRequired,

/Users/dwick/work/code/reddit-mobile/src/views/pages/search.jsx:
   33      time: T.string.isRequired,
   34      query: T.string,
   35:     token: T.string,
   36      after: T.string,
   37      before: T.string,
```