### PR TITLE
Adjust the apple-app-site-association to remove the root path

### DIFF
--- a/src/server/routes.es6.js
+++ b/src/server/routes.es6.js
@@ -20,7 +20,7 @@ const appleAppSiteAssociation = JSON.stringify({
     details: [
       {
         appID: '2TDUX39LX8.com.reddit.Reddit',
-        paths: [ '/r/*', '/u/*', '/user/*', '/' ],
+        paths: [ '/r/*', '/u/*', '/user/*' ],
       },
     ],
   },


### PR DESCRIPTION
👓 @chenchencs @phil303 @kjoconnor 

Per Chen's suggestion in https://reddit.atlassian.net/browse/MOBILEWEB-494 we remove the root from the paths in the apple-app-site-association.