### PR TITLE
Fix comment caron icon vertical alignment

### DIFF
--- a/assets/less/components/comment/CommentHeader.less
+++ b/assets/less/components/comment/CommentHeader.less
@@ -82,6 +82,7 @@
 
     &:before {
       font-size: 12px;
+      line-height: 21px;
     }
 
     &.m-collapsed {


### PR DESCRIPTION
This fixes the comment caron icon being a few pixels off vertically

Before
![image](https://cloud.githubusercontent.com/assets/307983/16060953/643cbf64-323f-11e6-9940-823375b930ff.png)

After
![image](https://cloud.githubusercontent.com/assets/307983/16060965/78387b5c-323f-11e6-84be-2a14f81c84be.png)

👓 @phil303 or @nramadas 
