### PR TITLE
Add next-content experiments

### DIFF
--- a/assets/js/trackingEvents.es6.js
+++ b/assets/js/trackingEvents.es6.js
@@ -478,7 +478,8 @@ function trackingEvents(app) {
       listingName: listing_name,
       linkIndex: link_index,
       linkName: link_name,
-      refererPageType: referer_page_type,
+      referrerPageType: referrer_page_type,
+      referrerUrl: referrer_url,
       targetId: target_id,
       targetFullname: target_fullname,
       targetUrl: url,
@@ -507,7 +508,8 @@ function trackingEvents(app) {
       link_name, // human-readable name of the link clicked
       loid,
       loid_created,
-      referer_page_type, // "listing", "link", "self", "comment"
+      referrer_page_type, // "listing", "link", "self", "comment"
+      referrer_url, // full url of the referrer of the user clicking
       target_id, // base-10 id of the target (used for subreddits only)
       // fullname (prefix+base-36 id) of the content at the target location
       // Currently skipped for subreddit targets to circumvent a data

--- a/assets/less/base.less
+++ b/assets/less/base.less
@@ -74,6 +74,7 @@
 @import "components/messages.less";
 @import "components/minimalinput.less";
 @import "components/Modal.less";
+@import "components/NextContent.less";
 @import "components/NSFWFlair.less";
 @import "components/panels.less";
 @import "components/interstitial.less";

--- a/assets/less/components/NextContent.less
+++ b/assets/less/components/NextContent.less
@@ -1,0 +1,306 @@
+@thumbnail-size: 50px;
+@nextcontent-height: @thumbnail-size + 2 * @grid-size;
+@nextcontent-text-row-height: @nextcontent-height / 3;
+@nextcontent-link-width: 80px;
+.NextContent {
+  width: 100%;
+  height: @nextcontent-height;
+  cursor: pointer;
+
+  padding: @grid-size;
+
+  .Post {
+    margin-bottom: 0;
+  }
+
+  .PostContent.size-compact {
+    position: absolute;
+    width: @thumbnail-size;
+    height: @thumbnail-size;
+    top: @grid-size;
+    left: @grid-size;
+    margin-bottom: 0;
+
+    .PostContent__image-link {
+      height: 50px;
+      width: 50px;
+    }
+  }
+
+  &.bottom {
+    position: fixed;
+    bottom: 0px;
+    padding: 0;
+    margin: 0;
+    .themeify({
+      border-top: @theme-border;
+      background-color: @theme-body-color;
+    });
+  }
+
+  .banner& {
+    position: fixed;
+    bottom: @grid-size;
+    padding: 0;
+    margin: 0;
+    width: calc(~"100% - "2 * @grid-size);
+    left: @grid-size;
+    article {
+      background-color: @blue;
+    }
+  }
+
+  .banner& &, .bottom& & {
+    &__post-wrapper {
+      position: relative;
+      display: inline-block;
+      width: calc(~"100% - "@nextcontent-link-width);
+    }
+    &__header {
+      @rendered-thumbnail-size: @thumbnail-size + 2 * @grid-size;
+      margin-left: @rendered-thumbnail-size;
+      min-height: @rendered-thumbnail-size - 2 * @grid-size;
+      margin-bottom: @grid-size;
+    }
+    &__post-title-line {
+      font-size: 14px;
+      white-space: normal;
+      display: inline-block;
+      overflow: hidden;
+    }
+    &__post-descriptor-line {
+      display: block;
+      max-width: 100%;
+      overflow: hidden;
+      white-space: nowrap;
+      position: relative;
+      vertical-align: middle;
+      padding-right: 3em;
+      line-height: 1.2;
+
+      .icon-font({
+        vertical-align: text-bottom;
+        font-size: 18px;
+        line-height: 18px;
+      });
+
+      &:after {
+        content: '';
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        width: 3em;
+        z-index: 1;
+
+      }
+    }
+  }
+
+  .banner& & {
+    &__header {
+      margin-top: @grid-size;
+    }
+    &__post-title-line {
+      height: @thumbnail-size;
+      .themeify({
+        color: @theme-light-nav-text-color;
+      });
+    }
+    &__post-descriptor-line {
+      .themeify({
+        color: @theme-meta-text-color;
+      });
+
+      &:after {
+        .themeify({
+          #gradient > .horizontal(@start-color: fade(@blue, 0%);
+            @end-color:fade(@blue, 100%) ; @end-percent: 70%);
+        });
+      }
+    }
+  }
+
+  .bottom& & {
+    &__header {
+      margin-top: @grid-size;
+    }
+    &__post-title-line {
+      max-height: 2 * @thumbnail-size / 3;
+      .themeify({
+        color: @theme-body-text-color;
+      });
+    }
+    &__post-descriptor-line {
+      .themeify({
+        color: @theme-meta-text-color;
+      });
+
+      &:after {
+        .themeify({
+          #gradient > .horizontal(@start-color: fade(@theme-body-color, 0%);
+            @end-color:fade(@theme-body-color, 100%) ; @end-percent: 70%);
+        });
+      }
+    }
+  }
+
+  .middle& {
+    height: 2 * @thumbnail-size + 2.5 * @grid-size;
+    padding: @grid-size 0 @grid-size 0;
+    overflow: hidden;
+    margin-top: -8px;
+    .themeify({
+    },
+    @inDayMode: {
+      background-color: @pale-grey;
+    },
+    @inNightMode: {
+      background-color: @theme-comment-body-color;
+    });
+  }
+  .middle& & {
+    &__post-wrapper {
+      .themeify({
+      },
+      @inNightMode: {
+        background-color: @black;
+      });
+    }
+
+    &__header {
+      @rendered-thumbnail-size: @thumbnail-size + 2 * @grid-size;
+      margin-left: @rendered-thumbnail-size;
+      min-height: @thumbnail-size;
+      margin-bottom: @grid-size;
+    }
+
+    &__post-title-line {
+      max-height: 2 * @nextcontent-text-row-height;
+      overflow: hidden;
+      white-space: normal;
+      padding-top: @grid-size / 2;
+      font-size: 14px;
+      display: inline-block;
+      .themeify({
+        color: @theme-body-text-color;
+      });
+    }
+
+    &__post-descriptor-line {
+      display: block;
+      padding-right: 0;
+      padding-bottom: 0;
+      max-width: 100%;
+      overflow: hidden;
+      white-space: nowrap;
+      position: relative;
+      vertical-align: middle;
+      padding-right: @grid-size / 2;
+      .themeify({
+        color: @theme-meta-text-color;
+      });
+      &:last-child {
+        padding-bottom: @grid-size / 2;
+      }
+    }
+
+    &__heading {
+      text-transform: uppercase;
+      font-size: @font-size-base;
+      font-weight: bold;
+      line-height: 2;
+      height: @font-size-h4 * 1.5 + @grid-size / 2;
+      text-align: center;
+      .themeify({
+        color: @theme-body-text-color;
+      },
+      @inDayMode: {
+        background-color: @pale-grey;
+      },
+      @inNightMode: {
+        background-color: @theme-comment-body-color;
+      });
+    }
+  }
+
+  &__drag-container {
+    position: relative;
+    height: @thumbnail-size + 2 * @grid-size;
+  }
+
+  &.middle &__carousel-item &__header {
+    margin-top: 0;
+    margin-bottom: 0;
+    height: @thumbnail-size + 2 * @grid-size;
+  }
+
+  &.middle article&__carousel-item {
+    width: calc(~"100% - " 2 * @thumbnail-size);
+    position: absolute;
+    top: 8px;
+    left: 50px;
+  }
+
+  &__next-link {
+    font-weight: bold;
+    right: 0;
+    position: absolute;
+    width: @nextcontent-link-width;
+    display: inline-block;
+    font-size: @font-size-base;
+    line-height: 1.5;
+    text-align: center;
+    text-transform: uppercase;
+    color: @blue;
+    margin-top: (@nextcontent-height - (1.5 * @font-size-base)) / 2;
+    margin-bottom: (@nextcontent-height - (1.5 * @font-size-base)) / 2;
+    margin-right: @grid-size;
+    margin-left: @grid-size;
+    a, a:hover, a:visited {
+      vertical-align: bottom;
+      text-decoration: none;
+      .themeify({
+        color: @blue;
+      });
+      .icon-inline {
+        font-size: @font-size-base;
+        line-height: 1.5;
+        .themeify({
+          color: @blue;
+          text-decoration: none;
+        });
+      }
+    }
+  }
+
+  &.banner &__next-link {
+    a, a:hover, a:visited {
+      vertical-align: bottom;
+      text-decoration: none;
+      .themeify({
+        color: @theme-light-nav-text-color;
+      });
+      .icon-inline {
+        font-size: @font-size-base;
+        line-height: 1.5;
+        .themeify({
+          color: @theme-light-nav-text-color;
+          text-decoration: none;
+        });
+      }
+    }
+  }
+
+  .PostContent.size-compact + .PostHeader.m-thumbnail-margin {
+    @rendered-thumbnail-size: @thumbnail-size + 2 * @grid-size;
+    margin-left: @rendered-thumbnail-size;
+    min-height: @rendered-thumbnail-size - 2 * @grid-size;
+    margin-top: @grid-size;
+    margin-bottom: @grid-size;
+  }
+}
+
+.container.with-footer-nextcontent {
+  margin-bottom: @nextcontent-height + @grid-size;
+}

