### PR TITLE
remove svg compatibility check

### DIFF
--- a/src/app/components/SVG/index.jsx
+++ b/src/app/components/SVG/index.jsx
@@ -1,59 +1,39 @@
 import React from 'react';
 
+const T = React.PropTypes;
+
 const _NS = 'http://www.w3.org/2000/svg';
+const ICON_SIZE = 20;
 
-function SVG (props) {
-  const width = props.width || SVG.ICON_SIZE;
-  const height = props.height || SVG.ICON_SIZE;
-
-  if (SVG.ENABLED) {
-    const move = props.move;
-    const out = props.out;
-
-    return (
-      <svg
-        className={ props.className }
-        version='1.1'
-        xmlns={ _NS }
-        x='0px'
-        y='0px'
-        width={ `${width}px` }
-        height={ `${height}px` }
-        viewBox={ `0 0 ${width} ${height}` }
-        onMouseMove={ move }
-        onMouseLeave={ out }
-      >
-        { props.children }
-      </svg>
-    );
-  }
-
-  const fallbackIcon = props.fallbackIcon;
-  if (fallbackIcon) {
-    return <figure className={ `${props.className} ${fallbackIcon}` }/>;
-  }
-
-  const fallbackText = props.fallbackText;
-  if (fallbackText) {
-    return <span className='fallbackText'>{ fallbackText }</span>;
-  }
-
-  const fallbackImg = props.fallbackImg;
-  if (fallbackImg) {
-    return <img className='fallbackImg' src={ fallbackImg } width={ width } height={ height }/>;
-  }
-
-  const Fallback = props.fallbackComponent;
-  if (Fallback) {
-    return <Fallback/>;
-  }
-
-  return <span className='placeholder'/>;
+export default function SVG(props) {
+  const { move, out, className, children, width, height } = props;
+  return (
+    <svg
+      className={ className }
+      version='1.1'
+      xmlns={ _NS }
+      x='0px'
+      y='0px'
+      width={ `${width}px` }
+      height={ `${height}px` }
+      viewBox={ `0 0 ${width} ${height}` }
+      onMouseMove={ move }
+      onMouseLeave={ out }
+    >
+      { children }
+    </svg>
+  );
 }
 
-SVG.ENABLED = typeof document !== 'undefined' &&
-              (!!document.createElementNS && !!document.createElementNS(_NS, 'svg').createSVGRect);
+SVG.propTypes = {
+  move: T.func,
+  out: T.func,
+  className: T.string,
+  width: T.number,
+  height: T.number,
+};
 
-SVG.ICON_SIZE = 20;
-
-export default SVG;
+SVG.defaultProps = {
+  width: ICON_SIZE,
+  height: ICON_SIZE,
+};


### PR DESCRIPTION
I'm not sure what mweb browers don't support SVG. This check was causing an error in the console which was a bit maddening. Removing it cleans up that warning and a bunch of code.

## Before
![screen shot 2016-07-28 at 5 14 27 pm](https://cloud.githubusercontent.com/assets/787203/17233699/d571573e-54e6-11e6-9af1-e983b3c0690c.png)

## After
![screen shot 2016-07-28 at 5 14 50 pm](https://cloud.githubusercontent.com/assets/787203/17233707/e065c436-54e6-11e6-89d1-d659e39bd27d.png)
Sweet relief.

:eyeglasses: @schwers @nramadas 