### PR TITLE
Enable post expanding

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:watch": "npm run test -- -w"
   },
   "dependencies": {
-    "@r/api-client": "~3.14.2",
+    "@r/api-client": "~3.14.3",
     "@r/build": "^0.6.0",
     "@r/flags": "^1.5.0",
     "@r/middleware": "~0.6.1",

--- a/src/Client.js
+++ b/src/Client.js
@@ -25,7 +25,11 @@ const client = Client({
     if (isLocalStorageAvailable()) {
       try {
         data.collapsedComments = JSON.parse(window.localStorage.collapsedComments);
-      } catch (e) { console.log(e); }
+      } catch (e) { console.warn(e); }
+
+      try {
+        data.expandedPosts = JSON.parse(window.localStorage.expandedPosts);
+      } catch (e) { console.warn(e); }
     }
 
     return data;

--- a/src/app/actions/posts.js
+++ b/src/app/actions/posts.js
@@ -1,0 +1,2 @@
+export const TOGGLE_EXPANDED = 'TOGGLE_EXPANDED';
+export const toggleExpanded = postId => ({ type: TOGGLE_EXPANDED, postId });

--- a/src/app/components/Post/PostContent/index.jsx
+++ b/src/app/components/Post/PostContent/index.jsx
@@ -155,22 +155,6 @@ export default class PostContent extends React.Component {
     return DEFAULT_ASPECT_RATIO;
   }
 
-  heightStyle(aspectRatio) {
-    if (this.props.single && aspectRatio) {
-      return `${1 / aspectRatio * this.props.width}px`;
-    }
-  }
-
-  baseStyleFromAspectRatio(aspectRatio) {
-    const style = {};
-    const heightStyle = this.heightStyle(aspectRatio);
-    if (heightStyle) {
-      style.height = heightStyle;
-    }
-
-    return style;
-  }
-
   render() {
     const isCompact = this.isCompact();
     const { single, post, isDomainExternal } = this.props;
@@ -307,11 +291,16 @@ export default class PostContent extends React.Component {
     }
 
     const { onTapExpand } = this.props;
+    const callOnTapExpand = e => {
+      e.preventDefault();
+      onTapExpand();
+    };
+
     const sourceURL = post.cleanUrl;
 
     if (isCompact) {
       // the thumbnail
-      return this.renderImage(previewImage, sourceURL, linkDescriptor, onTapExpand,
+      return this.renderImage(previewImage, sourceURL, linkDescriptor, callOnTapExpand,
         needsNSFWBlur, true, playableType);
     }
 
@@ -369,7 +358,7 @@ export default class PostContent extends React.Component {
       case 'image':
         return this.renderIframe(sourceURL, aspectRatio);
       case 'video':
-        return this.renderRawHTML(post.expandContent, aspectRatio);
+        return this.renderRawHTML(post.expandedContent, aspectRatio);
       case 'rich':
         return this.renderRichOembed(oembed.html, aspectRatio);
     }
@@ -420,7 +409,6 @@ export default class PostContent extends React.Component {
         href={ linkDescriptor.url }
         target={ this.props.showLinksInNewTab ? '_blank' : null }
         onClick={ onClick }
-        data-no-route={ !!onClick }
       >
         <img className='PostContent__image-img' src={ imageURL } />
         { playbackControlNode }
@@ -433,7 +421,7 @@ export default class PostContent extends React.Component {
       onClick, isCompact, playbackControlNode, nsfwNode) {
     const { forceHTTPS } = this.props;
 
-    const style = this.baseStyleFromAspectRatio(aspectRatio);
+    const style = {};
 
     if (previewImage.url) {
       const giphyPosterHref = posterForHrefIfGiphyCat(imageURL);
@@ -454,7 +442,6 @@ export default class PostContent extends React.Component {
         href={ linkDescriptor.url }
         target={ this.props.showLinksInNewTab ? '_blank' : null }
         onClick={ onClick }
-        data-no-route={ !!onClick }
         style={ style }
       >
         { isPlaying
@@ -466,13 +453,8 @@ export default class PostContent extends React.Component {
   }
 
   renderIframe(src, aspectRatio) {
-    const style = this.baseStyleFromAspectRatio(aspectRatio);
-
     return (
-      <div
-        className={ `PostContent__iframe-wrapper ${aspectRatioClass(aspectRatio)}` }
-        style={ style }
-      >
+      <div className={ `PostContent__iframe-wrapper ${aspectRatioClass(aspectRatio)}` } >
         <iframe
           className='PostContent__iframe'
           src={ src }
@@ -485,13 +467,8 @@ export default class PostContent extends React.Component {
   }
 
   renderVideo(videoSpec, posterImage, aspectRatio) {
-    const style = this.baseStyleFromAspectRatio(aspectRatio);
-
     return (
-      <div
-        className={ `PostContent__video-wrapper ${aspectRatioClass(aspectRatio)}` }
-        style={ style }
-      >
+      <div className={ `PostContent__video-wrapper ${aspectRatioClass(aspectRatio)}` } >
         <video
           className='PostContent__video'
           poster={ posterImage }

--- a/src/app/components/Post/index.jsx
+++ b/src/app/components/Post/index.jsx
@@ -4,8 +4,9 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 import { models } from '@r/api-client';
-
 const { PostModel } = models;
+
+import * as postActions from 'app/actions/posts';
 
 import {
   isPostDomainExternal,
@@ -63,9 +64,8 @@ export function Post(props) {
   const isAndroid = userAgent && /android/i.test(userAgent);
   const showLinksInNewTab = externalDomain && isAndroid;
   const showNSFW = !props.showOver18Interstitial && props.subredditIsNSFW;
-  const { expanded, editing, winWidth, z } = props;
+  const { expanded, toggleExpanded, editing, winWidth, z } = props;
 
-  const toggleExpanded = () => {};
   const toggleShowNSFW = () => {};
 
   const {
@@ -152,15 +152,12 @@ export function Post(props) {
 }
 
 const postIdSelector = (_, props) => props.postId;
-
 const compactSeletor = (state, props) => props.forceCompact || state.compact;
-
 const singleSelector = (_, props) => props.single;
-
 const postModelSelector = (state, props) => state.posts[props.postId];
-
-const combineSelectors = (postId, compact, single, post) => ({
-  postId, compact, single, post,
+const expandedSelector = (state, props) => !!state.expandedPosts[props.postId];
+const combineSelectors = (postId, compact, expanded, single, post) => ({
+  postId, compact, expanded, single, post,
 });
 
 const makeConnectedPostSelector = () => {
@@ -168,10 +165,16 @@ const makeConnectedPostSelector = () => {
     [
       postIdSelector,
       compactSeletor,
+      expandedSelector,
       singleSelector,
       postModelSelector,
     ],
     combineSelectors);
 };
 
-export default connect(makeConnectedPostSelector)(Post);
+const mapDispatchToProps = (dispatch, { postId }) => ({
+  toggleExpanded: () => dispatch(postActions.toggleExpanded(postId)),
+});
+
+
+export default connect(makeConnectedPostSelector, mapDispatchToProps)(Post);

--- a/src/app/less/components/aspect-ratio.less
+++ b/src/app/less/components/aspect-ratio.less
@@ -1,3 +1,8 @@
+[class^="aspect-ratio-"]:before, [class*=" aspect-ratio-"]:before {
+  content: "";
+  display: block;
+}
+
 //there are JavaScript values in ListingContent.jsx that must correlate with @WIDEST, @TALLEST, @HEIGHT, and @INCREMENT
 @WIDEST: 3;
 @TALLEST: 1 / 3;
@@ -14,5 +19,8 @@
   @width: @i / @euclid;
   @height: @HEIGHT / @euclid;
 
+  .aspect-ratio-@{width}x@{height}:before {
+    padding-top: (@HEIGHT / @i * 100%);
+  }
   .aspect-ratio(@n, (@i + @INCREMENT));
 }

--- a/src/app/reducers/expandedPosts.js
+++ b/src/app/reducers/expandedPosts.js
@@ -1,0 +1,32 @@
+import * as loginActions from 'app/actions/login';
+import * as postActions from 'app/actions/posts';
+
+const DEFAULT = {};
+
+export default function(state=DEFAULT, action={}) {
+  switch (action.type) {
+    case loginActions.LOGGED_IN:
+    case loginActions.LOGGED_OUT: {
+      return DEFAULT;
+    }
+
+    case postActions.TOGGLE_EXPANDED: {
+      const { postId } = action;
+      const currentlyExpanded = state[postId];
+
+      if (currentlyExpanded) {
+        // Remove keys from state when it unexpands so there's less written to localStorage
+        const nextState = { ...state };
+        delete nextState[postId];
+        return nextState;
+      }
+
+      return {
+        ...state,
+        [postId]: true,
+      };
+    }
+
+    default: return state;
+  }
+}

--- a/src/app/reducers/expandedPosts.test.js
+++ b/src/app/reducers/expandedPosts.test.js
@@ -1,0 +1,55 @@
+import createTest from '@r/platform/createTest';
+
+import expandedPosts from './expandedPosts';
+import * as loginActions from 'app/actions/login';
+import * as postActions from 'app/actions/posts';
+
+createTest({ reducers: { expandedPosts }}, ({ getStore, expect }) => {
+  describe('expandedPosts', () => {
+    describe('LOGGED_IN and LOGGED_OUT', () => {
+      it('should return the default on log in', () => {
+        const { store } = getStore({
+          expandedPosts: { t3_asdf: true },
+        });
+
+        store.dispatch(loginActions.loggedIn());
+        const { expandedPosts } = store.getState();
+        expect(expandedPosts).to.eql({});
+      });
+
+      it('should return the default on log out', () => {
+        const { store } = getStore({
+          expandedPosts: { t3_asdf: true },
+        });
+
+        store.dispatch(loginActions.loggedOut());
+        const { expandedPosts } = store.getState();
+        expect(expandedPosts).to.eql({});
+      });
+    });
+
+    describe('TOGGLE_EXPANDED', () => {
+      it('should set the expanded state of a post to true', () => {
+        const id = 't3_asdf';
+        const { store } = getStore();
+
+        store.dispatch(postActions.toggleExpanded(id));
+        const { expandedPosts } = store.getState();
+        expect(expandedPosts).to.eql({ [id]: true });
+      });
+
+      it('should remove posts when they\'re already expanded', () => {
+        const id = 't3_asdf';
+        const { store } = getStore({
+          expandedPosts: {
+            [id]: true,
+          },
+        });
+
+        store.dispatch(postActions.toggleExpanded(id));
+        const { expandedPosts } = store.getState();
+        expect(expandedPosts).to.eql({});
+      });
+    });
+  });
+});

--- a/src/app/reducers/index.js
+++ b/src/app/reducers/index.js
@@ -5,6 +5,7 @@ import collapsedComments from './collapsedComments';
 import comments from './comments';
 import commentsPages from './commentsPages';
 import compact from './compact';
+import expandedPosts from './expandedPosts';
 import hiddenRequests from './hiddenRequests';
 import loid from './loid';
 import posts from './posts';
@@ -28,6 +29,7 @@ export default {
   comments,
   commentsPages,
   compact,
+  expandedPosts,
   hiddenRequests,
   loid,
   posts,

--- a/src/app/side-effect-components/LocalStorageSync.js
+++ b/src/app/side-effect-components/LocalStorageSync.js
@@ -1,9 +1,11 @@
 import { makeLocalStorageArchiver } from '@r/redux-state-archiver';
 
 const collapsedSelector = state => state.collapsedComments;
-const combiner = (collapsedComments) => ({ collapsedComments });
+const expandedSelector = state => state.expandedPosts;
+const combiner = (collapsedComments, expandedPosts) => ({ collapsedComments, expandedPosts });
 
 export const LocalStorageSync = makeLocalStorageArchiver(
   collapsedSelector,
+  expandedSelector,
   combiner,
 );


### PR DESCRIPTION
This adds post expanding behavior from mweb 1x. 

There was a change to `aspect-ratio.less` [commit](https://github.com/reddit/art-gallery/commit/d4dbd5bea64e8dc7bde2c76301d3259ba78126c6) that was trying to remove padding to fix hit areas on comments pages. That fix should have been removing the height set the images rendered by `PostContent` because the difference in that height versus the `aspect-ratio` seems to be what was really causing issues. This needed to be reverted in this patch to fix expands, and actually card view in general.

This depends on https://github.com/reddit/node-api-client/pull/127 to ensure the failed https requests to  `http:self` disappear and fixes empty preview images