### PR TITLE
Change badly named css selector

### DIFF
--- a/src/app/components/ErrorPage/index.jsx
+++ b/src/app/components/ErrorPage/index.jsx
@@ -27,10 +27,10 @@ const ErrorPage = props => {
   const errorContent = ERROR_MAP[String(props.status)] || ERROR_GENERIC;
 
   return (
-    <div className='Error BelowTopNav'>
-      <div className='Error__image' />
-      <div className='Error__error'>{ errorContent } </div>
-      <Anchor href={ href } className='Error__redirect-anchor'>
+    <div className='ErrorPage BelowTopNav'>
+      <div className='ErrorPage__image' />
+      <div className='ErrorPage__error'>{ errorContent } </div>
+      <Anchor href={ href } className='ErrorPage__redirect-anchor'>
         { anchorContent }
       </Anchor>
     </div>

--- a/src/app/components/ErrorPage/styles.less
+++ b/src/app/components/ErrorPage/styles.less
@@ -1,4 +1,4 @@
-.Error {
+.ErrorPage {
   text-align: center;
   font-size: 16px;
   padding-top: 1px;


### PR DESCRIPTION
`Error` is far too generic a term so make this selector more specific by calling it `ErrorPage`.