### PR TITLE
Comment page: disable reply for banned users

### DIFF
--- a/src/views/components/LinkTools.jsx
+++ b/src/views/components/LinkTools.jsx
@@ -126,6 +126,8 @@ export default class LinkTools extends React.Component {
   }
 
   renderTools() {
+    const text = this.props.disableReply ? '' : 'Write a comment';
+
     return (
       <div className='LinkTools__tools'>
         { this.renderSort() }
@@ -133,7 +135,7 @@ export default class LinkTools extends React.Component {
           className='LinkTools__comment'
           onClick={ this.toggleForm }
         >
-          Write a comment
+          { text }
         </div>
       </div>
     );

--- a/src/views/components/LinkTools.jsx
+++ b/src/views/components/LinkTools.jsx
@@ -47,8 +47,7 @@ export default class LinkTools extends React.Component {
   }
 
   toggleForm() {
-    if (this.props.isArchived) { return; }
-    if (this.props.isLocked) { return; }
+    if (this.props.disableReply) { return; }
     if (this.props.app.needsToLogInUser()) { return; }
 
     this.setState({
@@ -127,14 +126,6 @@ export default class LinkTools extends React.Component {
   }
 
   renderTools() {
-    const { isArchived, isLocked } = this.props;
-    let text = 'Write a comment';
-    if (isArchived) {
-      text = 'Post is archived';
-    } else if (isLocked) {
-      text = 'Comments are locked';
-    }
-
     return (
       <div className='LinkTools__tools'>
         { this.renderSort() }
@@ -142,7 +133,7 @@ export default class LinkTools extends React.Component {
           className='LinkTools__comment'
           onClick={ this.toggleForm }
         >
-          { text }
+          Write a comment
         </div>
       </div>
     );

--- a/src/views/components/comment/Comment.jsx
+++ b/src/views/components/comment/Comment.jsx
@@ -535,12 +535,14 @@ export default class Comment extends BaseComponent {
   }
 
   renderReplyArea() {
-    const { isArchived, repliesLocked } = this.state;
+    const { isArchived, repliesLocked, userIsBanned } = this.props;
 
     if (isArchived) {
       return this.renderArchivedReplyForm();
     } else if (repliesLocked) {
       return this.renderLockedReplyForm();
+    } else if (userIsBanned) {
+      return this.renderBannedReplyForm();
     }
 
     return this.renderReplyForm();
@@ -579,6 +581,16 @@ export default class Comment extends BaseComponent {
       <div className='Comment__replyForm'>
         <div className='Comment__replyFormLocked'>
           Posting is archived
+        </div>
+      </div>
+    );
+  }
+
+  renderBannedReplyForm() {
+    return (
+      <div className='Comment__replyForm'>
+        <div className='Comment__replyFormLocked'>
+          You are currently banned
         </div>
       </div>
     );

--- a/src/views/components/comment/Comment.jsx
+++ b/src/views/components/comment/Comment.jsx
@@ -590,7 +590,7 @@ export default class Comment extends BaseComponent {
     return (
       <div className='Comment__replyForm'>
         <div className='Comment__replyFormLocked'>
-          You are currently banned
+          You are banned from commenting in this community for now.
         </div>
       </div>
     );

--- a/src/views/pages/listing.jsx
+++ b/src/views/pages/listing.jsx
@@ -195,6 +195,42 @@ class ListingPage extends BasePage {
     this.setState({ expandComments: true });
   }
 
+  renderThreadNotice(subreddit, listing, commentId) {
+    let message;
+    if (commentId) {
+      message = (
+        <p>
+          <span>You are viewing a single comment's thread. </span>
+          <a href={ listing.permalink }>View the rest of the comments</a>
+        </p>
+      );
+    }
+
+    if (subreddit && subreddit.user_is_banned) {
+      message = <p>You are banned from commenting</p>;
+    }
+
+    if (listing.locked) {
+      message = <p>Comments are locked</p>;
+    }
+
+    if (listing.archived) {
+      message = <p>Post is archived</p>;
+    }
+
+    if (message) {
+      return (
+        <div className='alert alert-warning vertical-spacing vertical-spacing-top'>
+          <p>
+            { message }
+          </p>
+        </div>
+      );
+    }
+
+    return null;
+  }
+
   render() {
     const { data, editing, loadingMoreComments, linkEditError, expandComments } = this.state;
 
@@ -224,17 +260,11 @@ class ListingPage extends BasePage {
 
     app.emit('setTitle', { title: listing.title });
 
-    let singleComment;
-    if (commentId) {
-      singleComment = (
-        <div className='alert alert-warning vertical-spacing vertical-spacing-top'>
-          <p>
-            <span>You are viewing a single comment's thread. </span>
-            <a href={ permalink }>View the rest of the comments</a>
-          </p>
-        </div>
-      );
-    }
+    const threadNotification =
+      this.renderThreadNotice(subreddit, listing, commentId);
+    const disableReply = listing.archived ||
+                         listing.locked ||
+                         subreddit.user_is_banned;
 
     let commentsList;
     let googleCarousel;
@@ -291,6 +321,7 @@ class ListingPage extends BasePage {
                 sort={ sort }
                 repliesLocked={ listing.locked }
                 isArchived={ listing.archived }
+                userIsBanned={ subreddit.user_is_banned }
               />
             </div>
           );
@@ -409,6 +440,7 @@ class ListingPage extends BasePage {
                 apiOptions={ apiOptions }
                 token={ token }
                 linkId={ listing.name }
+                disableReply={ disableReply }
                 isArchived={ listing.archived }
                 isLocked={ listing.locked }
                 sort={ sort }
@@ -416,7 +448,7 @@ class ListingPage extends BasePage {
                 onSortChange={ this.handleSortChange }
               />
             </div>
-            { singleComment }
+            { threadNotification }
             { commentsList }
           </div>
           { relevantContent }

--- a/src/views/pages/listing.jsx
+++ b/src/views/pages/listing.jsx
@@ -207,7 +207,7 @@ class ListingPage extends BasePage {
     }
 
     if (subreddit && subreddit.user_is_banned) {
-      message = <p>You are banned from commenting</p>;
+      message = <p>You are banned from commenting in this community for now</p>;
     }
 
     if (listing.locked) {


### PR DESCRIPTION
Also refactored to show the same alert used to notify users
that they are on a permalink page for banned users and when
the post is locked or archived

👓  @schwers 

I saw [this](https://www.reddit.com/r/mobileweb/comments/4ovwre/better_handling_of_subreddit_bans_and_disabled/) in the channel last night and it looked easy so here we are.

As you can see here in the screenshot I changed it to use the same alert we use for permalink pages. I think it is much more noticeable. Let me know what you think.
![screen shot 2016-06-20 at 11 36 33 am](https://cloud.githubusercontent.com/assets/7064600/16206517/a27a1eb4-36dd-11e6-9591-cca19bafc67b.png)
