### PR TITLE
2X error logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:watch": "npm run test -- -w"
   },
   "dependencies": {
-    "@r/api-client": "~3.18.0",
+    "@r/api-client": "~3.19.0",
     "@r/build": "~0.7.2",
     "@r/flags": "^1.5.0",
     "@r/middleware": "~0.8.0",

--- a/src/app/actions/accounts.js
+++ b/src/app/actions/accounts.js
@@ -1,16 +1,29 @@
 import { apiOptionsFromState } from 'lib/apiOptionsFromState';
-import { endpoints } from '@r/api-client';
-
+import { endpoints, errors } from '@r/api-client';
 const { AccountsEndpoint } = endpoints;
+const { ResponseError } = errors;
 
 export const FETCHING_ACCOUNT = 'FETCHING_ACCOUNT';
-export const fetching = options => ({ type: FETCHING_ACCOUNT, ...options });
+// options is for the accounts endpoint, its properties are
+// name: T.string.isRequired,
+// loggedOut: T.bool, ( true if the user is loggedOut)
+export const fetching = options => ({
+  type: FETCHING_ACCOUNT,
+  ...options,
+});
 
 export const RECEIVED_ACCOUNT = 'RECEIVED_ACCOUNT';
 export const received = (options, apiResponse) => ({
   type: RECEIVED_ACCOUNT,
   ...options,
   apiResponse,
+});
+
+export const FAILED = 'FAILED_ACCOUNT';
+export const failed = (options, error) => ({
+  type: FAILED,
+  options,
+  error,
 });
 
 export const fetch = options => async (dispatch, getState) => {
@@ -22,6 +35,14 @@ export const fetch = options => async (dispatch, getState) => {
   dispatch(fetching(options));
   const query = { user: name, loggedOut };
 
-  const apiResponse = await AccountsEndpoint.get(apiOptionsFromState(state), query);
-  dispatch(received(options, apiResponse));
+  try {
+    const apiResponse = await AccountsEndpoint.get(apiOptionsFromState(state), query);
+    dispatch(received(options, apiResponse));
+  } catch (e) {
+    if (e instanceof ResponseError) {
+      dispatch(failed(options, e));
+    } else {
+      throw e;
+    }
+  }
 };

--- a/src/app/actions/activities.js
+++ b/src/app/actions/activities.js
@@ -1,5 +1,6 @@
-import { endpoints } from '@r/api-client';
+import { endpoints, errors } from '@r/api-client';
 const { ActivitiesEndpoint } = endpoints;
+const { ResponseError } = errors;
 
 import { apiOptionsFromState } from 'lib/apiOptionsFromState';
 import { paramsToActiviesRequestId } from 'app/models/ActivitiesRequest';
@@ -8,10 +9,24 @@ export const POSTS_ACTIVITY = 'submitted';
 export const COMMENTS_ACTIVITY = 'comments';
 
 export const FETCHING_ACTIVITIES = 'FETCHING_ACTIVITIES';
-export const fetching = (id, params) => ({ type: FETCHING_ACTIVITIES, id, params });
+export const fetching = (id, params) => ({
+  type: FETCHING_ACTIVITIES,
+  id,
+  params,
+});
 
 export const RECEIVED_ACTIVITIES = 'RECEIVED_ACTIVITIES';
-export const received = (id, apiResponse) => ({ type: RECEIVED_ACTIVITIES, id, apiResponse });
+export const received = (id, apiResponse) => ({
+  type: RECEIVED_ACTIVITIES,
+  id,
+  apiResponse,
+});
+
+export const FAILED = 'FAILED_ACTIVITIES';
+export const failed = (id, error) => ({
+  type: FAILED,
+  error,
+});
 
 export const fetch = activiesParams => async (dispatch, getState) => {
   const state = getState();
@@ -21,7 +36,15 @@ export const fetch = activiesParams => async (dispatch, getState) => {
 
   dispatch(fetching(id, activiesParams));
 
-  const apiOptions = apiOptionsFromState(state);
-  const apiResponse = await ActivitiesEndpoint.get(apiOptions, activiesParams);
-  dispatch(received(id, apiResponse));
+  try {
+    const apiOptions = apiOptionsFromState(state);
+    const apiResponse = await ActivitiesEndpoint.get(apiOptions, activiesParams);
+    dispatch(received(id, apiResponse));
+  } catch (e) {
+    if (e instanceof ResponseError) {
+      dispatch(failed(id, e));
+    } else {
+      throw e;
+    }
+  }
 };

--- a/src/app/actions/commentsPage.js
+++ b/src/app/actions/commentsPage.js
@@ -1,35 +1,40 @@
+import { endpoints, errors } from '@r/api-client';
+const { CommentsEndpoint, PostsEndpoint } = endpoints;
+const { ResponseError } = errors;
 import { some } from 'lodash/collection';
 
 import { apiOptionsFromState } from 'lib/apiOptionsFromState';
 import getSubreddit from 'lib/getSubredditFromState';
 import { cleanObject } from 'lib/cleanObject';
 import features from 'app/featureFlags';
-import { endpoints } from '@r/api-client';
+
 import { paramsToCommentsPageId } from 'app/models/CommentsPage';
 import { paramsToPostsListsId } from 'app/models/PostsList';
-import { fetching as fetchingPosts, received as receivedPosts } from 'app/actions/postsList';
+import * as postListActions from 'app/actions/postsList';
 import { flags } from 'app/constants';
-
-const { CommentsEndpoint, PostsEndpoint } = endpoints;
 
 const {
   VARIANT_NEXTCONTENT_BOTTOM,
 } = flags;
 
 export const FETCHING_COMMENTS_PAGE = 'FETCHING_COMMENTS_PAGE';
-
-export const fetchingCommentsPage = (commentsPageId, commentsPageParams) => ({
+export const fetching = (commentsPageId, commentsPageParams) => ({
   type: FETCHING_COMMENTS_PAGE,
   commentsPageId,
   commentsPageParams,
 });
 
 export const RECEIVED_COMMENTS_PAGE = 'RECEIVED_COMMENTS_PAGE';
-
 export const received = (commentsPageId, apiResponse) => ({
   type: RECEIVED_COMMENTS_PAGE,
   commentsPageId,
   apiResponse,
+});
+
+export const FAILED = 'FAILED_COMMENTS_PAGE';
+export const failed = (commentsPageId, error) => ({
+  type: FAILED,
+  error,
 });
 
 export const VISITED_COMMENTS_PAGE = 'VISITED_COMMENTS_PAGE';
@@ -46,14 +51,22 @@ export const fetchCommentsPage = commentsPageParams => async (dispatch, getState
 
   if (commentsPage) { return; }
 
-  dispatch(fetchingCommentsPage(commentsPageId, commentsPageParams));
+  dispatch(fetching(commentsPageId, commentsPageParams));
 
   // note that the comments endpoint returns the post, so we don't have to also
-  // fetch that somewere else. it's in the api response so the post's reducer will
+  // fetch that somewhere else. it's in the api response so the post's reducer will
   // will automatically update the post slice of the store
-  const apiOptions = apiOptionsFromState(state);
-  const apiResponse = await CommentsEndpoint.get(apiOptions, commentsPageParams);
-  dispatch(received(commentsPageId, apiResponse));
+  try {
+    const apiOptions = apiOptionsFromState(state);
+    const apiResponse = await CommentsEndpoint.get(apiOptions, commentsPageParams);
+    dispatch(received(commentsPageId, apiResponse));
+  } catch (e) {
+    if (e instanceof ResponseError) {
+      dispatch(failed(commentsPageId, e));
+    } else {
+      throw e;
+    }
+  }
 };
 
 export function relevantContentPostsParams({ subredditName }) {
@@ -76,10 +89,18 @@ export const fetchRelevantContent =
 
         if (postsList) { return; }
 
-        dispatch(fetchingPosts(postsListId, postsParams));
+        dispatch(postListActions.fetching(postsListId, postsParams));
         const apiOptions = apiOptionsFromState(state);
-        const apiResponse = await PostsEndpoint.get(apiOptions, postsParams);
-        dispatch(receivedPosts(postsListId, apiResponse));
+        try {
+          const apiResponse = await PostsEndpoint.get(apiOptions, postsParams);
+          dispatch(postListActions.received(postsListId, apiResponse));
+        } catch (e) {
+          if (e instanceof ResponseError) {
+            dispatch(postListActions.failed(postsListId, e));
+          } else {
+            throw e;
+          }
+        }
       }
     });
   };

--- a/src/app/actions/hidden.js
+++ b/src/app/actions/hidden.js
@@ -1,14 +1,30 @@
-import { endpoints } from '@r/api-client';
+import { endpoints, errors } from '@r/api-client';
 const { HiddenEndpoint } = endpoints;
+const { ResponseError } = errors;
 
 import { apiOptionsFromState } from 'lib/apiOptionsFromState';
 import { paramsToHiddenRequestid } from 'app/models/HiddenRequest';
 
 export const FETCHING_HIDDEN = 'FETCHING_HIDDEN';
-export const fetching = (id, params) => ({ type: FETCHING_HIDDEN, id, params });
+export const fetching = (id, params) => ({
+  type: FETCHING_HIDDEN,
+  id,
+  params,
+});
 
 export const RECEIVED_HIDDEN = 'RECEIVED_HIDDEN';
-export const received = (id, apiResponse) => ({ type: RECEIVED_HIDDEN, id, apiResponse });
+export const received = (id, apiResponse) => ({
+  type: RECEIVED_HIDDEN,
+  id,
+  apiResponse,
+});
+
+export const FAILED = 'FAILED_HIDDEN';
+export const failed = (id, error) => ({
+  type: FAILED,
+  id,
+  error,
+});
 
 export const fetch = params => async (dispatch, getState) => {
   const state = getState();
@@ -18,7 +34,15 @@ export const fetch = params => async (dispatch, getState) => {
 
   dispatch(fetching(id, params));
 
-  const apiOptions = apiOptionsFromState(state);
-  const apiResponse = await HiddenEndpoint.get(apiOptions, params);
-  dispatch(received(id, apiResponse));
+  try {
+    const apiOptions = apiOptionsFromState(state);
+    const apiResponse = await HiddenEndpoint.get(apiOptions, params);
+    dispatch(received(id, apiResponse));
+  } catch (e) {
+    if (e instanceof ResponseError) {
+      dispatch(failed(id, e));
+    } else {
+      throw e;
+    }
+  }
 };

--- a/src/app/actions/mail.js
+++ b/src/app/actions/mail.js
@@ -1,23 +1,24 @@
-import { endpoints } from '@r/api-client';
+import { endpoints, errors } from '@r/api-client';
+const { ResponseError } = errors;
 
 import { apiOptionsFromState } from 'lib/apiOptionsFromState';
 
 export const FETCHING = 'MAIL__FETCHING';
-export const RECEIVED = 'MAIL__RECEIVED';
-export const FAILURE = 'MAIL__FAILURE';
-
 export const setInboxPending = mailType => ({
-  mailType,
   type: FETCHING,
+  mailType,
 });
 
+export const RECEIVED = 'MAIL__RECEIVED';
 export const setInboxSuccess = (mailType, apiResponse) => ({
+  type: RECEIVED,
   mailType,
   apiResponse,
-  type: RECEIVED,
 });
 
+export const FAILED = 'MAIL__FAILED';
 export const setInboxFailure = (mailType, error) => ({
+  type: FAILED,
   mailType,
   error,
 });
@@ -30,6 +31,10 @@ export const fetchInbox = mailType => async (dispatch, getState) => {
     const apiResponse = await endpoints.MessagesEndpoint.get(apiOptions, { type: mailType });
     dispatch(setInboxSuccess(mailType, apiResponse));
   } catch (e) {
-    dispatch(setInboxFailure(mailType, e));
+    if (e instanceof ResponseError) {
+      dispatch(setInboxFailure(mailType, e));
+    } else {
+      throw e;
+    }
   }
 };

--- a/src/app/actions/meta.js
+++ b/src/app/actions/meta.js
@@ -1,0 +1,2 @@
+export const SET_META = 'SET_META';
+export const setMeta = meta => ({ type: SET_META, meta });

--- a/src/app/actions/postsList.js
+++ b/src/app/actions/postsList.js
@@ -1,11 +1,11 @@
 import { apiOptionsFromState } from 'lib/apiOptionsFromState';
-import { endpoints } from '@r/api-client';
+import { endpoints, errors } from '@r/api-client';
 import { paramsToPostsListsId } from 'app/models/PostsList';
 
 const { PostsEndpoint } = endpoints;
+const { ResponseError } = errors;
 
 export const FETCHING_POSTS_LIST = 'FETCHING_POSTS_LIST';
-
 export const fetching = (postsListId, postsParams) => ({
   type: FETCHING_POSTS_LIST,
   postsListId,
@@ -13,11 +13,17 @@ export const fetching = (postsListId, postsParams) => ({
 });
 
 export const RECEIVED_POSTS_LIST = 'RECEIVED_POSTS_LIST';
-
 export const received = (postsListId, apiResponse) => ({
   type: RECEIVED_POSTS_LIST,
   postsListId,
   apiResponse,
+});
+
+export const FAILED = 'FAILED_POSTS_LIST';
+export const failed = (postsListId, error) => ({
+  type: FAILED,
+  postsListId,
+  error,
 });
 
 export const fetchPostsFromSubreddit = postsParams => async (dispatch, getState) => {
@@ -29,7 +35,15 @@ export const fetchPostsFromSubreddit = postsParams => async (dispatch, getState)
 
   dispatch(fetching(postsListId, postsParams));
 
-  const apiOptions = apiOptionsFromState(state);
-  const apiResponse = await PostsEndpoint.get(apiOptions, postsParams);
-  dispatch(received(postsListId, apiResponse));
+  try {
+    const apiOptions = apiOptionsFromState(state);
+    const apiResponse = await PostsEndpoint.get(apiOptions, postsParams);
+    dispatch(received(postsListId, apiResponse));
+  } catch (e) {
+    if (e instanceof ResponseError) {
+      dispatch(failed(postsListId, e));
+    } else {
+      throw e;
+    }
+  }
 };

--- a/src/app/actions/preferences.js
+++ b/src/app/actions/preferences.js
@@ -1,7 +1,7 @@
 import { apiOptionsFromState } from 'lib/apiOptionsFromState';
-import { endpoints } from '@r/api-client';
-
+import { endpoints, errors } from '@r/api-client';
 const { PreferencesEndpoint } = endpoints;
+const { ResponseError } = errors;
 
 export const PENDING = 'PENDING_PREFERENCES';
 export const pending = () => ({
@@ -33,7 +33,11 @@ export const fetch = () => async (dispatch, getState) => {
     const preferences = await PreferencesEndpoint.get(apiOptionsFromState(state));
     dispatch(received(preferences));
   } catch (e) {
-    dispatch(failed(e));
+    if (e instanceof ResponseError) {
+      dispatch(failed(e));
+    } else {
+      throw e;
+    }
   }
 };
 
@@ -52,7 +56,11 @@ export const patch = changes => async (dispatch, getState) => {
       apiOptionsFromState(state), changes);
     dispatch(received(updatedPreferences));
   } catch (e) {
-    dispatch(failed(e));
+    if (e instanceof ResponseError) {
+      dispatch(failed(e));
+    } else {
+      throw e;
+    }
   }
 };
 

--- a/src/app/actions/saved.js
+++ b/src/app/actions/saved.js
@@ -1,14 +1,30 @@
-import { endpoints } from '@r/api-client';
+import { endpoints, errors } from '@r/api-client';
 const { SavedEndpoint } = endpoints;
+const { ResponseError } = errors;
 
 import { apiOptionsFromState } from 'lib/apiOptionsFromState';
 import { paramsToSavedRequestId } from 'app/models/SavedRequest';
 
 export const FETCHING_SAVED = 'FETCHING_SAVED';
-export const fetching = (id, params) => ({ type: FETCHING_SAVED, id, params });
+export const fetching = (id, params) => ({
+  type: FETCHING_SAVED,
+  id,
+  params,
+});
 
 export const RECEIVED_SAVED = 'RECEIVED_SAVED';
-export const received = (id, apiResponse) => ({ type: RECEIVED_SAVED, id, apiResponse });
+export const received = (id, apiResponse) => ({
+  type: RECEIVED_SAVED,
+  id,
+  apiResponse,
+});
+
+export const FAILED = 'FAILED_SAVED';
+export const failed = (id, error) => ({
+  type: FAILED,
+  id,
+  error,
+});
 
 export const fetch = params => async (dispatch, getState) => {
   const state = getState();
@@ -18,7 +34,15 @@ export const fetch = params => async (dispatch, getState) => {
 
   dispatch(fetching(id, params));
 
-  const apiOptions = apiOptionsFromState(state);
-  const apiResponse = await SavedEndpoint.get(apiOptions, params);
-  dispatch(received(id, apiResponse));
+  try {
+    const apiOptions = apiOptionsFromState(state);
+    const apiResponse = await SavedEndpoint.get(apiOptions, params);
+    dispatch(received(id, apiResponse));
+  } catch (e) {
+    if (e instanceof ResponseError) {
+      dispatch(failed(id, e));
+    } else {
+      throw e;
+    }
+  }
 };

--- a/src/app/actions/subreddits.js
+++ b/src/app/actions/subreddits.js
@@ -1,17 +1,29 @@
-import { endpoints } from '@r/api-client';
+import { endpoints, errors } from '@r/api-client';
 import { apiOptionsFromState } from 'lib/apiOptionsFromState';
 import isFakeSubreddit from 'lib/isFakeSubreddit';
 
 const { SubredditEndpoint } = endpoints;
+const { ResponseError } = errors;
 
 export const FETCHING_SUBREDDIT = 'FETCHING_SUBREDDIT';
-export const fetching = name => ({ type: FETCHING_SUBREDDIT, name });
+export const fetching = name => ({
+  type: FETCHING_SUBREDDIT,
+  name,
+});
 
 export const RECEIVED_SUBREDDIT = 'RECEIVED_SUBREDDIT';
-export const received = (name, model) => ({ type: RECEIVED_SUBREDDIT, name, model });
+export const received = (name, model) => ({
+  type: RECEIVED_SUBREDDIT,
+  name,
+  model,
+});
 
-export const FAILED_SUBREDDIT = 'FAILED_SUBREDDIT';
-export const failed = name => ({ type: FAILED_SUBREDDIT, name });
+export const FAILED = 'FAILED_SUBREDDIT';
+export const failed = (name, error) => ({
+  type: FAILED,
+  name,
+  error,
+});
 
 export const fetchSubreddit = (name) => async (dispatch, getState) => {
   if (isFakeSubreddit(name)) { return; }
@@ -29,6 +41,10 @@ export const fetchSubreddit = (name) => async (dispatch, getState) => {
     const model = response.getModelFromRecord(response.results[0]);
     dispatch(received(name, model));
   } catch (e) {
-    dispatch(failed(name));
+    if (e instanceof ResponseError) {
+      dispatch(failed(name, e));
+    } else {
+      throw e;
+    }
   }
 };

--- a/src/app/actions/vote.js
+++ b/src/app/actions/vote.js
@@ -1,8 +1,21 @@
+import { models, errors } from '@r/api-client';
+const { ResponseError } = errors;
 import { apiOptionsFromState } from 'lib/apiOptionsFromState';
-import { models } from '@r/api-client';
+
 
 export const VOTED = 'VOTED';
-export const voted = (id, model) => ({ type: VOTED, id, model });
+export const voted = (id, model) => ({
+  type: VOTED,
+  id,
+  model,
+});
+
+export const FAILED = 'VOTE_FAILED';
+export const voteFailed = (id, error) => ({
+  type: FAILED,
+  id,
+  error,
+});
 
 export const vote = (id, direction) => async (dispatch, getState) => {
   const state = getState();
@@ -17,5 +30,11 @@ export const vote = (id, direction) => async (dispatch, getState) => {
     dispatch(voted(id, resolved));
   } catch (e) {
     dispatch(voted(id, thing));
+
+    if (e instanceof ResponseError) {
+      dispatch(voteFailed(id, e));
+    } else {
+      throw e;
+    }
   }
 };

--- a/src/app/components/TopNav/index.jsx
+++ b/src/app/components/TopNav/index.jsx
@@ -53,7 +53,6 @@ export const TopNav = (props) => {
         <Anchor
           className='MobileButton TopNav-padding TopNav-snoo'
           href='/'
-          data-no-route={ true }
         >
           <SnooIcon />
         </Anchor>

--- a/src/app/reducers/commentsPages.test.js
+++ b/src/app/reducers/commentsPages.test.js
@@ -33,7 +33,6 @@ createTest({ reducers: { commentsPages } }, ({ getStore, expect }) => {
     });
 
     describe('FETCHING_COMMENTS_PAGE', () => {
-
       const COMMENTS_PAGE_ID = COMMENTS_PAGE_ID;
       const POST_ID = 't3_12345';
 
@@ -51,7 +50,7 @@ createTest({ reducers: { commentsPages } }, ({ getStore, expect }) => {
           commentsPages: { [COMMENTS_PAGE_ID]: CACHED_COMMENTS_PAGE },
         });
 
-        store.dispatch(commentsPageActions.fetchingCommentsPage(
+        store.dispatch(commentsPageActions.fetching(
           COMMENTS_PAGE_ID,
           { id: POST_ID },
         ));
@@ -62,7 +61,7 @@ createTest({ reducers: { commentsPages } }, ({ getStore, expect }) => {
 
       it('should add a new commentsPage to the store', () => {
         const { store } = getStore();
-        store.dispatch(commentsPageActions.fetchingCommentsPage(
+        store.dispatch(commentsPageActions.fetching(
           COMMENTS_PAGE_ID,
           { id: POST_ID },
         ));
@@ -81,7 +80,6 @@ createTest({ reducers: { commentsPages } }, ({ getStore, expect }) => {
     });
 
     describe('RECEIVED_COMMENTS_PAGE', () => {
-
       const COMMENTS_PAGE_ID = '1';
       const POST_ID = 't3_12345';
 

--- a/src/app/reducers/index.js
+++ b/src/app/reducers/index.js
@@ -1,7 +1,7 @@
 import widgets from '@r/widgets/reducer';
 
-import accounts from './accounts';
 import accountRequests from './accountRequests';
+import accounts from './accounts';
 import activitiesRequests from './activitiesRequests';
 import adRequests from './adRequests';
 import autocompleteSubreddits from './autocompleteSubreddits';
@@ -9,10 +9,13 @@ import collapsedComments from './collapsedComments';
 import comments from './comments';
 import commentsPages from './commentsPages';
 import compact from './compact';
-import expandedPosts from './expandedPosts';
 import editingComment from './editingComment';
+import expandedPosts from './expandedPosts';
 import hiddenRequests from './hiddenRequests';
 import loid from './loid';
+import mail from './mail';
+import meta from './meta';
+import messages from './messages';
 import posting from './posting';
 import posts from './posts';
 import postsLists from './postsLists';
@@ -24,17 +27,15 @@ import savedRequests from './savedRequests';
 import searchRequests from './searchRequests';
 import session from './session';
 import sessionRefresing from './sessionRefreshing';
+import subredditRequests from './subredditRequests';
 import subreddits from './subreddits';
 import subscribedSubreddits from './subscribedSubreddits';
-import subredditRequests from './subredditRequests';
 import theme from './theme';
 import unblurredPosts from './unblurredPosts';
 import user from './user';
 import visitedPosts from './visitedPosts';
-import wikis from './wikis';
 import wikiRequests from './wikiRequests';
-import mail from './mail';
-import messages from './messages';
+import wikis from './wikis';
 
 export default {
   accounts,
@@ -51,6 +52,7 @@ export default {
   hiddenRequests,
   loid,
   mail,
+  meta,
   messages,
   posting,
   posts,

--- a/src/app/reducers/mail.js
+++ b/src/app/reducers/mail.js
@@ -37,7 +37,7 @@ export default function(state=DEFAULT, action={}) {
         },
       });
     }
-    case mailActions.FAILURE: {
+    case mailActions.FAILED: {
       const { mailType, error } = action;
       return merge(state, {
         [mailType]: {

--- a/src/app/reducers/meta.js
+++ b/src/app/reducers/meta.js
@@ -1,0 +1,16 @@
+import * as metaActions from 'app/actions/meta';
+
+export const DEFAULT = {
+  userAgent: '',
+  country: '',
+};
+
+export default (state=DEFAULT, action={}) => {
+  switch (action.type) {
+    case metaActions.SET_META: {
+      return action.meta;
+    }
+
+    default: return state;
+  }
+};

--- a/src/app/reducers/preferences.test.js
+++ b/src/app/reducers/preferences.test.js
@@ -32,7 +32,7 @@ createTest({ reducers: { preferences }}, ({ getStore, expect }) => {
       });
     });
 
-    describe('RECEIEVED', () => {
+    describe('RECEIVED', () => {
       it('should update the state with newest preferences object', () => {
         const { store } = getStore();
 

--- a/src/app/reducers/subredditRequests.js
+++ b/src/app/reducers/subredditRequests.js
@@ -31,7 +31,7 @@ export default (state=DEFAULT, action={}) => {
       return merge(state, { [name]: { loading: false } });
     }
 
-    case subredditActions.FAILED_SUBREDDIT: {
+    case subredditActions.FAILED: {
       const { name } = action;
       const currentRequest = state[name];
       if (!(currentRequest && currentRequest.loading)) { return state; }

--- a/src/app/reduxMiddleware/errorLogger.js
+++ b/src/app/reduxMiddleware/errorLogger.js
@@ -1,0 +1,136 @@
+import * as platformActions from '@r/platform/actions';
+import { urlFromPage } from '@r/platform/pageUtils';
+import config from 'config';
+import errorLog from 'lib/errorLog';
+import RingStack from 'lib/RingStack';
+
+import * as accountActions from 'app/actions/accounts';
+import * as activityActions from 'app/actions/activities';
+import * as adActions from 'app/actions/ads';
+import * as commentsPageActions from 'app/actions/commentsPage';
+import * as hiddenActions from 'app/actions/hidden';
+import * as mailActions from 'app/actions/mail';
+import * as postsListActions from 'app/actions/postsList';
+import * as preferenceActions from 'app/actions/preferences';
+import * as savedActions from 'app/actions/saved';
+import * as searchActions from 'app/actions/search';
+import * as subredditActions from 'app/actions/subreddits';
+import * as subscribedSubredditActions from 'app/actions/subscribedSubreddits';
+import * as voteActions from 'app/actions/vote';
+import * as wikiActions from 'app/actions/wiki';
+
+export const errorLogger = () => {
+  const actionStack = new ActionStack(config.reduxActionLogSize, [
+    platformActions.SET_PAGE,
+    accountActions.FETCHING_ACCOUNT,
+    activityActions.FETCHING_ACTIVITIES,
+    commentsPageActions.FETCHING_COMMENTS_PAGE,
+    hiddenActions.FETCHING_HIDDEN,
+    mailActions.FETCHING,
+    postsListActions.FETCHING_POSTS_LIST,
+    savedActions.FETCHING_SAVED,
+    searchActions.FETCHING_SEARCH_REQUEST,
+    subredditActions.FETCHING_SUBREDDIT,
+    wikiActions.FETCHING_WIKI,
+  ]);
+
+  return store => next => action => {
+    actionStack.push(action);
+
+    // Check for specific error actions, this gives insight into what kind of
+    // error happened. I.E. its easier to differentiate between a specific
+    // action or endpoint failing than seeing its equivalent stack trace.
+    const error = checkForSpecificErrors(action);
+    if (error) {
+      logErrorWithConfig(error, store.getState(), actionStack);
+    } else if (action instanceof Promise) {
+      // async actions all have an associated Promises. To catch errors in these
+      // Promises we need to attach a .catch handler, otherwise they'll get
+      // turned into PromiseRejectionEvents which are pretty different than Errors
+      // (they don't even show up in window.onerror). This way we can catch
+      // any unhandled exceptions in async actions here.
+      // e.g. if we fetch some data and it parsed correctly, it could still
+      // cause an error in reducers or React's rendering. both of those would
+      // be caught here.
+
+      action.catch(error => {
+        logErrorWithConfig(error, store.getState(), actionStack);
+      });
+    }
+
+    // wrap the call of next(action) to catch any errors in reducers or middleware
+    try {
+      return next(action);
+    } catch (error) {
+      logErrorWithConfig(error, store.getState(), actionStack);
+    }
+  };
+};
+
+const checkForSpecificErrors = action => {
+  switch (action.type) {
+    case accountActions.FAILED:
+    case activityActions.FAILED:
+    case adActions.FAILED:
+    case commentsPageActions.FAILED:
+    case hiddenActions.FAILED:
+    case mailActions.FAILED:
+    case postsListActions.FAILED:
+    case preferenceActions.FAILED:
+    case savedActions.FAILED:
+    case searchActions.FAILED:
+    case subredditActions.FAILED:
+    case subscribedSubredditActions.FETCH_FAILED:
+    case subscribedSubredditActions.TOGGLE_FAILED:
+    case voteActions.FAILED:
+    case wikiActions.FAILED: {
+      const { error } = action;
+      if (error) {
+        return error;
+      }
+    }
+  }
+};
+
+const logErrorWithConfig = (error, state, actionStack) => {
+  const { env, userAgent, platform: { currentPage } } = state;
+
+  errorLog({
+    error,
+    userAgent: `${env}${userAgent ? `-${userAgent}` : ''}`,
+    reduxInfo: actionStack.toString(),
+    requestUrl: urlFromPage(currentPage),
+  }, {
+    hivemind: config.statsURL,
+    log: config.postErrorURL,
+  }, {
+    level: config.debugLevel || 'error',
+  });
+};
+
+// For more context in error logs we want to know the N most recent actions that
+// passed through redux. Having all of the action objects would get big pretty
+// fast so only track the type or 'name' of most actions. Some actions are
+// useful to understand what's been happening in the app so we allow some
+// configureable actions to be logged in their entirety.
+class ActionStack {
+  constructor(size, expandedInfoList=[]) {
+    this.stack = new RingStack(size);
+    this.expandedInfoList = new Set(expandedInfoList);
+  }
+
+  push(action) {
+    // skip thunk'd actions
+    if (typeof action === 'function') {
+      return;
+    }
+
+    const storedAction = this.expandedInfoList.has(action.type) ? action : action.type;
+    this.stack.push(storedAction);
+  }
+
+  // string representation of the action stack with most recent actions first.
+  toString() {
+    return `Redux Action Stack: ${this.stack.values().map(JSON.stringify).join(', ')}`;
+  }
+}

--- a/src/app/reduxMiddleware/index.js
+++ b/src/app/reduxMiddleware/index.js
@@ -1,0 +1,5 @@
+import { errorLogger } from './errorLogger';
+
+export default [
+  errorLogger(),
+];

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,51 @@
+/*eslint max-len: 0*/
+
+// This configuration is shared with the client. Any hidden, server-only config
+// belongs in ./server instead.
+
+import localStorageAvailable from 'lib/localStorageAvailable';
+
+const config = () => ({
+  https: process.env.HTTPS === 'true',
+  httpsProxy: process.env.HTTPS_PROXY === 'true',
+
+  debugLevel: process.env.DEBUG_LEVEL,
+  postErrorURL: '/error',
+
+  minifyAssets: process.env.MINIFY_ASSETS === 'true',
+
+  assetPath: process.env.STATIC_BASE || '',
+
+  origin: process.env.ORIGIN || 'http://localhost:4444',
+  port: process.env.PORT || 4444,
+  env: process.env.NODE_ENV || 'development',
+
+  nonAuthAPIOrigin: process.env.NON_AUTH_API_ORIGIN || 'https://www.reddit.com',
+  authAPIOrigin: process.env.AUTH_API_ORIGIN || 'https://oauth.reddit.com',
+
+  reddit: process.env.REDDIT || 'https://www.reddit.com',
+
+  googleAnalyticsId: process.env.GOOGLE_ANALYTICS_ID,
+  googleTagManagerId: process.env.GOOGLE_TAG_MANAGER_ID,
+
+  adblockTestClassName: process.env.ADBLOCK_TEST_CLASSNAME || 'ad adsense-ad googad gemini-ad openx',
+
+  localStorageAvailable: localStorageAvailable(),
+
+  statsURL: process.env.STATS_URL || 'https://stats.redditmedia.com/',
+  reduxActionLogSize: process.env.REDUX_ACTION_LOG_SIZE || 50,
+  mediaDomain: process.env.MEDIA_DOMAIN || 'www.redditmedia.com',
+  adsPath: process.env.ADS_PATH || '/api/request_promo.json',
+  manifest: {},
+
+  trackerKey: process.env.TRACKER_KEY,
+  trackerEndpoint: process.env.TRACKER_ENDPOINT,
+  trackerClientSecret: process.env.TRACKER_SECRET,
+  trackerClientAppName: process.env.TRACKER_CLIENT_NAME,
+
+  appName: process.env.APP_NAME || 'mweb',
+
+  defaultCountry: process.env.DEFAULT_COUNTRY || 'US',
+});
+
+export default config();

--- a/src/lib/RingStack.js
+++ b/src/lib/RingStack.js
@@ -1,0 +1,21 @@
+// A simple read-only ring-stack. Useful for keeping track of the N most recent items.
+
+export default class RingStack {
+  constructor(size) {
+    this.size = size;
+    this.stack = new Array(size);
+    this.head = 0;
+  }
+
+  push(item) {
+    this.stack[this.head] = item;
+    this.head = (this.head + 1) % this.size;
+  }
+
+  values() {
+    return this.stack.slice(this.head)
+      .concat(this.stack.slice(0, this.head))
+      .filter(x => !!x)
+      .reverse();
+  }
+}

--- a/src/lib/errorLog.js
+++ b/src/lib/errorLog.js
@@ -32,6 +32,8 @@ function simpleUA(agent) {
   return 'unknownClient';
 }
 
+const isAPIFailure = details => (details.error && details.error instanceof ResponseError);
+
 function formatLog(details) {
   if (!details) { return; }
 
@@ -42,12 +44,11 @@ function formatLog(details) {
     line,
     column,
     requestUrl,
-    error,
   } = details;
 
   const errorString = [userAgent || 'UNKNOWN'];
 
-  if (error instanceof ResponseError) {
+  if (isAPIFailure(details)) {
     errorString.push('API REQUEST FAILURE');
   }
 
@@ -80,12 +81,10 @@ function errorLog(details, errorEndpoints, config={}) {
     sendErrorLog(formattedLog, errorEndpoints.log);
   }
 
-  const isAPIFailure = details.error && details.error instanceof ResponseError;
-
   // send to statsd
   if (errorEndpoints.hivemind) {
     const ua = simpleUA(details.userAgent || '');
-    hivemind(ua, errorEndpoints.hivemind, isAPIFailure);
+    hivemind(ua, errorEndpoints.hivemind, isAPIFailure(details));
   }
 
   // log to winston, soon

--- a/src/lib/errorLog.js
+++ b/src/lib/errorLog.js
@@ -3,6 +3,125 @@ import makeRequest from './makeRequest';
 
 const { ResponseError } = errors;
 
+
+const isAPIFailure = details => details.error instanceof ResponseError;
+
+export default function (details, errorEndpoints, config={}) {
+  // parse the stack for location details if we're passed
+  // an Error or PromiseRejectionEvent
+  const { error, rejection } = details;
+  let parsedDetails = { ...details };
+  if (error) {
+    parsedDetails = { ...parsedDetails, ...parseError(error) };
+  } else if (rejection) {
+    parsedDetails = { ...parsedDetails, ...parseRejection(rejection) };
+  }
+
+  const formattedLog = formatLog(parsedDetails);
+  console.log(formattedLog);
+
+  if (config.debugLevel === 'info') {
+    if (error && error.stack) {
+      console.log(error.stack);
+    } else if (rejection && rejection.reason && rejection.reason.stack) {
+      console.log(rejection.reason.stack);
+    }
+  }
+
+  // send to local log
+  if (errorEndpoints.log) {
+    sendErrorLog(formattedLog, errorEndpoints.log);
+  }
+
+  // send to statsd
+  if (errorEndpoints.hivemind) {
+    const ua = simpleUA(details.userAgent || '');
+    hivemind(ua, errorEndpoints.hivemind, isAPIFailure(details));
+  }
+}
+
+const parseError = error => {
+  // error should be an instanceof Error
+  if (error.stack) {
+    const parts = textInParens(error.stack.split('\n')[1]).split(':');
+    const len = parts.length;
+    return {
+      url: parts.slice(0, len - 2).join(':'),
+      line: parts[len - 2],
+      column: parts[len - 1],
+      message: `Error: ${error.message}`,
+    };
+  }
+
+  return {
+    message: `Error: ${error.message}`,
+  };
+};
+
+const parseRejection = rejection => {
+  // rejection should be an instanceof PromiseRejectionEvent
+  if (rejection.reason && rejection.reason.stack) {
+    const parts = textInParens(rejection.reason.stack.split('\n')[1]).split(':');
+    const len = parts.length;
+    return {
+      url: parts.slice(0, len - 2).join(':'),
+      line: parts[len - 2],
+      column: parts[len - 1],
+      message: `Rejection: ${rejection.reason}`,
+    };
+  }
+
+  return {
+    message: `Rejection: ${rejection.reason}`,
+  };
+};
+
+const textInParens = string => {
+  const match = string.match(/.*\((.*)\).*/);
+  if (match) {
+    return match[1];
+  }
+
+  return '';
+};
+
+function formatLog(details) {
+  if (!details) { return; }
+
+  const {
+    userAgent,
+    message,
+    reduxInfo,
+    url,
+    line,
+    column,
+    requestUrl,
+  } = details;
+
+  const errorString = [userAgent || 'UNKNOWN'];
+
+  if (isAPIFailure(details)) {
+    errorString.push('API REQUEST FAILURE');
+  }
+
+  errorString.push(message || 'NO MESSAGE');
+  errorString.push(requestUrl || 'NO REQUEST URL');
+
+  if (reduxInfo) {
+    errorString.push(reduxInfo);
+  }
+
+  if (url) {
+    errorString.push(url);
+
+    if (line && typeof column !== 'undefined') {
+      errorString.push(`${line}:${column}`);
+    }
+  }
+
+  return errorString.join('|');
+}
+
 function simpleUA(agent) {
   if (/server/i.test(agent)) { return 'server'; }
 
@@ -32,64 +151,6 @@ function simpleUA(agent) {
   return 'unknownClient';
 }
 
-const isAPIFailure = details => (details.error && details.error instanceof ResponseError);
-
-function formatLog(details) {
-  if (!details) { return; }
-
-  const {
-    userAgent,
-    message,
-    url,
-    line,
-    column,
-    requestUrl,
-  } = details;
-
-  const errorString = [userAgent || 'UNKNOWN'];
-
-  if (isAPIFailure(details)) {
-    errorString.push('API REQUEST FAILURE');
-  }
-
-  errorString.push(message || 'NO MESSAGE');
-  errorString.push(requestUrl || 'NO REQUEST URL');
-
-  if (url) {
-    errorString.push(url);
-
-    if (line && typeof column !== 'undefined') {
-      errorString.push(`${line}:${column}`);
-    }
-  }
-
-  return errorString.join('|');
-}
-
-function errorLog(details, errorEndpoints, config={}) {
-  const formattedLog = formatLog(details);
-  console.log(formattedLog);
-
-  if (config.debugLevel === 'info') {
-    if (details.error && details.error.stack) {
-      console.log(details.error.stack);
-    }
-  }
-
-  // send to local log
-  if (errorEndpoints.log) {
-    sendErrorLog(formattedLog, errorEndpoints.log);
-  }
-
-  // send to statsd
-  if (errorEndpoints.hivemind) {
-    const ua = simpleUA(details.userAgent || '');
-    hivemind(ua, errorEndpoints.hivemind, isAPIFailure(details));
-  }
-
-  // log to winston, soon
-}
-
 function sendErrorLog(error, endpoint) {
   makeRequest
     .post(endpoint)
@@ -112,5 +173,3 @@ function hivemind(ua, endpoint, isAPIFailure) {
     .timeout(3000)
     .then();
 }
-
-export default errorLog;

--- a/src/server/initialState/dispatchInitialMeta.js
+++ b/src/server/initialState/dispatchInitialMeta.js
@@ -1,0 +1,12 @@
+import config from 'config';
+import * as metaActions from 'app/actions/meta';
+
+export const dispatchInitialMeta = async (ctx, dispatch) => {
+  const meta = {
+    userAgent: ctx.headers['user-agent'] || '',
+    country: ctx.headers['cf-ipcountry'] || config.defaultCountry,
+    env: 'SERVER', // overridden as 'CLIENT' in Client.js
+  };
+
+  dispatch(metaActions.setMeta(meta));
+};


### PR DESCRIPTION
Depends on https://github.com/reddit/node-api-client/pull/139

The basic principle of this patch is that we want to have as much info for debugging as possible. Thus most of the work for errorLogging is done by the errorLogger middlware. It intercepts actions that are considered failures to log errors. This seems better than only using a try/catch or Promise.catch approach because the action names will give us more context and seems to set us up nicely for error-handling. It also attaches a `.catch` handler to any promise it sees dispatched as well as wrapping `next(action)` in a try/catch. 