### PR TITLE
Redirect m. users to desktop if cookie exists

### DIFF
--- a/assets/js/clientEvents.es6.js
+++ b/assets/js/clientEvents.es6.js
@@ -26,6 +26,11 @@ export default function setAppEvents(app, hasHistAndBindLinks, render, $body) {
     options.expires = date;
 
     if (window.location.host.indexOf('localhost') === -1) {
+      // NOTE: It's very important that this is the root domain and not any
+      // subdomain for the cookie being set below. If it's set on a subdomain,
+      // than desktop won't be able to read and respect the cookie. Since the
+      // default behavior on desktop is to redirect mobile users to mweb, this
+      // will result in a redirect loop.
       const domain = `.${window.bootstrap.config.reddit}`
         .match(/https?:\/\/(.+)/)[1]
         .split('.')

--- a/src/lib/dom.es6.js
+++ b/src/lib/dom.es6.js
@@ -15,4 +15,4 @@ export const isHidden = (el) => {
   }
 
   return isHidden(el.parentNode);
-}
+};


### PR DESCRIPTION
Right now, mweb users who go to a www url will have their mweb redirect cookie respected. Mweb users who go to an m dot url will not. This patch adds the ability to respect that cookie on the mweb server.

:eyeglasses: @schwers