### PR TITLE
Add the amphtml link element for self posts

### DIFF
--- a/src/config.es6.js
+++ b/src/config.es6.js
@@ -60,6 +60,7 @@ function config() {
     statsURL: process.env.STATS_URL || 'https://stats.redditmedia.com/',
     mediaDomain: process.env.MEDIA_DOMAIN || 'www.redditmedia.com',
     adsPath: process.env.ADS_PATH || '/api/request_promo.json',
+    amp: process.env.AMP,
     manifest: {},
 
     trackerKey: process.env.TRACKER_KEY,

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -498,6 +498,15 @@ function routes(app) {
       props.data.set('canonical', canonical);
     }
 
+    const ampURL = listingPromise.then(listing => {
+      // Check if this is a self post. If so, add the amphtml link element.
+      if (config.amp && listing.is_self) {
+        props.ampURL = `${config.amp}${listing.permalink}`;
+        return props.ampURL;
+      }
+    });
+    props.data.set('ampURL', ampURL);
+
     const relevantPromise = featureWithUserContext(props).then(feature => {
       if (feature.enabled(constants.flags.VARIANT_RELEVANCY_TOP) ||
           feature.enabled(constants.flags.VARIANT_NEXTCONTENT_BOTTOM) ||

--- a/src/views/layouts/DefaultLayout.jsx
+++ b/src/views/layouts/DefaultLayout.jsx
@@ -32,6 +32,11 @@ function DefaultLayout (props) {
     );
   }
 
+  const { ampURL } = props;
+  const ampLink = ampURL ? (
+    <link rel='amphtml' href={ ampURL } />
+  ) : null;
+
   let metaDescription;
 
   if (props.metaDescription) {
@@ -78,6 +83,7 @@ function DefaultLayout (props) {
         <title>{ props.title }</title>
         <link href={ baseCSS } rel='stylesheet' />
         { canonical }
+        { ampLink }
 
         <meta
           name='viewport'


### PR DESCRIPTION
For self post pages rendered on the server, we need to add a link
element pointing to the equivalent AMP page, which is how we make the
AMP page visible to the world. Without a configured value, we will not
include an element, so this can be turned on/off via the AMP environment
variable.