### PR TITLE
Always render adblock test element.

### DIFF
--- a/assets/js/trackingEvents.es6.js
+++ b/assets/js/trackingEvents.es6.js
@@ -245,15 +245,10 @@ function trackingEvents(app) {
   }
 
   function getAdsBasePlayload(props) {
-    // Don't send the adblock parameter unless its a page we show ads on.
-    // Pages that don't have adsEnabled set to true won't have the adblock-test
-    // div anyway so the result of that test wouldn't be helpful.
-    const adBlock = props.adsEnabled ? { adBlock: testAdblock() } : {};
-
     return {
       dnt: !!window.DO_NOT_TRACK,
       compact_view: props.compact,
-      ...adBlock,
+      adblock: testAdblock(),
     };
   }
 

--- a/src/views/layouts/BodyLayout.jsx
+++ b/src/views/layouts/BodyLayout.jsx
@@ -73,11 +73,6 @@ class BodyLayout extends BasePage {
 
   renderAdCode = () => {
     const { adsEnabled, app, ctx, subredditName } = this.props;
-
-    if (!adsEnabled) {
-      return null;
-    }
-
     const { mediaDomain, googleTagManagerId, adblockTestClassName } = app.config;
     const adblockStyles = {
       height: '1px',
@@ -85,20 +80,30 @@ class BodyLayout extends BasePage {
       position: 'absolute',
       left: '-1000%',
     };
+    const adCode = [
+      <div
+        id="adblock-test"
+        key="adblock"
+        className={ adblockTestClassName }
+        style={ adblockStyles }
+      />,
+    ];
 
-    return (
-      <div>
-        <div
-          id="adblock-test"
-          className={ adblockTestClassName }
-          style={ adblockStyles }
-        />
+    if (adsEnabled && googleTagManagerId) {
+      adCode.push(
         <GoogleTagManager
+          key="gtm"
           nonce={ ctx.csrf }
           mediaDomain={ mediaDomain }
           googleTagManagerId={ googleTagManagerId }
           subredditName={ subredditName }
         />
+      );
+    }
+
+    return (
+      <div>
+        { adCode }
       </div>
     );
   }


### PR DESCRIPTION
We want to test for adblock on every page.  Google tag manager
should continue to be excluded for users with ads disable though.

👓 @schwers 

related to https://github.com/reddit/reddit-mobile/pull/654/files