### PR TITLE
Sort and Time selectors. Doesn't include comment tree updates.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@r/platform": "~0.11.0",
     "@r/private": "~0.1.2",
     "@r/redux-state-archiver": "~0.0.5",
-    "@r/widgets": "^0.1.2",
+    "@r/widgets": "~0.2.2",
     "atob": "2.0.3",
     "autoprefixer": "6.3.6",
     "babel-polyfill": "^6.7.4",

--- a/src/app/components/CommentsPage/CommentsPageTools/index.jsx
+++ b/src/app/components/CommentsPage/CommentsPageTools/index.jsx
@@ -5,13 +5,38 @@ import { Anchor } from '@r/platform/components';
 import { urlFromPage } from '@r/platform/pageUtils';
 
 import CommentReplyForm from 'app/components/Comment/CommentReplyForm';
+import SortSelector from 'app/components/SortSelector';
+import { SORTS } from 'app/sortValues';
 
-export default ({ replying, currentPage, id }) => {
-  const replyHref = urlFromPage(currentPage, { queryParams: { commentReply: id } });
+
+export default ({ replying, currentPage, id, onSortChange }) => {
+  const { queryParams: { sort } } = currentPage;
+
+  const replyHref = urlFromPage(currentPage, {
+    queryParams: {
+      sort,
+      commentReply: id,
+    },
+  });
 
   return (
     <div className='CommentsPage__tools'>
       <div className='CommentsPage__tools_toolbar'>
+        <SortSelector
+          className='CommentsPage__tools_sortSelector'
+          id='comment-sort-selector'
+          title='Sort comments by:'
+          sortValue={ sort || SORTS.CONFIDENCE }
+          sortOptions={ [
+            SORTS.CONFIDENCE,
+            SORTS.TOP,
+            SORTS.NEW,
+            SORTS.CONTROVERSIAL,
+            SORTS.QA,
+          ] }
+          onSortChange={ onSortChange }
+        />
+
         <Anchor className='Button m-linkbutton' href={ replyHref }>
           Write a comment
         </Anchor>

--- a/src/app/components/CommentsPage/CommentsPageTools/styles.less
+++ b/src/app/components/CommentsPage/CommentsPageTools/styles.less
@@ -10,4 +10,10 @@
       float: right;
     }
   }
+
+  &_sortSelector {
+    float: left;
+    line-height: 1.5;
+    padding: 0.5em 1em;
+  }
 }

--- a/src/app/components/Dropdown/styles.less
+++ b/src/app/components/Dropdown/styles.less
@@ -3,10 +3,16 @@
 
 .Dropdown {
   width: 600px;
-
+  
   .themeify({
     border: @theme-border;
   });
+
+  &__arrow {
+    .themeify({
+      border-bottom-color: @theme-body-color !important; // tool tip uses inline-styles
+    });
+  }
 }
 
 .DropdownRow,
@@ -36,18 +42,44 @@
     width: 50px;
     text-align: center;
 
+    &.m-selected {
+      color: @blue;
+    }
+
+    &.icon-check-circled.m-selected {
+      color: @lime;
+    }
+
     &.icon-link {
       font-size: 36px;
     }
 
-    &.icon-snoosilhouette,
-    &.icon-user-account,
-    &.icon-save,
-    &.icon-hide,
-    &.icon-flag,
+    &.icon-check-circled,
     &.icon-delete_remove,