--- a/assets/less/components/RelevantContent.less
+++ b/assets/less/components/RelevantContent.less
@@ -14,18 +14,27 @@
   .RelevantContent-action {
     display: block;
     font-size: @font-size-base;
+    font-weight: bold;
     text-align: center;
     text-transform: uppercase;
     color: @white;
     background: @blue;
     margin-top: 3*@grid-size;
     margin-bottom: 3*@grid-size;
-    margin-left: @grid-size;
-    margin-right: @grid-size;
     padding-top: @grid-size;
     padding-bottom: @grid-size;
+    line-height: 1.8;
   }
 
+  & .no-thumbs {
+    .PostContent.size-compact + .PostHeader {
+      margin-left: 0;
+      min-height: @font-size-base * @line-height-base * 3 + 2 * @grid-size;
+    }
+    .PostContent {
+      display: none;
+    }
+  }
 }
 
 .RelevantContent-header {
@@ -74,7 +83,7 @@
   }
 
   .RelevantContent-row-spacer {
-    width: 8 * @grid-size;
+    width: 6 * @grid-size;
     text-align: center;
   }
 
@@ -125,7 +134,7 @@
 
 .RelevantContent .Post,
 .RelevantContent .SearchPage__community {
-  border-width: 2px;
+  border-width: 1px;
   border-style: solid;
   margin-bottom: @grid-size;
   padding-left: 2 * @grid-size;
@@ -141,6 +150,13 @@
   });
 }
 
