### PR TITLE
Fix adblock tracking from throwing exceptions

### DIFF
--- a/assets/js/trackingEvents.es6.js
+++ b/assets/js/trackingEvents.es6.js
@@ -90,6 +90,8 @@ function trackingEvents(app) {
 
   function testAdblock() {
     const el = document.getElementById('adblock-test');
+    if (!el) { return true; }
+
     const rect = el.getBoundingClientRect();
 
     if (!rect.height || !rect.width) {
@@ -243,10 +245,15 @@ function trackingEvents(app) {
   }
 
   function getAdsBasePlayload(props) {
+    // Don't send the adblock parameter unless its a page we show ads on.
+    // Pages that don't have adsEnabled set to true won't have the adblock-test
+    // div anyway so the result of that test wouldn't be helpful.
+    const adBlock = props.adsEnabled ? { adBlock: testAdblock() } : {};
+
     return {
       dnt: !!window.DO_NOT_TRACK,
-      adblock: testAdblock(),
       compact_view: props.compact,
+      ...adBlock,
     };
   }
 


### PR DESCRIPTION
Fixes `/login` and `/register` pages from rendering as blank when you go there via an in-app navigation. 

The adblock tracking code is throwing an exception because the adblock test isn't rendered on that page, which breaks rendering. I modified the tracking to not test for adblock when we know the `div#adblock-test` won't be on the page, which would guarantee a false-positive. I changed `testAdblock` to not throw exceptions when the div isn't found.

👓  @dwick 