-    &.icon-posts {
+    &.icon-flag,
+    &.icon-hide,
+    &.icon-history,
+    &.icon-new,
+    &.icon-posts,
+    &.icon-save,
+    &.icon-snoosilhouette,
+    &.icon-user-account {
       font-size: 22px;
+    }
+
+    &.icon-bar-chart,
+    &.icon-hot,
+    &.icon-op {
+      font-size: 21px;
+    }
+
+    &.icon-karma {
+      font-size: 28px;
+    }
+
+    &.icon-circle {
+      font-size: 20px;
+      color: @pale-grey;
     }
 
     &.icon-save {

--- a/src/app/components/PostAndCommentList/index.jsx
+++ b/src/app/components/PostAndCommentList/index.jsx
@@ -56,7 +56,7 @@ const PostsCommentsAndPagination = props => {
   return (
     <div>
       { records.map(renderRecord) }
-      { records.length && <PaginationButtons records={ records } /> }
+      { records.length > 0 && <PaginationButtons records={ records } /> }
     </div>
   );
 };

--- a/src/app/components/SortAndTimeSelector/index.jsx
+++ b/src/app/components/SortAndTimeSelector/index.jsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { createSelector } from 'reselect';
+import * as navigationActions from '@r/platform/actions';
+import { METHODS } from '@r/platform/router';
+
+import { listingTime } from 'lib/listingTime';
+
+import SortSelector from 'app/components/SortSelector';
+import { SORTS } from 'app/sortValues';
+
+const T = React.PropTypes;
+
+const SortAndTimeSelector = props => {
+  const {
+    className,
+    sort,
+    sortOptions,
+    onSortChange,
+    time,
+    timeOptions,
+    onTimeChange,
+  } = props;
+
+  return (
+    <div className={ `SortAndTimeSelector ${className}` }>
+      <SortSelector
+        id='posts-sort-selector'
+        title='Sort posts by:'
+        sortValue={ sort }
+        sortOptions={ sortOptions }
+        onSortChange={ onSortChange }
+      />
+      { time &&
+        <SortSelector
+          id='posts-time-selector'
+          sortValue={ time }
+          sortOptions={ timeOptions }
+          onSortChange={ onTimeChange }
+        />
+      }
+    </div>
+  );
+};
+
+SortAndTimeSelector.propTypes = {
+  className: T.string,
+  onSortChange: T.func.isRequired,
+  onTimeChange: T.func.isRequired,
+  sort: SortSelector.sortType.isRequired,
+  sortOptions: SortSelector.sortOptionsType.isRequired,
+  time: SortSelector.sortType, // isn't required because the current page might
+  // not have a time filter active. We use the presence of this property
+  // to indicate a time selector should be shown.
+  timeOptions: SortSelector.sortOptionsType.isRequired,
+};
+
+SortAndTimeSelector.defaultProps = {
+  className: '',
+
+  sortOptions: [
+    SORTS.HOT,
+    SORTS.TOP,
+    SORTS.NEW,
+    SORTS.CONTROVERSIAL,
+  ],
+
+  timeOptions: [
+    SORTS.ALL_TIME,
+    SORTS.PAST_YEAR,
+    SORTS.PAST_MONTH,
+    SORTS.PAST_WEEK,
+    SORTS.PAST_DAY,
+    SORTS.PAST_HOUR,
+  ],
+};
+
+const mapStateToProps = createSelector(
+  state => state.platform.currentPage,
+  currentPage => ({ currentPage }),
+);
+
+const mapDispatchToProps = dispatch => ({
+  navigateToUrl(url, query) {
+    dispatch(navigationActions.navigateToUrl(METHODS.GET, url, query));
+  },
+});
+
+const mergeProps = (stateProps, dispatchProps, ownProps) => {
+  const { currentPage } = stateProps;
+  const { queryParams } = currentPage;
+  const { sort = SORTS.HOT } = queryParams;
+  const time = ownProps.time || listingTime(queryParams, sort);
+  const { navigateToUrl } = dispatchProps;
+
+  const onSortChange = sort => {
+    navigateToUrl(currentPage.url, {
+      queryParams: {
+        ...queryParams,
+        sort,
+      },
+    });
+  };
+
+  const onTimeChange = time => {
+    navigateToUrl(currentPage.url, {
+      queryParams: {
+        ...queryParams,
+        t: time,
+      },
+    });
+  };
+
+  return {
+    ...stateProps,
+    ...ownProps,
+    onSortChange,
+    onTimeChange,
+    sort,
+    time,
+  };
+};
+
+export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(SortAndTimeSelector);

--- a/src/app/components/SortSelector/index.jsx
+++ b/src/app/components/SortSelector/index.jsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { TooltipTarget } from '@r/widgets/tooltip';
+
+import './styles.less';
+import { SORTS, SORT_VALUES_MAP } from 'app/sortValues';
+import { Dropdown, DropdownRow } from 'app/components/Dropdown';
+
+const T = React.PropTypes;
+
+const getSortValue = sortValue => {
+  return SORT_VALUES_MAP[sortValue] ? sortValue : SORTS.CONFIDENCE;
+};
+
+export default function SortSelector(props) {
+  const {
+    id,
+    sortOptions,
+    sortValue,
+    onSortChange,
+    title,
+    className,
+  } = props;
+
+  return (
+    <div className={ `SortSelector ${className}` }>
+      <TooltipTarget
+        id={ id }
+        type={ TooltipTarget.TYPE.CLICK }
+      >
+        { renderCurrentSort(sortValue) }
+      </TooltipTarget>
+      <Dropdown id={ id } >
+        { title &&
+          <div className='SortSelector__title'>
+            { title.toUpperCase() }
+            <div className='SortSelector__title-separator' />
+          </div> }
+        { renderSortOptions(sortOptions, sortValue, onSortChange) }
+      </Dropdown>
+    </div>
+  );
+}
+
+const renderCurrentSort = currentSortValue => {
+  const sortValue = getSortValue(currentSortValue);
+  const { text, icon } = SORT_VALUES_MAP[sortValue];
+
+  return (
+    <div className='SortSelector__currentSort'>
+      { icon && renderCurrentIcon(sortValue) }
+      <span className='SortSelector__currentText'>{ text }</span>
+      <span className='SortSelector__currentCaron icon icon-caron' />
+    </div>
+  );
+};
+
+const renderCurrentIcon = sortName => {
+  let { icon } = SORT_VALUES_MAP[sortName];
+  if (icon === 'circle') { icon = 'history'; }
+  return <span className={ `SortSelector__currentIcon icon icon-${icon}` } />;
+};
+
+const renderSortOptions = (sortOptions, sortValue, onSortChange) => {
+  const currentSortValue = getSortValue(sortValue);
+
+  return sortOptions.map((sortName) => {
+    const selected = sortName === currentSortValue;
+
+    const { icon, text } = SORT_VALUES_MAP[sortName];
+    const iconName = icon === 'circle' && selected ? 'check-circled' : icon;
+
+    return (
+      <DropdownRow
+        key={ sortName }
+        onClick={ () => {
+          if (!selected) {
+            onSortChange(sortName);
+          }
+        } }
+        icon={ iconName }
+        text={ text }
+        isSelected={ selected }
+      />
+    );
+  });
+};
+
+SortSelector.sortType = T.oneOf(Object.values(SORTS));
+SortSelector.sortOptionsType = T.arrayOf(SortSelector.sortType);
+
+SortSelector.propTypes = {
+  className: T.string,
+  id: T.string.isRequired, // Tooltip target id
+  sortOptions: SortSelector.sortOptionsType.isRequired,
+  sortValue: SortSelector.sortType.isRequired,
+  onSortChange: T.func.isRequired,
+  title: T.string,
+};
+
+SortSelector.defaultProps = {
+  className: '',
+  title: 'Sort by:',
+  onSortChange: () => {},
+};

--- a/src/app/components/SortSelector/styles.less
+++ b/src/app/components/SortSelector/styles.less
@@ -1,0 +1,51 @@
+@import (reference) '~app/less/variables';
+@import (reference) '~app/less/themes/themeify';
+
+.SortSelector {
+  display: inline-block;
+
+  & + & {
+    margin-left: 2 * @grid-size;
+  }
+
+  &__currentIcon,
+  &__currentText,
+  &__currentCaron {
+    vertical-align: middle;
+    display: inline-block;
+  }
+
+  &__currentIcon {
+    width: 3 * @grid-size;
+  }
+
+  &__currentText {
+    color: @grey-text;
+    padding-right: @grid-size;
+  }
+
+  &__currentCaron {
+    color: @grey-text;
+  }
+
+  &__title {
+    padding: @grid-size @grid-size 0;
+    font-size: 10px;
+    line-height: 3 * @grid-size;
+    letter-spacing: 1.5;
+    font-weight: bold;
+
+    .themeify({
+      background-color: @theme-body-color;
+      color: @theme-meta-text-color;
+    });
+  }
+
+  &__title-separator {
+    margin-top: @grid-size;
+
+    .themeify({
+      border-top: @theme-alt-border;
+    });
+  }
+}

--- a/src/app/components/SubNav/index.js
+++ b/src/app/components/SubNav/index.js
@@ -21,20 +21,22 @@ const sidebarOrLoginLink = (rightLink, hasUser) => {
   }
 
   if (!hasUser) {
-    // TODO: need to get config set up in a reducer somewhere
     return subnavRightLink('/login', 'Log in / Register');
   }
 };
 
 export const SubNav = props => {
-  const { user, rightLink, showWithoutUser } = props;
+  const { user, rightLink, showWithoutUser, children } = props;
 
-  if (user && !(rightLink && showWithoutUser)) {
+  if (user && !(rightLink && showWithoutUser) && !children) {
     return null;
   }
 
   return (
     <nav className='SubNav'>
+      <div className='SubNav__leftContent'>
+        { children }
+      </div>
       <div className='SubNav__navLink'>
         { sidebarOrLoginLink(rightLink, !!user) }
       </div>

--- a/src/app/pages/PostsFromSubreddit.jsx
+++ b/src/app/pages/PostsFromSubreddit.jsx
@@ -6,6 +6,7 @@ import CommunityHeader from 'app/components/CommunityHeader';
 import Loading from 'app/components/Loading';
 import PostsList from 'app/components/PostsList';
 import NSFWInterstitial from 'app/components/NSFWInterstitial';
+import SortAndTimeSelector from 'app/components/SortAndTimeSelector';
 import SubNav from 'app/components/SubNav';
 
 import PostsFromSubredditHandler from 'app/router/handlers/PostsFromSubreddit';
@@ -22,6 +23,7 @@ const mapStateToProps = createSelector(
     const postsListParams = PostsFromSubredditHandler.pageParamsToSubredditPostsParams(pageProps);
     const postsListId = paramsToPostsListsId(postsListParams);
     const { subredditName } = postsListParams;
+
     return {
       postsListId,
       postsList: postsLists[postsListId],
@@ -34,7 +36,14 @@ const mapStateToProps = createSelector(
 
 // props is pageData
 export const PostsFromSubredditPage = connect(mapStateToProps)(props => {
-  const { postsListId, postsList, subredditName, subreddit, preferences } = props;
+  const {
+    postsListId,
+    postsList,
+    subredditName,
+    subreddit,
+    preferences,
+  } = props;
+
   const renderSubnav = !!postsList && !postsList.loading;
   const forFakeSubreddit = isFakeSubreddit(subredditName);
   const subnavLink = forFakeSubreddit ? null : {
@@ -76,7 +85,9 @@ export const PostsFromSubredditPage = connect(mapStateToProps)(props => {
         <SubNav
           rightLink={ subnavLink }
           showWithoutUser={ true }
-        /> }
+        >
+          <SortAndTimeSelector />
+        </SubNav> }
       <PostsList
         postsListId={ postsListId }
         subredditIsNSFW={ !!subreddit && subreddit.over18 }

--- a/src/app/pages/SearchPage/index.jsx
+++ b/src/app/pages/SearchPage/index.jsx
@@ -13,6 +13,8 @@ import CommunityRow from 'app/components/CommunityRow';
 import PaginationButtons from 'app/components/PaginationButtons';
 import Loading from 'app/components/Loading';
 import { PostsList } from 'app/components/PostsList';
+import SortAndTimeSelector from 'app/components/SortAndTimeSelector';
+
 // This is intentionally the non-connected version because search requests aren't loaded in the same
 // way as subreddit listings
 
@@ -134,35 +136,7 @@ const linksHeader = (/*sort, time*/) => (
   <div className='SearchPage__linksHeader clearfix'>
   <div className='SearchPage__linksHeaderTitle'>Posts</div>
   <div className='SearchPage__linksHeaderTools'>
-    <div className='SearchPage__linksHeaderSort'>
-      {/*<SortSelector
-        app={ app }
-        sortValue={ sort }
-        sortOptions={ [
-          SORTS.RELEVANCE,
-          SORTS.HOT,
-          SORTS.NEW,
-          SORTS.TOP,
-          SORTS.COMMENTS,
-        ] }
-        onSortChange={ this.handleSortChange }
-      />*/}
-    </div>
-    <div className='SearchPage__linksHeaderSort'>
-      {/*<SortSelector
-        app={ app }
-        sortValue={ time }
-        sortOptions={ [
-          SORTS.ALL_TIME,
-          SORTS.PAST_YEAR,
-          SORTS.PAST_MONTH,
-          SORTS.PAST_WEEK,
-          SORTS.PAST_DAY,
-          SORTS.PAST_HOUR,
-        ] }
-        onSortChange={ this.handleTimeChange }
-      />*/}
-    </div>
+    <SortAndTimeSelector />
   </div>
 </div>
 );

--- a/src/app/pages/UserActivity/index.jsx
+++ b/src/app/pages/UserActivity/index.jsx
@@ -4,6 +4,8 @@ import { createSelector } from 'reselect';
 
 import { UserProfileHeader } from 'app/components/UserProfileHeader';
 import PostAndCommentList from 'app/components/PostAndCommentList';
+import SortAndTimeSelector from 'app/components/SortAndTimeSelector';
+
 import { Section } from '../UserProfile';
 
 import { userAccountSelector } from 'app/selectors/userAccount';
@@ -40,6 +42,7 @@ export const UserActivityPage = connect(mapStateToProps)(props => {
           currentActivity={ currentActivity }
         />
       </Section>
+      <SortAndTimeSelector className='UserProfilePage__sorts' />
       <PostAndCommentList
         requestLocation='activitiesRequests'
         requestId={ activitiesId }

--- a/src/app/pages/UserProfile/styles.less
+++ b/src/app/pages/UserProfile/styles.less
@@ -29,7 +29,7 @@
 
     &, &:visited, &:hover {
       text-decoration: none;
-      
+
       .themeify({
         color: @theme-body-text-color;
       });
@@ -40,5 +40,9 @@
     margin-right: 2 * @grid-size;
     position: relative;
     top: -2px;
+  }
+
+  &__sorts {
+    padding: 0.5em 1em;
   }
 }

--- a/src/app/router/handlers/CommentsPage.js
+++ b/src/app/router/handlers/CommentsPage.js
@@ -39,7 +39,6 @@ export default class CommentsPage extends BaseHandler {
     });
   }
 
-
   async [METHODS.GET](dispatch, getState) {
     const state = getState();
     if (state.platform.shell) { return; }

--- a/src/app/router/handlers/PostsFromSubreddit.js
+++ b/src/app/router/handlers/PostsFromSubreddit.js
@@ -5,12 +5,13 @@ import * as subredditActions from 'app/actions/subreddits';
 import { paramsToPostsListsId } from 'app/models/PostsList';
 
 import { cleanObject } from 'lib/cleanObject';
+import { listingTime } from 'lib/listingTime';
 import { fetchUserBasedData } from './handlerCommon';
 
 export default class PostsFromSubreddit extends BaseHandler {
   static pageParamsToSubredditPostsParams({ urlParams, queryParams}) {
     const { multi, multiUser } = urlParams;
-    const { sort, t, after, before } = queryParams;
+    const { sort, after, before } = queryParams;
     let { subredditName } = urlParams;
     subredditName = subredditName ? subredditName.toLowerCase() : null;
 
@@ -19,7 +20,7 @@ export default class PostsFromSubreddit extends BaseHandler {
       multi,
       multiUser,
       sort,
-      t,
+      t: listingTime(queryParams, sort),
       after,
       before,
     });

--- a/src/app/router/handlers/SearchPage.js
+++ b/src/app/router/handlers/SearchPage.js
@@ -18,7 +18,7 @@ const searchPath = (subredditOrNil) => {
 };
 
 const SORT = 'sort';
-const TIME = 'time';
+const TIME = 't';
 const TYPE = 'type';
 
 const DEFUALT_PARAMS = {
@@ -50,12 +50,12 @@ export default class SearchPage extends BaseHandler {
   static pageParamsToSearchRequestParams({ urlParams, queryParams }) {
     const { q, after, before } = queryParams;
     const sort = getDefaultable(SORT, queryParams);
-    const time = getDefaultable(TIME, queryParams);
+    const t = getDefaultable(TIME, queryParams);
     const type = getDefaultable(TYPE, queryParams);
     const { subredditName } = urlParams;
 
     return cleanObject({
-      q, after, before, sort, time, type, subreddit: subredditName,
+      q, after, before, sort, t, type, subreddit: subredditName,
     });
   }
 

--- a/src/app/router/handlers/UserActivity.js
+++ b/src/app/router/handlers/UserActivity.js
@@ -5,6 +5,7 @@ import { SORTS } from 'app/sortValues';
 import { POSTS_ACTIVITY } from 'app/actions/activities';
 import * as activitiesActions from 'app/actions/activities';
 import { fetchUserBasedData } from './handlerCommon';
+import { listingTime } from 'lib/listingTime';
 import { urlWith } from 'lib/urlWith';
 
 export default class UserActivityHandler extends BaseHandler {
@@ -15,10 +16,12 @@ export default class UserActivityHandler extends BaseHandler {
   static pageParamsToActivitiesParams({ urlParams, queryParams }) {
     const { userName } = urlParams;
     const { sort=SORTS.CONFIDENCE, activity=POSTS_ACTIVITY, before, after } = queryParams;
+    const t = listingTime(queryParams, sort);
 
     return cleanObject({
       user: userName,
       sort,
+      t,
       activity,
       before,
       after,

--- a/src/app/sortValues.js
+++ b/src/app/sortValues.js
@@ -21,86 +21,86 @@ export const SORTS = {
 export const SORT_VALUES_MAP = {
   [SORTS.CONFIDENCE]: {
     text: 'Best',
-    icon: 'icon-hot',
+    icon: 'hot',
   },
 
   [SORTS.HOT]: {
     text: 'Hot',
-    icon: 'icon-hot',
+    icon: 'hot',
   },
 
   [SORTS.NEW]: {
     text: 'New',
-    icon: 'icon-new',
+    icon: 'new',
   },
 
   [SORTS.RISING]: {
     text: 'Rising',
-    icon: 'icon-hot',
+    icon: 'hot',
   },
 
   [SORTS.TOP]: {
     text: 'Top',
-    icon: 'icon-bar-chart',
+    icon: 'bar-chart',
   },
 
   [SORTS.CONTROVERSIAL]: {
     text: 'Controversial',
-    icon: 'icon-controversial',
+    icon: 'controversial',
   },
 
   [SORTS.OLD]: {
     text: 'Old',
-    icon: 'icon-text',
+    icon: 'text',
   },
 
   [SORTS.QA]: {
     text: 'Q&A',
-    icon: 'icon-op',
+    icon: 'op',
   },
 
   [SORTS.GILDED]: {
     text: 'Gilded',
-    icon: 'icon-gold',
+    icon: 'gold',
   },
 
   [SORTS.RELEVANCE]: {
     text: 'Relevance',
-    icon: 'icon-bar-chart',
+    icon: 'bar-chart',
   },
 
   [SORTS.COMMENTS]: {
     text: 'Comments',
-    icon: 'icon-comments',
+    icon: 'comments',
   },
 
   [SORTS.ALL_TIME]: {
     text: 'All Time',
-    icon: 'icon-circle',
+    icon: 'circle',
   },
 
   [SORTS.PAST_YEAR]: {
     text: 'Past Year',
-    icon: 'icon-circle',
+    icon: 'circle',
   },
 
   [SORTS.PAST_MONTH]: {
     text: 'Past Month',
-    icon: 'icon-circle',
+    icon: 'circle',
   },
 
   [SORTS.PAST_WEEK]: {
     text: 'Past Week',
-    icon: 'icon-circle',
+    icon: 'circle',
   },
 
   [SORTS.PAST_DAY]: {
     text: 'Past Day',
-    icon: 'icon-circle',
+    icon: 'circle',
   },
 
   [SORTS.PAST_HOUR]: {
     text: 'Past Hour',
-    icon: 'icon-circle',
+    icon: 'circle',
   },
 };

--- a/src/lib/listingTime.js
+++ b/src/lib/listingTime.js
@@ -1,0 +1,9 @@
+import { SORTS } from 'app/sortValues';
+
+const TIME_FILTERABLE_SORTS = new Set([SORTS.TOP, SORTS.CONTROVERSIAL]);
+
+export const listingTime = (query, sort)=> {
+  if (TIME_FILTERABLE_SORTS.has(sort)) {
+    return query.t || query.time || SORTS.PAST_DAY;
+  }
+};


### PR DESCRIPTION
(edit: widgets patch merged, no longer dependent)

This patch adds sorting and time filtering selectors for lists of posts and comments. Comments don't completely work, but are included to get an MVP of this feature into 2X. Comments will need some api work, because the comment tree is stored ad-hoc in each individual comments' `.replies` field. e.g. Go to a comments page sorted by best (a), change sort to top (b), and then back to best (c). You may notice on page (c) that some comment replies aren't ordered the same as page (a) even though they have the same exact sort.