### PR TITLE
Improve table display in links/comments

### DIFF
--- a/assets/less/base.less
+++ b/assets/less/base.less
@@ -40,6 +40,7 @@
 @import "../../lib/snooboots/less/utilities.less";
 @import "../../lib/snooboots/less/responsive-utilities.less";
 
+@import "components/tables.less";
 @import "components/comment/importAll.less";
 @import "components/dropdown/importAll.less";
 @import "components/formElements/importAll.less";

--- a/assets/less/components/comment/Comment.less
+++ b/assets/less/components/comment/Comment.less
@@ -10,6 +10,8 @@
   &__body {
     padding-top: @grid-size;
     overflow-x: hidden;
+
+    .table();
     
     a {
       color: @blue;

--- a/assets/less/components/listings/PostContent.less
+++ b/assets/less/components/listings/PostContent.less
@@ -1,4 +1,5 @@
 .PostContent {
+  .table();
 
   &.size-compact {
     position: absolute;

--- a/assets/less/components/tables.less
+++ b/assets/less/components/tables.less
@@ -1,4 +1,4 @@
-.PostContent, .Comment__body {
+.table () {
   table {
     margin: 1em 0;
     width: 100%;
@@ -9,3 +9,5 @@
     border-bottom: solid 1px @neutral;
   }
 }
+
+

--- a/assets/less/components/tables.less
+++ b/assets/less/components/tables.less
@@ -1,0 +1,11 @@
+.PostContent, .Comment__body {
+  table {
+    margin: 1em 0;
+    width: 100%;
+  }
+
+  td, th {
+    padding: .25em;
+    border-bottom: solid 1px @neutral;
+  }
+}


### PR DESCRIPTION
This adds borders and padding so that tables are easier to read in comments and links.

<img width="493" alt="screen shot 2016-03-29 at 2 20 40 pm" src="https://cloud.githubusercontent.com/assets/175515/14124297/9ab52e36-f5b9-11e5-9b56-250a6ff96351.png">
<img width="491" alt="screen shot 2016-03-29 at 2 21 22 pm" src="https://cloud.githubusercontent.com/assets/175515/14124298/9aca645e-f5b9-11e5-85be-021d61734ff8.png">

:eyeglasses: @nramadas 