### PR TITLE
Remove permalinkBase as it's not used.

### DIFF
--- a/src/app/components/Comment/index.jsx
+++ b/src/app/components/Comment/index.jsx
@@ -118,7 +118,6 @@ function renderBody(props) {
 function renderTools(props) {
   const {
     user,
-    permalinkBase,
     comment,
     commentCollapsed,
     currentPage,
@@ -144,7 +143,7 @@ function renderTools(props) {
           saved={ comment.saved }
           currentPage = { currentPage }
           replying={ commentReplying }
-          permalinkUrl={ `${permalinkBase}${comment.id}` }
+          permalinkUrl={ comment.cleanPermalink }
           onEdit={ onToggleEditForm }
           onDelete={ onDeleteComment }
           onToggleSave={ onToggleSaveComment }
@@ -183,7 +182,7 @@ function renderCommentReply(props) {
 }
 
 function renderReplies(props) {
-  const { op, nestingLevel, comment, permalinkBase, commentCollapsed } = props;
+  const { op, nestingLevel, comment, commentCollapsed } = props;
 
   let cls = 'Comment__replies';
   if (commentCollapsed) { cls += ' m-hidden'; }
@@ -201,7 +200,6 @@ function renderReplies(props) {
         op={ op }
         commentRecords={ comment.replies }
         parentComment={ comment }
-        permalinkBase={ permalinkBase }
         nestingLevel={ nestingLevel + 1 }
       />
       { renderLoadMore(comment, props.loadMore) }
@@ -216,7 +214,6 @@ Comment.propTypes = {
   user: T.object,
   op: T.string,
   nestingLevel: T.number,
-  permalinkBase: T.string,
   repliesLocked: T.bool,
   highlightedComment: T.string,
   isEditing: T.bool,

--- a/src/app/pages/Comments.jsx
+++ b/src/app/pages/Comments.jsx
@@ -36,10 +36,8 @@ const stateProps = createSelector(
       ? []
       : commentsPage.results;
 
-    const permalinkBase = pageProps.url;
     const post = posts[commentsPageParams.id];
     const postLoaded = !!post;
-
     const replying = currentPage.queryParams.commentReply === commentsPageParams.id;
 
     return {
@@ -48,7 +46,6 @@ const stateProps = createSelector(
       commentsPageParams,
       commentsPage,
       commentsPageId,
-      permalinkBase,
       topLevelComments,
       currentPage,
       replying,
@@ -89,7 +86,6 @@ export const CommentsPage = connect(stateProps, dispatchProps, mergeProps)(props
     commentsPage,
     commentsPageParams,
     topLevelComments,
-    permalinkBase,
     postLoaded,
     currentPage,
     replying,
@@ -118,7 +114,6 @@ export const CommentsPage = connect(stateProps, dispatchProps, mergeProps)(props
         <CommentsList
           op={ op }
           commentRecords={ topLevelComments }
-          permalinkBase={ permalinkBase }
           className={ 'CommentsList__topLevel' }
         /> }
 


### PR DESCRIPTION
The comment model has the permalink as a
cleanPermalink attribute, so use that rather
than constructing it.

👓 @schwers @phil303 