### PR TITLE
Add UTM data to semantic URLs. (CHAN-71)

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -35,6 +35,7 @@ require('./src/featureflags');
 global.document = {};
 
 // components
+require('./views/components/GoogleCarouselMetadata');
 require('./views/components/Modal');
 
 // components -> listings

--- a/test/lib/extractErrorMsg.es6.js
+++ b/test/lib/extractErrorMsg.es6.js
@@ -9,26 +9,26 @@ const GENERIC_MESSAGE = 'There was a problem';
 chai.use(sinonChai);
 
 describe('lib: extractErrorMsg', () => {
-  it('returns error messages nested in a compolete, 2-deep array', () => {
+  it('returns error messages nested in a complete, 2-deep array', () => {
     expect(extractErrorMsg({errors: [['error type', TEST_MESSAGE]]}))
       .to.equal(TEST_MESSAGE);
   });
-  
-  it('returns a any message found in error.message', () => {
+
+  it('returns any message found in error.message', () => {
     expect(extractErrorMsg({message: TEST_MESSAGE}))
     .to.equal(TEST_MESSAGE);
   });
-  
+
   it('returns a generic message for all other cases', () => {
     expect(extractErrorMsg({errors: []}))
       .to.equal(GENERIC_MESSAGE);
-      
+
     expect(extractErrorMsg({errors: [[]]}))
       .to.equal(GENERIC_MESSAGE);
-      
+
     expect(extractErrorMsg(null))
       .to.equal(GENERIC_MESSAGE);
-      
+
     expect(extractErrorMsg({}))
       .to.equal(GENERIC_MESSAGE);
   });

--- a/test/views/components/GoogleCarouselMetadata.es6.js
+++ b/test/views/components/GoogleCarouselMetadata.es6.js
@@ -1,0 +1,61 @@
+import chai from 'chai';
+import sinonChai from 'sinon-chai';
+import {
+  isRedditDomain,
+  addUtmTracking,
+} from '../../../src/views/components/GoogleCarouselMetadata';
+
+
+chai.use(sinonChai);
+const expect = chai.expect;
+
+
+describe('GoogleCarouselMetadata: isRedditDomain', () => {
+  it('handles localhost', () => {
+    expect(isRedditDomain('localhost')).to.equal(false);
+  });
+
+  it('handles common reddit domains', () => {
+    expect(isRedditDomain('reddit.com')).to.equal(true);
+    expect(isRedditDomain('m.reddit.com')).to.equal(true);
+    expect(isRedditDomain('np.reddit.com')).to.equal(true);
+    expect(isRedditDomain('www.reddit.com')).to.equal(true);
+  });
+
+  it('ignores other reddit domain names', () => {
+    expect(isRedditDomain('i.redd.it')).to.equal(false);
+    expect(isRedditDomain('i.reddituploads.com')).to.equal(false);
+    expect(isRedditDomain('redditmedia.com')).to.equal(false);
+  });
+
+});
+
+describe('GoogleCarouselMetadata: addUtmTracking', () => {
+  it('ignores non-reddit domains', () => {
+    const ignoredUrls = [
+      'http://localhost:9000',
+      'https://i.reddituploads.com/82d0fb0eb19648b3ab300fd0e1f54195?fit=max&h=1536&w=1536&s=6b355faf769e0b72535757fa196d6c34',
+    ];
+
+    ignoredUrls.forEach((url) => {
+      expect(addUtmTracking(url)).to.equal(url);
+    });
+  });
+
+  it('handles null urls', () => {
+    expect(addUtmTracking(null)).to.equal(null);
+  });
+
+  it('adds tracking to reddit domains', () => {
+    const redditUrls = [
+      'http://m.reddit.com/r/explainlikeimfive/comments/4ukacd/eli5_why_college_is_so_high_priced_in_the_us/',
+      'https://www.reddit.com/r/IAmA/comments/4red1n/were_scientists_and_engineers_on_nasas_juno/',
+      'https://np.reddit.com/r/BitcoinMarkets/comments/4rgor8/daily_discussion_wednesday_july_06_2016/d51m0ee?context=3#randomHashAnchor',
+    ];
+
+    redditUrls.forEach((url) => {
+      expect(addUtmTracking(url)).to.include('utm_source=search');
+      expect(addUtmTracking(url)).to.include('utm_medium=structured_data');
+    });
+  });
+});


### PR DESCRIPTION
Confirmed locally:
```shell
╭─@eikyo ~ ‹python-2.7.12›
╰─ curl -s -A "wting-${RANDOM}" http://localhost:4444/r/explainlikeimfive/comments/4ukacd/eli5_why_college_is_so_high_priced_in_the_us/ | python -c 'import sys; from BeautifulSoup import BeautifulSoup; print(BeautifulSoup(sys.stdin.read()).findAll("script", type="application/ld+json")[0].contents[0])' | jq '{url, sharedContent}'
{
  "url": "http://localhost:4444/r/explainlikeimfive/comments/4ukacd/eli5_why_college_is_so_high_priced_in_the_us/?utm_source=search&utm_medium=structured_data",
  "sharedContent": {
    "url": "http://localhost:4444/r/explainlikeimfive/comments/4ukacd/eli5_why_college_is_so_high_priced_in_the_us/?utm_source=search&utm_medium=structured_data"
  }
}
```

👓  @prashtx 

cc: @drunken-economist @schwers 