### PR TITLE
Add Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,36 @@
+.PHONY: dev-server
+dev-server: dependencies dev-tools
+	nodemon -e jsx,js,less,css index.js
+
+.PHONY: dev-autobuild
+dev-autobuild: dependencies dev-tools
+	npm run watch
+
+.PHONY: dev-tools
+dev-tools:
+	@command -v mocha &>/dev/null || npm install -g mocha
+	@command -v nodemon &>/dev/null || npm install -g nodemon
+
+.PHONY: lint
+lint:
+	npm run lint
+
+.PHONY: test
+test: dev-tools
+	mocha
+
+.PHONY: clean
+clean:
+	rm -fr ./build ./node_modules
+
+.PHONY: dependencies
+dependencies: node_modules lib/snooboots/LICENSE build
+
+build:
+	npm run build
+
+lib/snooboots/LICENSE:
+	git submodule update --init
+
+node_modules:
+	npm install


### PR DESCRIPTION
👓 : @schwers 

This file is to formalize some of the build processes for working with this
repo, as well as providing a self-documenting entry point for new devs working
on this codebase.

Devs can hit `make <tab>` to see which targets they can build, while defaulting to `dev-server`.

Longer term, the goal is to standardize some of these targets cross repositories. This provides a consistent interface for devs while allowing each repo to customize what `make test` means.

Tested via `make clean && make`, and cloning to a new location and running `make`.