+.RelevantContent .Post {
+  padding-left: 0;
+  &.no-thumbs {
+    padding-left: 2 * @grid-size;
+  }
+}
+
 .RelevantContent .SearchPage__community:last-child {
   margin-bottom: 4 * @grid-size;
 }
@@ -148,3 +164,4 @@
 .RelevantContent .PostHeader__post-title-line {
   color: @grey-text;
 }
+

--- a/assets/less/components/icon-font.less
+++ b/assets/less/components/icon-font.less
@@ -149,14 +149,14 @@ button, a {
   position: relative;
   top: -2px;
 
-  line-height: 30px;
+  line-height: 35px;
   padding-left: 1px;
-  font-size: 21px;
+  font-size: 24px;
 
   background-color:@orangered;
   color: white !important;
-  width: 30px;
-  height: 30px;
+  width: 35px;
+  height: 35px;
   border-radius: 19px;
 }
 

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "react-addons-test-utils": "^15.0.1",
     "react-dom": "^15.0.1",
     "react-motion": "0.4.2",
+    "react-touch": "0.4.0",
     "scmp": "1.0.0",
     "semver": "5.0.3",
     "simple-oauth2": "0.2.1",

--- a/src/constants.es6.js
+++ b/src/constants.es6.js
@@ -41,6 +41,9 @@ export default {
     SUCCESS: 'success',
   },
 
+  VISITED_POST_COUNT: 20,
+  VISITED_POSTS_KEY: 'visitedPosts',
+
   /* eslint-disable max-len */
   BANNER_URLS_TUNE: {
     IMPRESSION: 'https://249639.measurementapi.com/serve?action=impression&publisher_id=249639&site_id=122129&site_id_ios=121809',
@@ -59,6 +62,10 @@ export default {
     VARIANT_RELEVANCY_ENGAGING: 'experimentRelevancyEngaging',
     VARIANT_RELEVANCY_RELATED: 'experimentRelevancyRelated',
     NO_ADS: 'experimentNoAds',
+    VARIANT_NEXTCONTENT_BOTTOM: 'experimentNextContentBottom',
+    VARIANT_NEXTCONTENT_MIDDLE: 'experimentNextContentMiddle',
+    VARIANT_NEXTCONTENT_BANNER: 'experimentNextContentBanner',
+    VARIANT_NEXTCONTENT_TOP3: 'experimentNextContentTop3',
   },
 
   themes: {

--- a/src/featureflags.es6.js
+++ b/src/featureflags.es6.js
@@ -8,6 +8,10 @@ const {
   VARIANT_RELEVANCY_TOP,
   VARIANT_RELEVANCY_ENGAGING,
   VARIANT_RELEVANCY_RELATED,
+  VARIANT_NEXTCONTENT_BOTTOM,
+  VARIANT_NEXTCONTENT_MIDDLE,
+  VARIANT_NEXTCONTENT_BANNER,
+  VARIANT_NEXTCONTENT_TOP3,
 } = constants.flags;
 
 const config = {
@@ -42,6 +46,34 @@ const config = {
         variant: 'relevancy_mweb:related',
       }],
     },
+  },
+  [VARIANT_NEXTCONTENT_BOTTOM]: {
+    url: 'experimentnextcontentbottom',
+    and: [{
+      variant: 'nextcontent_mweb:bottom',
+      loggedin: false,
+    }],
+  },
+  [VARIANT_NEXTCONTENT_MIDDLE]: {
+    url: 'experimentnextcontentmiddle',
+    and: [{
+      variant: 'nextcontent_mweb:middle',
+      loggedin: false,
+    }],
+  },
+  [VARIANT_NEXTCONTENT_BANNER]: {
+    url: 'experimentnextcontentbanner',
+    and: [{
+      variant: 'nextcontent_mweb:banner',
+      loggedin: false,
+    }],
+  },
+  [VARIANT_NEXTCONTENT_TOP3]: {
+    url: 'experimentnextcontenttop3',
+    and: [{
+      variant: 'nextcontent_mweb:top3',
+      loggedin: false,
+    }],
   },
 };
 
