### PR TITLE
Handle comment threads that are too deep

### DIFF
--- a/assets/less/components/comment/Comment.less
+++ b/assets/less/components/comment/Comment.less
@@ -46,7 +46,8 @@
   }
 
   &__reply,
-  &__seemore {
+  &__seemore,
+  &__continuethisthread {
     margin-top: @grid-size;
     padding-top: @grid-size;
     .themeify({

--- a/assets/less/components/comment/CommentContinueThisThread.less
+++ b/assets/less/components/comment/CommentContinueThisThread.less
@@ -1,0 +1,26 @@
+.CommentContinueThisThread {
+  &__caron,
+  &__msg,
+  &__dots {
+    display: inline-block;
+    vertical-align: middle;
+  }
+  
+  &__caron {
+    margin-right: @grid-size;
+    transform: rotate(-90deg);
+    
+    &[class*=" icon-"] {
+      color: @blue;
+    }
+  }
+  
+  &__msg {
+    color: @blue;
+  }
+  
+  &__dots {
+    margin-right: @half-grid-size;
+    color: @blue;
+  }
+}

--- a/assets/less/components/comment/importAll.less
+++ b/assets/less/components/comment/importAll.less
@@ -3,3 +3,4 @@
 @import "./CommentTools.less";
 @import "./CommentReplyForm.less";
 @import "./CommentSeeMore.less";
+@import "./CommentContinueThisThread.less";

--- a/src/views/components/comment/Comment.jsx
+++ b/src/views/components/comment/Comment.jsx
@@ -11,6 +11,7 @@ import CommentHeader from './CommentHeader';
 import CommentTools from './CommentTools';
 import CommentReplyForm from './CommentReplyForm';
 import CommentSeeMore from './CommentSeeMore';
+import CommentContinueThisThread from './CommentContinueThisThread';
 import CommentEditForm from './CommentEditForm';
 
 const T = React.PropTypes;
@@ -643,13 +644,28 @@ export default class Comment extends BaseComponent {
       );
     }
 
+    const dots = Math.max(nestingLevel - 6, 0);
+
+    if (reply.count === 0) {
+      const { comment, permalinkBase } = this.props;
+      const dest = `${permalinkBase}${comment.id}`;
+      return (
+        <div className='Comment__continuethisthread' key={ reply.id } >
+          <CommentContinueThisThread
+            dest={ dest }
+            dots={ dots }
+          />
+        </div>
+      );
+    }
+
     return (
       <div className='Comment__seemore' key={ reply.id } >
         <CommentSeeMore
           count={ reply.count }
           isLoading={ loadingMoreComments }
           onLoadMore={ replyCallback }
-          dots={ Math.max(nestingLevel - 6, 0) }
+          dots={ dots }
         />
       </div>
     );

--- a/src/views/components/comment/CommentContinueThisThread.jsx
+++ b/src/views/components/comment/CommentContinueThisThread.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import fill from 'lodash/array/fill';
+
+const T = React.PropTypes;
+
+const LOADING_MSG = 'Continue this thread';
+
+function renderDots(count) {
+  const content = fill(Array(count), '•').join(' ');
+
+  return <div className='CommentContinueThisThread__dots'>{ content }</div>;
+}
+
+function CommentContinueThisThread(props) {
+  return (
+    <a href={ props.dest } className='CommentContinueThisThread'>
+      { props.dots ? renderDots(props.dots) : null }
+      <div className='CommentContinueThisThread__caron icon-caron-circled' />
+    <div className='CommentContinueThisThread__msg'>{ LOADING_MSG }</div>
+    </a>
+  );
+}
+
+CommentContinueThisThread.propTypes = {
+  dest: T.string.isRequired,
+  dots: T.number,
+};
+
+CommentContinueThisThread.defaultProps = {
+  dots: 0,
+};
+
+export default CommentContinueThisThread;


### PR DESCRIPTION
When a comment thread goes deeper than the maximum
levels to render a tree, it was displaying
"More comments (0)" and the action was failing.

This makes it so the behavior is more in line with
the desktop site in which it will load the comment
tree from the given point after clicking a
"Continue this thread" message.

This is how desktop handles it:
![screen shot 2016-08-10 at 5 44 40 pm](https://cloud.githubusercontent.com/assets/25475/17575957/f383e80e-5f22-11e6-970e-6a21f0ded4ed.png)

This is how it's currently handled:
![screen shot 2016-08-10 at 5 44 22 pm](https://cloud.githubusercontent.com/assets/25475/17575959/0083b516-5f23-11e6-87b7-bcd173fd52ae.png)

This is if you click on it right now:
![screen shot 2016-08-10 at 5 43 46 pm](https://cloud.githubusercontent.com/assets/25475/17575963/0d583e06-5f23-11e6-82c8-d0a2f1ed1615.png)

This is after the change:
![screen shot 2016-08-10 at 5 45 01 pm](https://cloud.githubusercontent.com/assets/25475/17575974/1e790300-5f23-11e6-89b5-86cd617a8890.png)

👓 @schwers @phil303 