### PR TITLE
Hide GoldInfo if user has no gold

### DIFF
--- a/src/app/components/UserProfileSummary/index.jsx
+++ b/src/app/components/UserProfileSummary/index.jsx
@@ -30,9 +30,7 @@ export const UserProfileSummary = props => {
           <UserProfileBadgeIcon iconName='cake' color='mint' />
         </UserProfileBadge>
       </UserProfileRow>
-      <UserProfileRow>
-        <GoldInfo { ...props } />
-      </UserProfileRow>
+      <GoldInfo { ...props } />
     </div>
   );
 };
@@ -46,13 +44,17 @@ const GoldInfo = props => {
   const { user, isMyUser } = props;
 
   if (isMyUser) {
+    if (!user.goldExpiration) { return null; }
+
     return (
-      <UserProfileBadge
-        text={ long(user.goldExpiration) }
-        subtext='of reddit gold remaining'
-      >
-        <UserProfileBadgeIcon iconName='gold-snoo' color='gold' />
-      </UserProfileBadge>
+      <UserProfileRow>
+        <UserProfileBadge
+          text={ long(user.goldExpiration) }
+          subtext='of reddit gold remaining'
+        >
+          <UserProfileBadgeIcon iconName='gold-snoo' color='gold' />
+        </UserProfileBadge>
+      </UserProfileRow>
     );
   }
 


### PR DESCRIPTION
👓 @phil303 @nramadas 

This is how it is:

<img width="402" alt="screen shot 2016-08-19 at 11 06 34 am" src="https://cloud.githubusercontent.com/assets/25475/17819510/218de408-65fd-11e6-9720-8d03a0ff97d3.png">

This is how the patch makes it:

<img width="416" alt="screen shot 2016-08-19 at 11 06 43 am" src="https://cloud.githubusercontent.com/assets/25475/17819517/2906a94a-65fd-11e6-9c65-a29355539229.png">

An alternative would be a variant of what we do if you view someone else's profile:

<img width="401" alt="screen shot 2016-08-19 at 11 06 54 am" src="https://cloud.githubusercontent.com/assets/25475/17819539/41a5ffc8-65fd-11e6-9737-f10f8df3b83f.png">

Instead of "give foo gold", it could be a "Buy gold"... which, granted isn't implemented yet.