### PR TITLE
Ads: Add support for keyword targeting

### DIFF
--- a/src/views/components/Ad.jsx
+++ b/src/views/components/Ad.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { models } from '@r/api-client';
+import propTypes from '../../propTypes';
 
 import constants from '../../constants';
 import BaseComponent from './BaseComponent';
@@ -21,6 +22,7 @@ class Ad extends BaseComponent {
     site: T.string.isRequired,
     subredditTitle: T.string,
     afterLoad: T.func.isRequired,
+    things: propTypes.postsAndComments.isRequired,
   };
 
   static defaultProps = {
@@ -78,6 +80,7 @@ class Ad extends BaseComponent {
     const headers = {};
     const postData = {
       site,
+      dt: this.props.things.map((thing) => thing.name),
       platform: 'mobile_web',
       raw_json: '1',
     };

--- a/src/views/components/listings/PostAndCommentList.jsx
+++ b/src/views/components/listings/PostAndCommentList.jsx
@@ -151,6 +151,7 @@ export default class PostAndCommentList extends BaseComponent {
         subredditTitle={ subredditTitle }
         afterLoad={ this.afterAdDidLoad }
         winWidth={ winWidth }
+        things={ this.props.postsAndComments }
       />
     );
   }


### PR DESCRIPTION
Requires sending the list of thing fullnames that are rendered on
the page to request_promo as the param `dt`.

Change on .com: https://github.com/reddit/reddit-public/commit/1d4b9513d02bfd93168a06243ccede04e9bea732#diff-80017b87156838d1be01f5830f588095R173

👓 @curioussavage @tsegaran 