### PR TITLE
Fix compact query param

### DIFF
--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -112,7 +112,7 @@ function setCompact(ctx, app) {
 
   if (compact) {
     ctx.cookies.set('compact', compact, cookieOptions);
-  } else if (ctx.cookies.get('compact') === 'false') {
+  } else {
     ctx.cookies.set('compact');
   }
 


### PR DESCRIPTION
👓  @ajacksified  or @schwers 

Looks like there is no code that sets a compact cookie with a 'false' value anymore. With git blame it looks like this was intended to fix some clients that still had them. Changing this enables you to switch from compact back to card view by url query parameter. 