### PR TITLE
Add statsd, and request and response error code stats

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -98,6 +98,7 @@
     "curly": 2,
     "dot-location": [2, 'property'],
     "dot-notation": 2,
+    "eol-last": 2,
     "eqeqeq": 2,
     "no-alert": 2,
     "no-else-return": 2,
@@ -137,7 +138,7 @@
     "no-undef-init": 2,
     "no-undef": 2,
     "no-unused-vars": 2,
-    "callback-return": 2,
+    "callback-return": [2, ["callback", "cb"]],
 
     // es6-specific
     "prefer-template": 1,

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "reselect": "2.5.1",
     "sha1": "^1.1.1",
     "source-map-support": "^0.4.0",
+    "statsd-client": "^0.2.2",
     "superagent": "1.8.3",
     "superagent-retry": "git://github.com/ajacksified/superagent-retry#d39d7adbcd021d8ed09df440dba970c91fed9cd4"
   },

--- a/src/Server.js
+++ b/src/Server.js
@@ -26,6 +26,7 @@ import { dispatchInitialOver18 } from 'server/initialState/dispatchInitialOver18
 import { dispatchInitialTheme } from 'server/initialState/dispatchInitialTheme';
 import { dispatchInitialRecentSubreddits } from 'server/initialState/dispatchInitialRecentSubreddits';
 import metaRoutes from 'server/meta';
+import statsRouterMiddleware from 'server/meta/stats';
 
 import dispatchInitialCollapsedComments from
   'server/initialState/dispatchInitialCollapsedComments';
@@ -97,6 +98,9 @@ export function startServer() {
       buildFiles,
     ],
     getServerRouter: router => {
+      // middleware
+      statsRouterMiddleware(router, ConfigedAPIOptions);
+
       // private routes for login, logout, register, and token refresh
       loginproxy(router, ConfigedAPIOptions);
       logoutproxy(router, ConfigedAPIOptions);

--- a/src/config.js
+++ b/src/config.js
@@ -43,6 +43,13 @@ const config = () => ({
   trackerClientSecret: process.env.TRACKER_SECRET,
   trackerClientAppName: process.env.TRACKER_CLIENT_NAME,
 
+  // If statsdHost isn't set, then statsd is skipped
+  statsdHost: process.env.STATSD_HOST,
+  statsdPort: process.env.STATSD_PORT,
+  statsdDebug: process.env.STATSD_DEBUG,
+  statsdPrefix: process.env.STATSD_PREFIX || 'mweb2x.staging.server',
+  statsdSocketTimeout: process.env.STATSD_TIMEOUT || 100,
+
   appName: process.env.APP_NAME || 'mweb',
 
   defaultCountry: process.env.DEFAULT_COUNTRY || 'US',

--- a/src/server/meta/stats.js
+++ b/src/server/meta/stats.js
@@ -1,0 +1,43 @@
+import StatsdClient from 'statsd-client';
+
+import config from 'config';
+import errorLog from 'lib/errorLog';
+
+
+let statsdConfig;
+if (config.statsdHost) {
+  statsdConfig = {
+    host: config.statsdHost,
+    port: config.statsdPort,
+    debug: config.statsdDebug,
+    prefix: config.statsdPrefix,
+    socketTimeout: config.statsdSocketTimeout,
+  };
+}
+
+const statsd = new StatsdClient(statsdConfig || {
+  _socket: { send: ()=>{}, close: ()=>{} },
+});
+
+export default router => {
+  router.use(async (ctx, next) => {
+    statsd.increment('request');
+
+    const start = Date.now();
+    try {
+      await next();
+    } catch (e) {
+      errorLog({
+        error: `${e.name}: ${e.message}`,
+        userAgent: 'SERVER',
+      }, {
+        hivemind: config.statsURL,
+      });
+    }
+    const delta = Math.ceil(Date.now() - start);
+    statsd.timing('response_time', delta);
+
+    const status = ctx.response.status;
+    statsd.increment(`response.${status}`);
+  });
+};


### PR DESCRIPTION
We log stats to graphite via statsd -- so add that
packages along with its base configuration.

Initial stats are counting the number of requests
as well as the response error codes.