### PR TITLE
Allow users to login in with reddit.com session cookies

### DIFF
--- a/src/server/session/dispatchSession.js
+++ b/src/server/session/dispatchSession.js
@@ -10,36 +10,37 @@ export default async (ctx, dispatch, apiOptions) => {
   // try to create a session from the existing cookie
   // if the session is malformed somehow, the catch will trigger when trying
   // to access it
-  const tokenCookie = ctx.cookies.get('token');
-  const redditSessionExists = ctx.cookies.get('reddit_session');
-  if (!(tokenCookie || redditSessionExists)) {
-    return;
-  }
+  const token = ctx.cookies.get('token');
+  const redditSession = ctx.cookies.get('reddit_session');
 
   let session;
   let sessionData;
 
-  if (tokenCookie) {
-    sessionData = JSON.parse(atob(tokenCookie));
+  if (token) { // if we're working with the new session type
+    sessionData = JSON.parse(atob(token));
     session = new Session(sessionData);
-  } else {
-    // try to convert reddit session cookie
-    const cookies = ctx.headers.cookie.replace(/__cf_mob_redir=1/, '__cf_mob_redir=0').split(';');
-    sessionData = await PrivateAPI.convertCookiesToAuthToken(apiOptions, cookies);
+  } else if (redditSession) { // we detect a legacy reddit.com session
+    const cookies = ctx.headers.cookie.replace('__cf_mob_redir=1', '__cf_mob_redir=0').split(';');
+    sessionData = makeSessionFromData(await PrivateAPI.convertCookiesToAuthToken(apiOptions, cookies));
     session = new Session(sessionData);
+
+    // since we converted a legacy session into a 2X token, we want to make sure
+    // we forward the new cookies for the token
+    setSessionCookies(ctx, session);
   }
 
   // if the session is invalid, try to use the refresh token to grab a new
   // session.
-  if (!session.isValid) {
+  if (session && sessionData && !session.isValid) {
     const data = await PrivateAPI.refreshToken(apiOptions, sessionData.refreshToken);
-    session = makeSessionFromData({ ...data, refresh_token: sessionData.refreshToken });
+    session = makeSessionFromData({ refresh_token: sessionData.refreshToken, ...data });
 
     // don't forget to set the cookies with the new session, or the session
     // will remain invalid the next time the page is fetched
     setSessionCookies(ctx, session);
   }
 
-  // push the session into the store
-  dispatch(sessionActions.setSession(session));
+  if (session && session.isValid) {
+    dispatch(sessionActions.setSession(session));
+  }
 };


### PR DESCRIPTION
This is largely just copied over from what works in modmail. Essentially, it allows users that have a reddit_session cookie (set by reddit.com) to automatically log in to 2X.

:eyeglasses: @phil303 @schwers @uzi 