### PR TITLE
Default to compact mode on the client

### DIFF
--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -93,7 +93,8 @@ function setCompact(ctx, app) {
     return;
   }
 
-  let compact = (ctx.cookies.get('compact') || '').toString() === 'true';
+  // default to compact mode
+  let compact = (ctx.cookies.get('compact') || 'true').toString() === 'true';
 
   const cookieOptions = makeCookieOptions(app);
 


### PR DESCRIPTION
We're only defaulting to compact mode when the user comes in through reddit.com (via a url parameter) but not when they come in directly through m.reddit.com.

:eyeglasses: @schwers 