### PR TITLE
Add routes for feedback data from the client

### DIFF
--- a/src/Server.js
+++ b/src/Server.js
@@ -36,6 +36,9 @@ const ConfigedAPIOptions = {
   oauthAppOrigin: 'https://m.reddit.com',
   clientId: process.env.SECRET_OAUTH_CLIENT_ID,
   clientSecret: process.env.OAUTH_SECRET,
+  servedOrigin: process.env.ORIGIN || 'http://localhost:8888',
+  statsURL: process.env.STATS_URL || 'https://stats.redditmedia.com/',
+  actionNameSecret: process.env.ACTION_NAME_SECRET,
 };
 
 export function startServer() {


### PR DESCRIPTION
Ports from 1X of the `/timings`, `/csp-report`, and `/error` behavior.

Small change to the apple app-site association data, so that we don't
match on all paths (`/`) but do continue matching on `/comments/*` paths.