### PR TITLE
Set the token, loid, and loid_created to the root domain.

### DIFF
--- a/src/Server.js
+++ b/src/Server.js
@@ -19,6 +19,7 @@ import logoutproxy from 'server/session/logoutproxy';
 import registerproxy from 'server/session/registerproxy';
 import refreshproxy from 'server/session/refreshproxy';
 import dispatchSession from 'server/session/dispatchSession';
+import { clearDeprecatedCookies } from 'server/initialState/clearDeprecatedCookies';
 import { dispatchInitialCompact } from 'server/initialState/dispatchInitialCompact';
 import { dispatchInitialLoid } from 'server/initialState/dispatchInitialLoid';
 import { dispatchInitialMeta } from 'server/initialState/dispatchInitialMeta';
@@ -84,6 +85,7 @@ export function startServer() {
     reduxMiddleware,
     dispatchBeforeNavigation: async (ctx, dispatch/*, getState, utils*/) => {
       dispatchInitialShell(ctx, dispatch);
+      clearDeprecatedCookies(ctx);
       dispatchInitialLoid(ctx, dispatch);
       await dispatchSession(ctx, dispatch, ConfigedAPIOptions);
       dispatchInitialTheme(ctx, dispatch);

--- a/src/config.js
+++ b/src/config.js
@@ -34,6 +34,7 @@ const config = () => ({
 
   statsURL: process.env.STATS_URL || 'https://stats.redditmedia.com/',
   reduxActionLogSize: process.env.REDUX_ACTION_LOG_SIZE || 50,
+  rootCookieDomain: process.env.ROOT_COOKIE_DOMAIN || 'localhost',
   mediaDomain: process.env.MEDIA_DOMAIN || 'www.redditmedia.com',
   adsPath: process.env.ADS_PATH || '/api/request_promo.json',
   manifest: {},

--- a/src/lib/loid.js
+++ b/src/lib/loid.js
@@ -1,3 +1,4 @@
+import globalConfig from 'config';
 import randomString from './randomString';
 
 export function setLoggedOutCookies(cookies, config) {
@@ -7,6 +8,7 @@ export function setLoggedOutCookies(cookies, config) {
   const options = {
     secure: config.https,
     secureProxy: config.httpsProxy,
+    domain: globalConfig.rootCookieDomain,
     httpOnly: false,
     maxAge: 1000 * 60 * 60 * 24 * 365 * 2,
   };

--- a/src/server/initialState/clearDeprecatedCookies.js
+++ b/src/server/initialState/clearDeprecatedCookies.js
@@ -1,0 +1,10 @@
+export const clearDeprecatedCookies = (ctx) => {
+  // these cookies are deprecated on non root domains.
+  ctx.cookies.set('loid');
+  ctx.cookies.set('loidcreated');
+  ctx.cookies.set('token');
+
+  ctx.cookies.set('tokenExpires');
+  ctx.cookies.set('refreshToken');
+  ctx.cookies.set('reddit_session');
+};

--- a/src/server/session/logoutproxy.js
+++ b/src/server/session/logoutproxy.js
@@ -1,10 +1,9 @@
+import config from 'config';
+
 export default (router) => {
   router.post('/logout', async (ctx/*, next*/) => {
-    ctx.cookies.set('token');
-    ctx.cookies.set('tokenExpires');
-    ctx.cookies.set('refreshToken');
+    ctx.cookies.set('token', '', { domain: config.rootCookieDomain });
     ctx.cookies.set('over18');
-    ctx.cookies.set('reddit_session');
     ctx.cookies.set('compact');
     ctx.cookies.set('theme');
     ctx.redirect('/');

--- a/src/server/session/setSessionCookies.js
+++ b/src/server/session/setSessionCookies.js
@@ -1,8 +1,11 @@
+import config from 'config'
+
 const COOKIE_OPTIONS = {
   // signed: true,
   httpOnly: false,
   overwrite: true,
   maxAge: 1000 * 60 * 60,
+  domain: config.rootCookieDomain,
 };
 
 export default (ctx, session) => {


### PR DESCRIPTION
At a high level the reason this PR exists is that `amp.reddit.com` will need to know if users already have a `loid` or `token` cookie so that we don't double count users that visit mweb and amp. The reason this is not possible is that currently the domain of these cookies are set to `m.reddit.com`. This means those cookies aren't readable by `amp.reddit.com`. We need them to be set to the root level `.reddit.com` to count correctly on amp.

In order to guarantee that we create new root level cookies we have to delete the old ones. The reason is that ideally we would just do this:

```
if (isNotOnRootLevelDomain(ctx.cookies.get('loid'))) {
    ctx.cookies.set('loid');
}
```

Unfortunately there's no way to tell what domain the cookie is on. So we have to simply delete the non-root cookies so that we can then regenerate them correctly.   

You'll note that this change will globally log out all users and generate new loids for existing users. Luckily we aren't live yet :D

👓 : @schwers @prashtx 