### PR TITLE
Make page no. visible in URL bar.

### DIFF
--- a/src/views/components/listings/ListingPaginationButtons.jsx
+++ b/src/views/components/listings/ListingPaginationButtons.jsx
@@ -41,8 +41,8 @@ export default class ListingPaginationButtons extends BaseComponent {
     if (page > 0) {
       const prevQuery = {
         ...ctx.query,
-        count: 25,
         page: page - 1,
+        count: 25,
         before: firstId,
         after: undefined,
       };
@@ -59,8 +59,8 @@ export default class ListingPaginationButtons extends BaseComponent {
 
     const nextQuery = {
       ...props.ctx.query,
-      count: 25,
       page: page + 1,
+      count: 25,
       after: lastId,
       before: undefined,
     };


### PR DESCRIPTION
This makes it easier to glance up and see how much time you've
wasted browsing /r/all. The desktop site has an incrementing count
as its first URL argument too, and I miss it when I'm on mobile.
