### PR TITLE
Remove country filter from the smart banner

### DIFF
--- a/assets/js/client.es6.js
+++ b/assets/js/client.es6.js
@@ -100,7 +100,6 @@ function initialize(bindLinks) {
     } = shouldShowBanner({
       actionName: data.actionName,
       loid: data.loid,
-      country: data.country,
       userAgent: data.ctx.userAgent || '',
       data: data.data,
     });

--- a/src/lib/smartBannerState.es6.js
+++ b/src/lib/smartBannerState.es6.js
@@ -28,8 +28,6 @@ const ANDROID_USER_AGENTS = [
 
 const ALLOWED_DEVICES = IOS_USER_AGENTS.concat(ANDROID_USER_AGENTS);
 
-const DISALLOWED_COUNTRIES = new Set(['BR', 'CU', 'DE', 'FR', 'ID', 'IR', 'MM', 'SD']);
-
 const PAGE_PERCENTAGES = {
   'comments.subreddit': 5,
 };
@@ -58,16 +56,13 @@ export function shouldShowBanner({ actionName, loid, country, data, userAgent }=
   // 4) Check the user agent
   if (!checkDeviceType(ALLOWED_DEVICES, userAgent)) { return BASE_VAL; }
 
-  // 5) Don't show banner to people from certain countries
-  if (DISALLOWED_COUNTRIES.has(country)) { return BASE_VAL; }
-
   // Create a bucket; a few rules are going to depend on that
   let userId = '';
   if (loid || data.user) { userId = loid || data.user.id; }
   const userIdSum = userId.split('').reduce((sum, chr) => sum + chr.charCodeAt(0), 0);
   const bucket = userIdSum % 100;
 
-  // 6) only show to a certain % of users that land on a given page
+  // 5) only show to a certain % of users that land on a given page
   for (let pageName in PAGE_PERCENTAGES) {
     if ((actionName === pageName) && (bucket > PAGE_PERCENTAGES[pageName])) {
       return BASE_VAL;

--- a/src/lib/smartBannerState.es6.js
+++ b/src/lib/smartBannerState.es6.js
@@ -38,7 +38,7 @@ const checkDeviceType = (allowedAgents, userAgentString) => {
   return allowedAgents.some(a => userAgentString.indexOf(a) > -1);
 };
 
-export function shouldShowBanner({ actionName, loid, country, data, userAgent }={}) {
+export function shouldShowBanner({ actionName, loid, data, userAgent }={}) {
   // Lots of options we have to consider.
   // 1) Easiest. Make sure local storage exists
   if (!localStorageAvailable()) { return BASE_VAL; }


### PR DESCRIPTION
Native mobile is launched in all countries now,
so remove the country filter as it's no longer needed.

:eyeglasses: @phil303 @schwers 