### PR TITLE
Add unhandledrejection listener on server and client

### DIFF
--- a/assets/js/clientEvents.es6.js
+++ b/assets/js/clientEvents.es6.js
@@ -211,4 +211,11 @@ export default function setAppEvents(app, hasHistAndBindLinks, render, $body) {
       app.emit(constants.RESIZE);
     }
   }, 100));
+
+  window.addEventListener('unhandledrejection', event => {
+    app.error(event, this, app, {
+      replaceBody: false,
+      redirect: false,
+    });
+  });
 }


### PR DESCRIPTION
this can help us find promises that need
rejection to be handled. currently only works
in chrome on the browser


👓  @ajacksified @schwers @nramadas 

I think this is really handy, just like `uncaughtException` its a nice helper in dev. only available in chrome right now though :(

see:
http://www.2ality.com/2016/04/unhandled-rejections.html?utm_source=javascriptweekly&utm_medium=email