### PR TITLE
activeRequests tracking

### DIFF
--- a/src/server/meta/stats.js
+++ b/src/server/meta/stats.js
@@ -3,6 +3,7 @@ import StatsdClient from 'statsd-client';
 import config from 'config';
 import errorLog from 'lib/errorLog';
 
+let activeRequests = 0;
 
 let statsdConfig;
 if (config.statsdHost) {
@@ -19,9 +20,21 @@ const statsd = new StatsdClient(statsdConfig || {
   _socket: { send: ()=>{}, close: ()=>{} },
 });
 
+// Check in with the statsd server every 10 seconds with how many
+// active requests this instance is handling. If all instances do
+// the same in the same time windows, then we'll have the right info.
+const logStats = () => {
+  setTimeout(() => {
+    statsd.increment('activeRequests', activeRequests);
+    logStats();
+  }, 10000);
+}
+logStats();
+
 export default router => {
   router.use(async (ctx, next) => {
     statsd.increment('request');
+    activeRequests += 1;
 
     const start = Date.now();
     try {
@@ -37,6 +50,7 @@ export default router => {
     const delta = Math.ceil(Date.now() - start);
     statsd.timing('response_time', delta);
 
+    activeRequests -= 1;
     const status = ctx.response.status;
     statsd.increment(`response.${status}`);
   });

--- a/src/server/meta/stats.js
+++ b/src/server/meta/stats.js
@@ -23,13 +23,9 @@ const statsd = new StatsdClient(statsdConfig || {
 // Check in with the statsd server every 10 seconds with how many
 // active requests this instance is handling. If all instances do
 // the same in the same time windows, then we'll have the right info.
-const logStats = () => {
-  setTimeout(() => {
-    statsd.increment('activeRequests', activeRequests);
-    logStats();
-  }, 10000);
-}
-logStats();
+setInterval(() => {
+  statsd.increment('activeRequests', activeRequests);
+}, 10000);
 
 export default router => {
   router.use(async (ctx, next) => {


### PR DESCRIPTION
This is a simplified version of what we do in 1X.
We use the fact that graphite buckets in 10s increments
and have the individual servers tell graphite about
their view of activeRequests counts.

👓  @schwers @nramadas @phil303 