### PR TITLE
Prevent client retrying 4XX statuses too

### DIFF
--- a/assets/js/client.es6.js
+++ b/assets/js/client.es6.js
@@ -132,7 +132,7 @@ function initialize(bindLinks) {
   };
 
   const serverStatus = bootstrap.ctx ? bootstrap.ctx.status : 500;
-  if (serverStatus >= 500 && serverStatus < 600) {
+  if (serverStatus >= 400 && serverStatus < 600) {
     // If there was any errors on the server, we don't want to automatically
     // retry requests on the client. This increases server load when we know
     // something is probably wrong at the moment and is exacerbated by us


### PR DESCRIPTION
From the logs, we seem to get a surprising number of 401s and 404s. In both cases we're autoretrying on the client which defeats the purpose of https://github.com/reddit/reddit-mobile/pull/666, and in the 404 case we often will get the same 404 response back on the client anyway. 

👓  @nramadas 