### PR TITLE
Add CSP headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "event-tracker": "git://github.com/reddit/event-tracker.git#28bc2dd9ce3b80540fdf189e1b003f8264cd0d08",
     "feet": "1.2.0",
     "horse": "1.3.2",
-    "horse-react": "1.1.4",
+    "horse-react": "1.2.0",
     "koa": "1.0.0",
     "koa-bodyparser": "2.0.1",
     "koa-compress": "1.0.8",
@@ -52,7 +52,7 @@
     "semver": "5.0.3",
     "simple-oauth2": "0.2.1",
     "sinon": "1.17.3",
-    "snoode": "1.20.6",
+    "snoode": "1.21.3",
     "statsd-client": "0.2.1",
     "superagent": "1.3.0",
     "uuid": "2.0.1"

--- a/src/server/routes.es6.js
+++ b/src/server/routes.es6.js
@@ -93,6 +93,26 @@ const serverRoutes = function(app) {
     this.body = null;
     return;
   });
+
+  router.post('/csp-report', function* () {
+    // log it out if it's a legit origin
+    if (this.headers.origin &&
+        app.config.origin.indexOf(this.headers.origin) === 0) {
+
+      const report = this.body['csp-report'];
+
+      const log = [
+        'CSP REPORT',
+        report['document-uri'],
+        report['blocked-uri'],
+      ];
+
+      console.log(log.join('|'));
+    }
+
+    this.body = null;
+    return;
+  });
 };
 
 export default serverRoutes;

--- a/src/views/components/GoogleCarouselMetadata.jsx
+++ b/src/views/components/GoogleCarouselMetadata.jsx
@@ -92,7 +92,7 @@ function GoogleCarouselMetadata (props) {
   baseObject.comment['@list'] = formatComments(comments, props.origin);
 
   const googleScript = `
-    <script type='application/ld+json'>
+    <script type='application/ld+json' nonce=${props.nonce}>
       ${props.app.safeStringify(baseObject)}
     </script>
   `;

--- a/src/views/components/LiveReload.jsx
+++ b/src/views/components/LiveReload.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
-function LiveReload () {
+function LiveReload ({ nonce }) {
   return (
-    <script src="//localhost:35729/livereload.js?snipver=1"></script>
+    <script src="//localhost:35729/livereload.js?snipver=1" nonce={ nonce }></script>
   );
 }
 

--- a/src/views/layouts/DefaultLayout.jsx
+++ b/src/views/layouts/DefaultLayout.jsx
@@ -12,7 +12,7 @@ function DefaultLayout (props) {
 
   let liveReload;
   if (config.liveReload) {
-    liveReload = (<LiveReload />);
+    liveReload = (<LiveReload nonce={ props.ctx.csrf } />);
   }
 
   if (config.minifyAssets) {
@@ -45,7 +45,7 @@ function DefaultLayout (props) {
     const googleAnalyticsId = config.googleAnalyticsId;
 
     const trackingCode = `
-      <script>
+      <script nonce=${props.ctx.csrf}>
       if (!window.DO_NOT_TRACK) {
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
         (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -68,7 +68,7 @@ function DefaultLayout (props) {
 
   if (config.googleTagManagerId && config.mediaDomain) {
     const gtmCode = `
-      <script>
+      <script nonce=${props.ctx.csrf}>
         if (!window.DO_NOT_TRACK) {
           var frame = document.createElement('iframe');
 
@@ -126,7 +126,7 @@ function DefaultLayout (props) {
           !!CONTENT!!
         </div>
 
-        <script src={ clientJS } async='true'></script>
+        <script src={ clientJS } async='true' nonce={ props.ctx.csrf }></script>
         { liveReload }
         { gtmTracking }
         { gaTracking }

--- a/src/views/pages/listing.jsx
+++ b/src/views/pages/listing.jsx
@@ -261,6 +261,7 @@ class ListingPage extends BasePage {
       if (env === 'SERVER') {
         googleCarousel = (
           <GoogleCarouselMetadata
+            nonce={ this.props.ctx.csrf }
             url={ url }
             app={ app }
             origin={ origin }


### PR DESCRIPTION
This restricts the domains that can host content that is run on mobile
web. The headers added are:

* Self to scripts, styles, and fonts, which lets us load locally
* Localhost for scripts, for livereload
* Google analytics for scripts, for obvious reasons
* ASSET_URL from config, for cdn'd stuff

:eyeglasses: @nramadas (for smart banner) and @spladug 