### PR TITLE
Check and update state.finished atomically

### DIFF
--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -492,6 +492,7 @@ function routes(app) {
       const canonical = listingPromise.then(listing => {
         const { permalink } = listing;
         props.canonicalPath = permalink;
+        return permalink;
       });
       // Make sure this promise is part of the super-promise used by
       // horse-react/server for rendering the page.


### PR DESCRIPTION
We may have data promises that lead to other data promises, which result
in multiple checks for `this.state.finished` when a page has finished
rendering. `this.setState` doesn't act immediately, so both checks will
see a false value, and we'll take page-finished actions twice. Instead,
we should check and set the state as an atomic operation.