### PR TITLE
Resolve data promises with non-undefined

### DIFF
--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -504,6 +504,7 @@ function routes(app) {
         props.ampURL = `${config.amp}${listing.permalink}`;
         return props.ampURL;
       }
+      return '';
     });
     props.data.set('ampURL', ampURL);
 


### PR DESCRIPTION
We assume that promise values in `props.data` will resolve to objects,
so we should avoid resolving them with `undefined`, even if we we're in
a situation where the value has become irrelevant.