### PR TITLE
Count filtered r/all as a fake subreddit

### DIFF
--- a/src/lib/isFakeSubreddit.es6.js
+++ b/src/lib/isFakeSubreddit.es6.js
@@ -4,5 +4,9 @@ const fakeSubs = ['all', 'mod', 'friends'].concat(randomSubs);
 export { fakeSubs, randomSubs };
 
 export default function isFakeSubreddit(subredditName) {
-  return !!subredditName && (subredditName.indexOf('+') > -1 || fakeSubs.includes(subredditName));
+  return !!subredditName && (
+    subredditName.indexOf('+') > -1 ||
+    subredditName.indexOf('-') > -1 ||
+    fakeSubs.includes(subredditName)
+  );
 }


### PR DESCRIPTION
We get a lot of hits to `r/all-<subreddit-A>-<subreddit-B>-...-<subreddit-Z>`. This filtered view of `r/all` is valid for gold users, otherwise we return the normal list of posts. However our fake subreddit detector doesn't consider this filtered view to be faking, causing an error when we try to fetch subreddit info.

👓  @prashtx @nramadas 