### PR TITLE
Add `no_ads` experiment

### DIFF
--- a/assets/js/client.es6.js
+++ b/assets/js/client.es6.js
@@ -115,7 +115,7 @@ function initialize(bindLinks) {
   // config value after render.
   const beginRender = Date.now();
 
-  render(app, app.fullPathName(), true, app.modifyContext).then(function() {
+  render(app, app.fullPathName(), true, app.modifyContext).then(function(props) {
     // clear dataCache so we don't hydrate again.
     app.setState('dataCache');
 
@@ -127,7 +127,7 @@ function initialize(bindLinks) {
     const hasHistAndBindLinks = history && bindLinks;
     setEvents(app, hasHistAndBindLinks, render, $body);
 
-    sendTimings(beginRender);
+    sendTimings(beginRender, props.adsEnabled);
   });
 }
 

--- a/assets/js/clientLib.es6.js
+++ b/assets/js/clientLib.es6.js
@@ -149,12 +149,18 @@ export function refreshToken (app) {
     });
 }
 
-export function sendTimings(beginRender) {
+export function sendTimings(beginRender, adsEnabled) {
   // Send the timings during the next cycle.
   if (window.bootstrap.actionName) {
     if (Math.random() < 0.1) { // 10% of requests
+      let actionName = `m.server.${window.bootstrap.actionName}`;
+
+      if (adsEnabled === false) {
+        actionName = `${actionName}.no_ads`;
+      }
+
       const timings = Object.assign({
-        actionName: `m.server.${window.bootstrap.actionName}`,
+        actionName: actionName,
       }, getTimes());
 
       timings.mountTiming = (Date.now() - beginRender) / 1000;

--- a/src/constants.es6.js
+++ b/src/constants.es6.js
@@ -58,6 +58,7 @@ export default {
     VARIANT_RELEVANCY_TOP: 'experimentRelevancyTop',
     VARIANT_RELEVANCY_ENGAGING: 'experimentRelevancyEngaging',
     VARIANT_RELEVANCY_RELATED: 'experimentRelevancyRelated',
+    NO_ADS: 'experimentNoAds',
   },
 
   themes: {

--- a/src/featureflags.es6.js
+++ b/src/featureflags.es6.js
@@ -3,6 +3,7 @@ import Flags from '@r/flags';
 import constants from './constants';
 
 const {
+  NO_ADS,
   SMARTBANNER,
   VARIANT_RELEVANCY_TOP,
   VARIANT_RELEVANCY_ENGAGING,
@@ -10,6 +11,10 @@ const {
 } = constants.flags;
 
 const config = {
+  [NO_ADS]: {
+    url: 'experimentnoads',
+    variant: 'no_ads:treatment',
+  },
   [SMARTBANNER]: true,
   [VARIANT_RELEVANCY_TOP]: {
     and: {

--- a/src/views/components/GoogleTagManager.jsx
+++ b/src/views/components/GoogleTagManager.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+const T = React.PropTypes;
+
+function GoogleTagManager (props) {
+  const script = `
+    <script nonce=${props.nonce}>
+      if (!window.DO_NOT_TRACK) {
+        var frame = document.createElement('iframe');
+
+        frame.style.display = 'none';
+        frame.referrer = 'no-referrer';
+        frame.id = 'gtm-jail';
+        frame.name = JSON.stringify({
+          subreddit: '${props.subredditName || ''}',
+          origin: location.origin,
+          pathname: location.pathname,
+        });
+        frame.src = '//${props.mediaDomain}/gtm/jail?id=${props.googleTagManagerId}';
+        document.body.appendChild(frame);
+      }
+    </script>
+  `;
+
+  return <div dangerouslySetInnerHTML={ { __html: script } } />;
+}
+
+GoogleTagManager.propTypes = {
+  nonce: T.string.isRequired,
+  mediaDomain: T.string.isRequired,
+  googleTagManagerId: T.string.isRequired,
+  subredditName: T.string,
+};
+
+export default GoogleTagManager;

--- a/src/views/layouts/BodyLayout.jsx
+++ b/src/views/layouts/BodyLayout.jsx
@@ -8,6 +8,7 @@ import BasePage from '../pages/BasePage';
 import InfoBar from '../components/InfoBar';
 import UserOverlayMenu from '../components/UserOverlayMenu';
 import CommunityOverlayMenu from '../components/CommunityOverlayMenu';
+import GoogleTagManager from '../components/GoogleTagManager';
 import Toaster from '../components/toasters/Toaster';
 import { userData } from '../../routes';
 
@@ -71,10 +72,21 @@ class BodyLayout extends BasePage {
   }
 
   render() {
-    const { hideTopNav } = this.props;
+    const { adsEnabled, app, ctx, hideTopNav, subredditName } = this.props;
+    const { mediaDomain, googleTagManagerId } = app.config;
 
     return (
       <div className='BodyLayout container-with-betabanner'>
+        {
+          adsEnabled ?
+            <GoogleTagManager
+              nonce={ ctx.csrf }
+              mediaDomain={ mediaDomain }
+              googleTagManagerId={ googleTagManagerId }
+              subredditName={ subredditName }
+            /> :
+            null
+        }
         { !hideTopNav ? this.renderTopNav() : null }
         <main>
           { this.props.children }

--- a/src/views/layouts/DefaultLayout.jsx
+++ b/src/views/layouts/DefaultLayout.jsx
@@ -63,34 +63,6 @@ function DefaultLayout (props) {
     );
   }
 
-  let gtmTracking;
-  const subredditName = props.ctx.params.subreddit;
-
-  if (config.googleTagManagerId && config.mediaDomain) {
-    const gtmCode = `
-      <script nonce=${props.ctx.csrf}>
-        if (!window.DO_NOT_TRACK) {
-          var frame = document.createElement('iframe');
-
-          frame.style.display = 'none';
-          frame.referrer = 'no-referrer';
-          frame.id = 'gtm-jail';
-          frame.name = JSON.stringify({
-            subreddit: '${subredditName || ''}',
-            origin: location.origin,
-            pathname: location.pathname,
-          });
-          frame.src = '//${config.mediaDomain}/gtm/jail?id=${config.googleTagManagerId}';
-          document.body.appendChild(frame);
-        }
-      </script>
-    `;
-
-    gtmTracking = (
-      <div dangerouslySetInnerHTML={ { __html: gtmCode } } />
-    );
-  }
-
   let keyColor = constants.DEFAULT_KEY_COLOR;
 
   if (props.dataCache &&
@@ -129,7 +101,6 @@ function DefaultLayout (props) {
 
         <script src={ clientJS } async='true' nonce={ props.ctx.csrf }></script>
         { liveReload }
-        { gtmTracking }
         { gaTracking }
       </body>
     </html>

--- a/src/views/pages/index.jsx
+++ b/src/views/pages/index.jsx
@@ -95,7 +95,7 @@ class IndexPage extends BasePage {
     let loading;
 
     const props = this.props;
-    const { data, meta, compact } = this.state;
+    const { data, meta, compact, feature } = this.state;
     const { app } = props;
 
     const subredditName = props.subredditName;
@@ -161,7 +161,7 @@ class IndexPage extends BasePage {
       excludedSorts.push('gilded');
     }
 
-    let showAds = !!props.config.adsPath;
+    let showAds = props.adsEnabled && !!props.config.adsPath;
 
     if (props.prefs && props.prefs.hide_ads === true) {
       showAds = false;
@@ -194,7 +194,7 @@ class IndexPage extends BasePage {
 
         <Listing
           { ...props }
-          feature={ this.state.feature }
+          feature={ feature }
           user={ user }
           showAds={ showAds }
           listings={ listings || [] }


### PR DESCRIPTION
👓 @prashtx 

ticket: https://reddit.atlassian.net/browse/ADS-567

(comscore/gtm are also disabled for no_ads group: https://reddit.atlassian.net/browse/ADS-579)

had to move the gtm code from the default layout to the bodylayout since it requires the user's `me.json` data.

using this existing feature config: https://github.com/reddit/reddit-private/blob/e918abff41544cfc0f67f29025869b52b1b87089/production.ini#L1229

forced variant:
<img width="991" alt="screen shot 2016-06-30 at 9 10 50 am" src="https://cloud.githubusercontent.com/assets/823747/16495715/7ae831d8-3ea3-11e6-9fe8-0b00c393a86f.png">
<img width="1016" alt="screen shot 2016-06-30 at 9 11 32 am" src="https://cloud.githubusercontent.com/assets/823747/16495716/7ae8e060-3ea3-11e6-8450-cb91d615eaa7.png">

normal:
<img width="1014" alt="screen shot 2016-06-30 at 9 11 17 am" src="https://cloud.githubusercontent.com/assets/823747/16495717/7afae8e6-3ea3-11e6-89dc-89438f28cf29.png">
<img width="1015" alt="screen shot 2016-06-30 at 9 11 04 am" src="https://cloud.githubusercontent.com/assets/823747/16495718/7afc5e42-3ea3-11e6-9da3-bcfdf749a881.png">
