### PR TITLE
Fix unhandledrejection listener passing undefined ctx

### DIFF
--- a/assets/js/clientEvents.es6.js
+++ b/assets/js/clientEvents.es6.js
@@ -228,7 +228,7 @@ export default function setAppEvents(app, hasHistAndBindLinks, render, $body) {
   }, 100));
 
   window.addEventListener('unhandledrejection', event => {
-    app.error(event, this, app, {
+    app.error(event, app.state.ctx, app, {
       replaceBody: false,
       redirect: false,
     });


### PR DESCRIPTION
This ends up bubbling to the error handler which
wants to check ctx.env, but ctx is undefined.  Instead
we pull ctx from app.state.

👓  @schwers @nramadas 