### PR TITLE
userOverlayMenu: add correct click handler to desktop link

### DIFF
--- a/src/views/components/UserOverlayMenu.jsx
+++ b/src/views/components/UserOverlayMenu.jsx
@@ -124,7 +124,7 @@ class UserOverlayMenu extends BaseComponent {
         icon='icon-desktop icon-large blue'
         text='Desktop Site'
         href={ `https://www.reddit.com${this.props.ctx.url}` }
-        clickHandler={ this._desktopSite }
+        clickHandler={ this._gotoDesktopSiteClick }
       />,
       <ExpandoRow
         key='about-reddit'


### PR DESCRIPTION
:eyeglasses: @schwers 

looks like this one slipped through code review. missing click handler