### PR TITLE
Avoid showing replies in inbox mode

### DIFF
--- a/src/views/components/Inbox.jsx
+++ b/src/views/components/Inbox.jsx
@@ -22,6 +22,10 @@ class Inbox extends BaseComponent {
   }
 
   onSubmit (message) {
+    if (!this.props.showReplies) {
+      return;
+    }
+
     const messages = this.state.messages || [];
 
     if (this.props.isReply) {

--- a/src/views/components/MessagePreview.jsx
+++ b/src/views/components/MessagePreview.jsx
@@ -212,6 +212,7 @@ class MessagePreview extends BaseComponent {
             app={ this.props.app }
             isReply={ true }
             messages={ message.replies }
+            showReplies={ true }
             user={ this.props.user }
             token={ this.props.token }
             apiOptions={ this.props.apiOptions }

--- a/src/views/pages/messages.jsx
+++ b/src/views/pages/messages.jsx
@@ -26,11 +26,13 @@ class MessagesPage extends BasePage {
     } else {
       const messages = this.state.data.messages;
       view = this.props.view.toLowerCase();
+      const showReplies = (view === 'messages');
 
       content = (
         <Inbox
           app={ this.props.app }
           messages={ messages }
+          showReplies={ showReplies }
           key={ `mesages-${view}` }
           user={ this.state.data.user }
           token={ this.props.token }


### PR DESCRIPTION
The mobile web messages view has an "All" view, which should not show a
user's own replies, and a "Messages" view, which should show a user's
reply (nested under the original message). The user can compose a reply
from both views, but we should only add the submitted message to the
view if we're in the "Messages" view.