### PR TITLE
Fix typos in the nextcontent_mweb feature configs

### DIFF
--- a/src/featureflags.es6.js
+++ b/src/featureflags.es6.js
@@ -49,31 +49,31 @@ const config = {
   },
   [VARIANT_NEXTCONTENT_BOTTOM]: {
     url: 'experimentnextcontentbottom',
-    and: [{
+    and: {
       variant: 'nextcontent_mweb:bottom',
       loggedin: false,
-    }],
+    },
   },
   [VARIANT_NEXTCONTENT_MIDDLE]: {
     url: 'experimentnextcontentmiddle',
-    and: [{
+    and: {
       variant: 'nextcontent_mweb:middle',
       loggedin: false,
-    }],
+    },
   },
   [VARIANT_NEXTCONTENT_BANNER]: {
     url: 'experimentnextcontentbanner',
-    and: [{
+    and: {
       variant: 'nextcontent_mweb:banner',
       loggedin: false,
-    }],
+    },
   },
   [VARIANT_NEXTCONTENT_TOP3]: {
     url: 'experimentnextcontenttop3',
-    and: [{
+    and: {
       variant: 'nextcontent_mweb:top3',
       loggedin: false,
-    }],
+    },
   },
 };
 


### PR DESCRIPTION
If we build more experiments into mweb 1X, we should move to the new `@r/flags` version, which handles boolean rules better than the interim versions in `featureflags.es6.js`.

