### PR TITLE
Compose: add escape hatch link

### DIFF
--- a/src/views/pages/messageCompose.jsx
+++ b/src/views/pages/messageCompose.jsx
@@ -3,10 +3,10 @@ import React from 'react';
 import MessageNav from '../components/MessageNav';
 import BasePage from './BasePage';
 
+const composeLink = 'https://www.reddit.com/message/compose';
+
 class MessageComposePage extends BasePage {
   render () {
-    const composeLink = "https://www.reddit.com/message/compose";
-
     return (
       <div className={ `message-page message-${this.props.view}` }>
         <div>
@@ -16,7 +16,9 @@ class MessageComposePage extends BasePage {
               <div className='col-xs-12 col-sm-6'>
                 <div className='well well-lg'>
                   <h3>
-                    Sorry, this isn’t ready yet! You can <a href={ composeLink }>compose a message on the desktop site</a> instead.
+                    Sorry, this isn’t ready yet! You can
+                    <a href={ composeLink }>compose a message on the desktop site</a>
+                    instead.
                   </h3>
                 </div>
               </div>

--- a/src/views/pages/messageCompose.jsx
+++ b/src/views/pages/messageCompose.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
 
+import config from '../../config';
+
 import MessageNav from '../components/MessageNav';
 import BasePage from './BasePage';
 
-const composeLink = 'https://www.reddit.com/message/compose';
+const COMPOSE_LINK = `${config.reddit}/message/compose`;
 
 class MessageComposePage extends BasePage {
   render () {
@@ -17,7 +19,7 @@ class MessageComposePage extends BasePage {
                 <div className='well well-lg'>
                   <h3>
                     Sorry, this isn’t ready yet! You can
-                    <a href={ composeLink }>compose a message on the desktop site</a>
+                    <a href={ COMPOSE_LINK }> compose a message on the desktop site </a>
                     instead.
                   </h3>
                 </div>

--- a/src/views/pages/messageCompose.jsx
+++ b/src/views/pages/messageCompose.jsx
@@ -5,6 +5,8 @@ import BasePage from './BasePage';
 
 class MessageComposePage extends BasePage {
   render () {
+    const composeLink = "https://www.reddit.com/message/compose";
+
     return (
       <div className={ `message-page message-${this.props.view}` }>
         <div>
@@ -13,7 +15,9 @@ class MessageComposePage extends BasePage {
             <div className='row'>
               <div className='col-xs-12 col-sm-6'>
                 <div className='well well-lg'>
-                  <p>Sorry, this isn’t ready yet!</p>
+                  <h3>
+                    Sorry, this isn’t ready yet! You can <a href={ composeLink }>compose a message on the desktop site</a> instead.
+                  </h3>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Compose is not yet ready on mweb, so we add a link to desktop compose as an alternative.

Fixes https://reddit.atlassian.net/browse/MOBILEWEB-634

Not very pretty, but it looks like this:

![image](https://cloud.githubusercontent.com/assets/285920/18136323/c1ea7e4c-6f59-11e6-810c-84850424e976.png)

👓  @phil303 