### PR TITLE
Use loids generated by the api

### DIFF
--- a/src/lib/loid.es6.js
+++ b/src/lib/loid.es6.js
@@ -1,15 +1,17 @@
-import randomString from './randomString';
+import config from '../config';
 
-function setLoggedOutCookies(cookies, app) {
-  const loid = randomString(18);
-  const loidcreated = (new Date()).toISOString();
-
+function setLoggedOutCookies(cookies, app, loid, loidcreated) {
   const options = {
     secure: app.getConfig('https'),
     secureProxy: app.getConfig('httpsProxy'),
     httpOnly: false,
     maxAge: 1000 * 60 * 60 * 24 * 365 * 2,
   };
+
+  if (app.config.origin.indexOf('localhost') === -1) {
+    // We set the domain here to be `reddit.com` (for production reddit)
+    options.domain = config.rootReddit;
+  }
 
   cookies.set('loid', loid, options);
   cookies.set('loidcreated', loidcreated, options);

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -326,6 +326,20 @@ function routes(app) {
       this.props.adsEnabled = !feature.enabled(constants.flags.NO_ADS);
     });
 
+    const loggedOutUserPromise = this.props.data.get('loggedOutUser');
+
+    if (loggedOutUserPromise) {
+      // we need to yield here to ensure that the logged out user data gets
+      // loaded in.
+      yield loggedOutUserPromise.then(user => {
+        this.props.loid = user.body.loid;
+        this.props.loidcreated = String(user.body.loid_created);
+      });
+    } else {
+      this.props.loid = '';
+      this.props.loidcreated = '';
+    }
+
     return yield next;
   }
 

--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -222,11 +222,15 @@ class Server {
       server.use(koaStatic(`${__dirname}/../../build`));
     }
 
+    // these first two yield first _before_ taking action, so they are ordered
+    // in "reverse" and at the top;
+    server.use(this.setExperiments(app));
+    server.use(this.setLOID(app));
+
+    // these do work first before yielding.
     server.use(this.checkForDesktopRedirect(app));
     server.use(this.checkToken(app));
     server.use(this.convertSession(app));
-    server.use(this.setLOID(app));
-    server.use(this.setExperiments(app));
     server.use(this.modifyRequest(app));
     server.use(this.setHeaders(app));
 
@@ -283,22 +287,28 @@ class Server {
 
   setLOID (app) {
     return function * (next) {
+      // if we have loid cookies, set them on the context. certain actions will
+      // depend on these preliminary loids. if they are wrong, they will get
+      // get corrected by the api
       const loid = this.cookies.get('loid');
 
       if (loid) {
         this.loid = loid;
         this.loidcreated = this.cookies.get('loidcreated');
-      } else {
-        const cookies = setLoggedOutCookies(this.cookies, app);
-
-        // koa doesn't return cookies set within the
-        // same request, cache it for later
-        this._loid = cookies.loid;
-        this.loid = cookies.loid;
-        this.loidcreated = cookies.loidcreated;
       }
 
+      // yield first, allowing the route to get handled. Then, pull data out
+      // and use it to set the loid cookie
       yield next;
+
+      // we might have gotten a new loid from the api after the route got
+      // handled. if so, we want to use that here.
+      if (this.props.loid) {
+        this.loid = this.props.loid;
+        this.loidcreated = this.props.loidcreated;
+        setLoggedOutCookies(this.cookies, app, this.props.loid, this.props.loidcreated);
+      }
+
       return;
     };
   }
@@ -309,6 +319,9 @@ class Server {
         yield next;
         return;
       }
+
+      // yield first since the route handling might set loids
+      yield next;
 
       let loid = this.cookies.get('loid');
 
@@ -323,8 +336,7 @@ class Server {
           }
         }
       } else {
-        loid = this._loid;
-
+        loid = this.loid;
         this.newUser = true;
       }
 
@@ -351,7 +363,6 @@ class Server {
         });
       }
 
-      yield next;
       return;
     };
   }


### PR DESCRIPTION
Through clever manipulation of 1X code (read: hacks and frustration), I think I have a solution for using api generated loids in 1X.

Essentially, I repurposed the current middleware used to create loids, and instead had the middleware yield on the route handling first so that the loids can be loaded by the api.

Blocked on: https://github.com/reddit/node-api-client/pull/151

:eyeglasses: @phil303 || @schwers || @uzi 