### PR TITLE
redirects: add /live and /rules

### DIFF
--- a/src/redirects.jsx
+++ b/src/redirects.jsx
@@ -44,6 +44,16 @@ function routes(app) {
     const url = this.params[0];
     return this.redirect(`/wiki/${url}`);
   });
+
+  app.router.get('/rules', function*() {
+    return this.redirect('/wiki/contentpolicy');
+  });
+
+  app.router.get('/live/:idOrFilter?', function*() {
+    const { idOrFilter } = this.params;
+    const id = idOrFilter ? `/${idOrFilter}` : '';
+    return this.redirect(`${app.config.reddit}/live${id}`);
+  });
 }
 
 export default routes;


### PR DESCRIPTION
:eyeglasses: @ajacksified or @schwers 

this is mostly for the /live because of this https://reddit.atlassian.net/browse/MOBILEWEB-405 issue.

I'm not sure what will fix that, but either way I think its not a bad thing to have this redirect there. And it sucks that there is an active thread now and its pointing to an error page for mobile

The rules endpoint just mirrors what r2 does - send this url to the content policy