@@ -111,7 +143,7 @@ flags.addRule('userAgentSubstr', function(agents) {
 });
 
 flags.addRule('subreddit', function (name) {
-  return this.props.subredditName && this.props.subredditName === name;
+  return this.props.subredditName && this.props.subredditName.toLowerCase() === name.toLowerCase();
 });
 
 flags.addRule('variant', function (name) {

--- a/src/lib/visitedPosts.es6.js
+++ b/src/lib/visitedPosts.es6.js
@@ -1,0 +1,36 @@
+import uniq from 'lodash/array/uniq';
+
+import constants from '../constants';
+import localStorageAvailable from './localStorageAvailable';
+
+// Return an array of ids of the posts the user has visited recently.
+// Return [] if we are unable to access such a list.
+export function getVisitedPosts() {
+  if (!localStorageAvailable()) {
+    return [];
+  }
+
+  const visitedString = global.localStorage.getItem(constants.VISITED_POSTS_KEY);
+
+  if (visitedString) {
+    return visitedString.split(',');
+  }
+
+  return [];
+}
+
+// Stores the array of recently-visited post IDs.
+// Stores only unique IDs and limited to VISITED_POST_COUNT.
+// The posts should be provided in descending chronological order (most-recent
+// first), so that the implementation provides us with the most recently
+// visited posts.
+// If we cannot store the list (no localStorage), then this is a silent no-op.
+export function setVisitedPosts(posts) {
+  if (localStorageAvailable()) {
+    const visited = uniq(posts)
+      .slice(0,constants.VISITED_POST_COUNT)
+      .join(',');
+    global.localStorage.setItem(constants.VISITED_POSTS_KEY, visited);
+  }
+}
+

--- a/src/views/components/listings/RelevantContent.jsx
+++ b/src/views/components/listings/RelevantContent.jsx
@@ -1,11 +1,20 @@
 import React from 'react';
 
+import first from 'lodash/array/first';
 import take from 'lodash/array/take';
 import filter from 'lodash/collection/filter';
+import some from 'lodash/collection/some';
+import range from 'lodash/utility/range';
+import curryRight from 'lodash/function/curryRight';
+import flow from 'lodash/function/flow';
+
+import { Swipeable, defineSwipe } from 'react-touch';
+import { Motion, spring } from 'react-motion';
 
 import constants from '../../../constants';
 import formatNumber from '../../../lib/formatNumber';
 import mobilify from '../../../lib/mobilify';
+import { getVisitedPosts } from '../../../lib/visitedPosts';
 
 import BaseComponent from '../BaseComponent';
 import PostContent from './PostContent';
@@ -13,13 +22,22 @@ import { cleanPostHREF } from './postUtils';
 
 const T = React.PropTypes;
 
-const NUM_LINKS = 3;
+const NUM_TOP_lINKS = 3;
+const NUM_NEXT_LINKS = 5;
 
 const {
   VARIANT_RELEVANCY_TOP,
   VARIANT_RELEVANCY_ENGAGING,
   VARIANT_RELEVANCY_RELATED,
+  VARIANT_NEXTCONTENT_BOTTOM,
+  VARIANT_NEXTCONTENT_MIDDLE,
+  VARIANT_NEXTCONTENT_BANNER,
+  VARIANT_NEXTCONTENT_TOP3,
 } = constants.flags;
+
+function mod(m, n) {
+  return ((m % n) + n) % n;
+}
 
 export default class RelevantContent extends BaseComponent {
   static propTypes = {
@@ -37,10 +55,66 @@ export default class RelevantContent extends BaseComponent {
   constructor(props) {
     super(props);
 
+    if (props.feature.enabled(VARIANT_NEXTCONTENT_MIDDLE)) {
+      this.state = {
+        carouselIndex: 0,
+        ...this.state,
+      };
+    }
+    if (props.feature.enabled(VARIANT_NEXTCONTENT_BANNER)) {
+      this.state = {
+        displayBanner: false,
+        ...this.state,
+      };
+    }
+
     this.renderPostList = this.renderPostList.bind(this);
+    this.renderCarouselPost = this.renderCarouselPost.bind(this);
     this.goToSubreddit = this.goToSubreddit.bind(this);
     this.goToPost = this.goToPost.bind(this);
+    this.goToRelevancyPost = this.goToRelevancyPost.bind(this);
+    this.goToNextContentPost = this.goToNextContentPost.bind(this);
+    this.maybeShowBanner = this.maybeShowBanner.bind(this);
   }
+
+  componentDidMount() {
+    this.addListeners();
+  }
+
+  componentWillUnmount() {
+    this.removeListeners();
+  }
+
+  addListeners() {
+    if (!this.hasListeners) {
+      this.hasListeners = true;
+      if (this.props.feature.enabled(VARIANT_NEXTCONTENT_BANNER)) {
+        if (window) {
+          this.scrollY = window.scrollY;
+          this.props.app.on(constants.SCROLL, this.maybeShowBanner);
+        }
+      }
+    }
+  }
+
+  removeListeners() {
+    if (this.hasListeners) {
+      this.hasListeners = false;
+      if (this.props.feature.enabled(VARIANT_NEXTCONTENT_BANNER)) {
+        this.props.app.off(constants.SCROLL, this.maybeShowBanner);
+      }
+    }
+  }
+
+  maybeShowBanner() {
+    if (window && window.scrollY > this.scrollY) {
+      this.props.app.off(constants.SCROLL, this.maybeShowBanner);
+      this.setState({
+        displayBanner: true,
+      });
+    }
+  }
+
 
   goToSubreddit(e, { url, id, name, linkName, linkIndex }) {
     e.preventDefault();
@@ -53,8 +127,8 @@ export default class RelevantContent extends BaseComponent {
       experimentName: 'relevancy_mweb',
       linkIndex,
       linkName,
-      refererPageType: isSelfText ? 'self' : 'link',
-      refererUrl: window.location.href,
+      referrerPageType: isSelfText ? 'self' : 'link',
+      referrerUrl: window.location.href,
       targetId: parseInt(id, 36),
       targetUrl: url,
       targetName: name,
@@ -64,19 +138,19 @@ export default class RelevantContent extends BaseComponent {
     app.redirect(url);
   }
 
-  goToPost(e, url, id, linkIndex) {
+  goToPost(e, { eventType, experimentName, linkName, url, id, linkIndex }) {
     e.preventDefault();
     const { app, isSelfText, loid, loidcreated } = this.props;
     // Send event
     app.emit('click:experiment', {
-      eventType: 'cs.relevant_posts_mweb_click',
+      eventType,
       loid,
       loidcreated,
-      experimentName: 'relevancy_mweb',
+      experimentName,
       linkIndex,
-      linkName: `top post ${linkIndex}`,
-      refererPageType: isSelfText ? 'self' : 'link',
-      refererUrl: window.location.href,
+      linkName,
+      referrerPageType: isSelfText ? 'self' : 'link',
+      referrerUrl: window.location.href,
       targetFullname: id,
       targetUrl: url,
       targetType: 'link',
@@ -85,8 +159,43 @@ export default class RelevantContent extends BaseComponent {
     app.redirect(url);
   }
 
+  goToRelevancyPost(e, { url, id, linkIndex }) {
+    return this.goToPost(e, {
+      eventType: 'cs.relevant_posts_mweb_click',
+      experimentName: 'relevancy_mweb',
+      linkName: `top post ${linkIndex}`,
+      url,
+      id,
+      linkIndex,
+    });
+  }
+
+  goToNextContentPost(e, { url, id, linkIndex }) {
+    return this.goToPost(e, {
+      eventType: 'cs.nextcontent_posts_mweb_click',
+      experimentName: 'nextcontent_mweb',
+      linkName: `next content ${linkIndex}`,
+      url,
+      id,
+      linkIndex,
+    });
+  }
+
   renderPostList(posts) {
-    const { width } = this.props;
+    const { width, feature } = this.props;
+
+    let makeOnClick;
+    if (feature.enabled(VARIANT_RELEVANCY_TOP)) {
+      makeOnClick = (url, name, i) => (
+        e => this.goToRelevancyPost(e, { url, id: name, linkIndex: i + 1 })
+      );
+    } else if (feature.enabled(VARIANT_NEXTCONTENT_TOP3)) {
+      makeOnClick = (url, name, i) => (
+        e => this.goToNextContentPost(e, { url, id: name, linkIndex: i + 1 })
+      );
+    }
+
+    const hasThumbs = some(posts, post => !!post.thumbnail && post.thumbnail !== '');
 
     return posts.map((post, i) => {
       const linkExternally = post.disable_comments;
@@ -100,10 +209,10 @@ export default class RelevantContent extends BaseComponent {
         thumbnail: post.thumbnail || '/img/placeholder-thumbnail.svg',
         cleanUrl: '#',
       };
-      const onClick = (e => this.goToPost(e, url, name, i + 1));
+      const onClick = makeOnClick(url, name, i);
       const noop = (e => e.preventDefault());
       return (
-        <article ref='rootNode' className='Post' key={ id }>
+        <article ref='rootNode' className={ `Post ${hasThumbs ? '' : 'no-thumbs'}` } key={ id }>
           <div className='Post__header-wrapper' onClick={ onClick }>
             <PostContent
               post={ postWithFallback }
@@ -147,6 +256,124 @@ export default class RelevantContent extends BaseComponent {
     });
   }
 
+  renderCarouselPost(post, i, offset) {
+    const { width } = this.props;
+    const noop = (e => e.preventDefault());
+
+    const linkExternally = post.disable_comments;
+    const url = cleanPostHREF(mobilify(linkExternally ? post.url : post.cleanPermalink));
+    const { id, title, name } = post;
+    // Make sure we always have an image to show
+    // Link to the comment thread instead of external content
+    const postWithFallback = {
+      preview: {},
+      ...post,
+      thumbnail: post.thumbnail || '/img/placeholder-thumbnail.svg',
+      cleanUrl: '#',
+    };
+    const onClick = (e => this.goToNextContentPost(e, { url, id: name, linkIndex: i + 1 }));
+
+    const content = (
+      <div className='NextContent__post-wrapper' onClick={ onClick }>
+        <PostContent
+          post={ postWithFallback }
+          single={ false }
+          compact={ true }
+          expandedCompact={ false }
+          onTapExpand={ function () {} }
+          width={ width }
+          toggleShowNSFW={ false }
+          showNSFW={ false }
+          editing={ false }
+          toggleEditing={ false }
+          saveUpdatedText={ false }
+          forceHTTPS={ this.forceHTTPS }
+          isDomainExternal={ this.externalDomain }
+          renderMediaFullbleed={ true }
+          showLinksInNewTab={ false }
+        />
+        <header className='NextContent__header'>
+          <div className='NextContent__post-descriptor-line'>
+          <a
+            className='NextContent__post-title-line'
+            href='#'
+            onClick={ noop }
+            target={ linkExternally ? '_blank' : null }
+          >
+            { title }
+          </a></div>
+          <a
+            className='NextContent__post-descriptor-line'
+            href='#'
+            onClick={ noop }
+            target={ linkExternally ? '_blank' : null }
+          >
+            { post.ups } upvotes in r/{ post.subreddit }
+          </a>
+        </header>
+      </div>
+    );
+
+    return ({ dx }) => {
+      const translateX = `calc(${dx + offset*100}% + ${8*offset}px)`;
+      return (
+        <article
+          ref='rootNode'
+          className="Post NextContent__carousel-item"
+          key={ `${id}-${offset}` }
+          style={ { transform: `translate3d(${translateX}, 0, 0)` } }
+        >
+          { content }
+        </article>
+      );
+    };
+  }
+
+  renderNextPostCarousel(posts) {
+    const { carouselIndex } = this.state;
+
+    const postCount = Math.min(posts.length, NUM_NEXT_LINKS);
+
+    const postIndices = range(1 - postCount, postCount);
+
+    const onSwipeLeft = () => {
+      this.setState({
+        carouselIndex: Math.min(carouselIndex + 1, postCount - 1),
+      });
+    };
+
+    const onSwipeRight = () => {
+      this.setState({
+        carouselIndex: Math.max(carouselIndex - 1, 1 - postCount),
+      });
+    };
+
+    const swipeConfig = defineSwipe({
+      swipeDistance: 50, // pixels
+    });
+
+    const postMakers = postIndices.map(i => {
+      const postNum = mod(i, postCount);
+      return this.renderCarouselPost(posts[postNum], postNum, i);
+    });
+
+    return (
+      <Motion style={ { dx: spring(-100*carouselIndex) } }>
+        { style => (
+          <Swipeable
+            config={ swipeConfig }
+            onSwipeLeft={ onSwipeLeft }
+            onSwipeRight={ onSwipeRight }
+          >
+            <div className='NextContent__drag-container'>
+              { postMakers.map(f => f(style)) }
+            </div>
+          </Swipeable>
+        ) }
+      </Motion>
+    );
+  }
+
   render() {
     const {
       feature,
@@ -156,22 +383,35 @@ export default class RelevantContent extends BaseComponent {
       listingId,
     } = this.props;
 
-    if (feature.enabled(VARIANT_RELEVANCY_TOP)) {
+    const visited = getVisitedPosts();
+
+    const safeAndNew = (link =>
+      !link.over_18 &&
+      link.id !== listingId &&
+      !link.stickied &&
+      (visited.indexOf(link.id) === -1));
+
+    const safe = (link =>
+        !link.over_18 &&
+        link.id !== listingId &&
+        !link.stickied);
+
+    if (feature.enabled(VARIANT_RELEVANCY_TOP) ||
+        feature.enabled(VARIANT_NEXTCONTENT_TOP3)) {
       // Show top posts from this subreddit
       const topLinks = relevant.topLinks;
-      const predicate = (link =>
-          !link.over_18 &&
-          link.id !== listingId &&
-          !link.stickied);
-      const links = take(filter(topLinks, predicate), NUM_LINKS);
+      const predicate = feature.enabled(VARIANT_NEXTCONTENT_TOP3) ? safeAndNew : safe;
+      const links = take(filter(topLinks, predicate), NUM_TOP_lINKS);
       const postList = this.renderPostList(links);
+
       const onActionClick = (e => this.goToSubreddit(e, {
         url: subreddit.url,
         id: subreddit.id,
         name: subreddit.title,
         linkName: 'top 25 posts',
-        linkIndex: NUM_LINKS + 1,
+        linkIndex: NUM_TOP_lINKS + 1,
       }));
+
       return (
         <div className='RelevantContent container' key='relevant-container'>
           <div className='RelevantContent-header'>
@@ -188,6 +428,138 @@ export default class RelevantContent extends BaseComponent {
           >
               See top 25 Posts
           </a>
+        </div>
+      );
+    }
+
+    if (feature.enabled(VARIANT_NEXTCONTENT_BOTTOM) ||
+        feature.enabled(VARIANT_NEXTCONTENT_BANNER)) {
+      const { displayBanner } = this.state;
+
+      const { topLinks } = relevant;
+      const post = flow(
+        curryRight(filter)(null)(safeAndNew),
+        first
+      )(topLinks);
+
+      if (!post) {
+        return null;
+      }
+
+      const { width } = this.props;
+      const linkExternally = post.disable_comments;
+      const url = cleanPostHREF(mobilify(linkExternally ? post.url : post.cleanPermalink));
+      const { id, title, name } = post;
+      // Make sure we always have an image to show
+      // Link to the comment thread instead of external content
+      const postWithFallback = {
+        preview: {},
+        ...post,
+        thumbnail: post.thumbnail || '/img/placeholder-thumbnail.svg',
+        cleanUrl: '#',
+      };
+      const onClick = (e => this.goToNextContentPost(e, { url, id: name, linkIndex: 0 }));
+      const noop = (e => e.preventDefault());
+
+      let variant = 'banner';
+      let descriptor = null;
+      let actionText = 'MORE';
+      if (feature.enabled(VARIANT_NEXTCONTENT_BOTTOM)) {
+        variant = 'bottom';
+        descriptor = (
+          <a
+            className='PostHeader__post-descriptor-line'
+            href='#'
+            onClick={ noop }
+            target={ linkExternally ? '_blank' : null }
+          >
+            { post.ups } upvotes in r/{ post.subreddit }
+          </a>
+        );
+        actionText = 'NEXT';
+      }
+
+      const nextContent = y => (
+        <div
+          className={ `NextContent container ${variant}` }
+          key='nextcontent-container'
+          onClick={ onClick }
+          style={ {
+            WebkitTransform: `translate3d(0, ${y}px, 0)`,
+            transform: `translate3d(0, ${y}px, 0)`,
+          } }
+        >
+          <article ref='rootNode' className='Post' key={ id }>
+            <div className='NextContent__post-wrapper'>
+              <PostContent
+                post={ postWithFallback }
+                single={ false }
+                compact={ true }
+                expandedCompact={ false }
+                onTapExpand={ function () {} }
+                width={ width }
+                toggleShowNSFW={ false }
+                showNSFW={ false }
+                editing={ false }
+                toggleEditing={ false }
+                saveUpdatedText={ false }
+                forceHTTPS={ this.forceHTTPS }
+                isDomainExternal={ this.externalDomain }
+                renderMediaFullbleed={ true }
+                showLinksInNewTab={ false }
+              />
+              <header className='NextContent__header'>
+                <div className='NextContent__post-descriptor-line'>
+                <a
+                  className='NextContent__post-title-line'
+                  href='#'
+                  onClick={ noop }
+                  target={ linkExternally ? '_blank' : null }
+                >
+                  { title }
+                </a></div>
+                { descriptor }
+              </header>
+            </div>
+            <div className='NextContent__next-link'>
+              <a
+                href='#'
+                onClick={ noop }
+              >
+                { actionText }
+                <span className='icon-nav-arrowforward icon-inline'></span>
+              </a>
+            </div>
+          </article>
+        </div>
+      );
+
+      if (feature.enabled(VARIANT_NEXTCONTENT_BOTTOM)) {
+        return nextContent(0);
+      }
+      return (
+        <Motion style={ { y: spring(displayBanner ? 0 : 200) } }>
+          { ({ y }) =>
+            nextContent(y)
+          }
+        </Motion>
+      );
+    }
+
+    if (feature.enabled(VARIANT_NEXTCONTENT_MIDDLE)) {
+      const topLinks = relevant.topLinks;
+      const links = take(filter(topLinks, safeAndNew), NUM_NEXT_LINKS);
+      const postList = this.renderNextPostCarousel(links);
+
+      return (
+        <div
+          className='NextContent container middle'
+          key='nextcontent-container'
+        >
+          <div className='NextContent__heading'>
+            Top Posts from r/{ subredditName }
+          </div>
+          { postList }
         </div>
       );
     }

--- a/src/views/pages/listing.jsx
+++ b/src/views/pages/listing.jsx
@@ -273,7 +273,26 @@ class ListingPage extends BasePage {
       !expandComments &&
       (this.state.feature.enabled(constants.flags.VARIANT_RELEVANCY_TOP) ||
        this.state.feature.enabled(constants.flags.VARIANT_RELEVANCY_RELATED) ||
-       this.state.feature.enabled(constants.flags.VARIANT_RELEVANCY_ENGAGING));
+       this.state.feature.enabled(constants.flags.VARIANT_RELEVANCY_ENGAGING) ||
+       this.state.feature.enabled(constants.flags.VARIANT_NEXTCONTENT_TOP3));
+
+    let footerClass = '';
+    if (this.state.feature.enabled(constants.flags.VARIANT_NEXTCONTENT_BOTTOM) ||
+        this.state.feature.enabled(constants.flags.VARIANT_NEXTCONTENT_BANNER)) {
+      footerClass = 'with-footer-nextcontent';
+    }
+
+    const relevantBottom =
+      (this.state.feature.enabled(constants.flags.VARIANT_RELEVANCY_TOP) ||
+       this.state.feature.enabled(constants.flags.VARIANT_RELEVANCY_RELATED) ||
+       this.state.feature.enabled(constants.flags.VARIANT_RELEVANCY_ENGAGING) ||
+       this.state.feature.enabled(constants.flags.VARIANT_NEXTCONTENT_BANNER) ||
+       this.state.feature.enabled(constants.flags.VARIANT_NEXTCONTENT_TOP3) ||
+       this.state.feature.enabled(constants.flags.VARIANT_NEXTCONTENT_BOTTOM));
+
+    const relevantMiddle =
+      this.state.feature.enabled(constants.flags.VARIANT_NEXTCONTENT_MIDDLE);
+
 
     /*
       comments can be in one of three states:
@@ -431,7 +450,8 @@ class ListingPage extends BasePage {
             toggleEdit={ this.toggleEdit }
             isArchived={ listing.archived }
           />
-          <div className='container'>
+          { relevantMiddle ? relevantContent : null }
+          <div className={ `container ${footerClass}` }>
             <div className="listing-content__tools">
               <LinkTools
                 ctx={ ctx }
@@ -451,7 +471,7 @@ class ListingPage extends BasePage {
             { threadNotification }
             { commentsList }
           </div>
-          { relevantContent }
+          { relevantBottom ? relevantContent : null }
         </div>
       </div>
     );


### PR DESCRIPTION
Support 4 next-content variants (middle carousel, bottom, banner, top
3). The "middle" variant shows a swipeable set of the top unread posts
from the current subreddit, positioned between the current post and the
comments. The "bottom" variant shows the top unread post from the
current subreddit, fixed to the bottom of the viewport. The "banner"
variant behaves like "bottom" but appears only after the user scrolls
and sits just above the bottom of the viewport. The "top3" variant is
identical to the "top3" variant of the relevancy_mweb experiment. The
experiment is not restricted to a particular subreddit.

Track the 10 most recently viewed posts, so that we can show new content
to logged-out and logged-in users.