### PR TITLE
Collect shell render RUM timings

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -13,6 +13,7 @@ import errorLog from 'lib/errorLog';
 import routes from 'app/router';
 import reducers from 'app/reducers';
 import reduxMiddleware from 'app/reduxMiddleware';
+import { sendTimings } from 'lib/timing';
 import Session from 'app/models/Session';
 
 // register window.onError asap so we can catch errors in the client's init
@@ -43,6 +44,7 @@ window.onunhandledrejection = rejection => {
 };
 
 // start the app now
+const beginRender = Date.now();
 const client = Client({
   routes,
   reducers,
@@ -84,3 +86,4 @@ const client = Client({
 })();
 
 client.dispatch(actions.activateClient());
+sendTimings(beginRender);

--- a/src/lib/timing.js
+++ b/src/lib/timing.js
@@ -47,23 +47,23 @@ export function getTimes() {
 }
 
 export function sendTimings(beginRender) {
-    if (Math.random() > 0.1) { // 10% of requests
-      return;
-    }
+  if (Math.random() > 0.1) { // 10% of requests
+    return;
+  }
 
-    let actionName = `m2.server.shell`;
+  const actionName = 'm2.server.shell';
 
-    const timings = Object.assign({
-      actionName: actionName,
-    }, getTimes());
+  const timings = Object.assign({
+    actionName,
+  }, getTimes());
 
-    timings.mountTiming = (Date.now() - beginRender) / 1000;
+  timings.mountTiming = (Date.now() - beginRender) / 1000;
 
-    makeRequest
-      .post('/timings')
-      .timeout(DEFAULT_API_TIMEOUT)
-      .send({
-        rum: timings,
-      })
-      .then();
+  makeRequest
+    .post('/timings')
+    .timeout(DEFAULT_API_TIMEOUT)
+    .send({
+      rum: timings,
+    })
+    .then();
 }

--- a/src/lib/timing.js
+++ b/src/lib/timing.js
@@ -1,4 +1,8 @@
-function getTimes() {
+import { DEFAULT_API_TIMEOUT } from 'app/constants';
+
+import makeRequest from './makeRequest';
+
+export function getTimes() {
   const performance = global.performance ||
                     global.webkitPerformance ||
                     global.msPerformance ||
@@ -42,4 +46,24 @@ function getTimes() {
   return timings;
 }
 
-export default getTimes;
+export function sendTimings(beginRender) {
+    if (Math.random() > 0.1) { // 10% of requests
+      return;
+    }
+
+    let actionName = `m2.server.shell`;
+
+    const timings = Object.assign({
+      actionName: actionName,
+    }, getTimes());
+
+    timings.mountTiming = (Date.now() - beginRender) / 1000;
+
+    makeRequest
+      .post('/timings')
+      .timeout(DEFAULT_API_TIMEOUT)
+      .send({
+        rum: timings,
+      })
+      .then();
+}

--- a/src/server/meta/index.js
+++ b/src/server/meta/index.js
@@ -151,6 +151,9 @@ export default (router, apiOptions) => {
         .send({ rum: timings })
         .timeout(DEFAULT_API_TIMEOUT)
         .end(err => err ? reject(err) : resolve());
+
+    ctx.body = null;
+    return;
   }));
 
 };


### PR DESCRIPTION
Gathers statistics on loading the initial state of
the app, which is before any of the API requests
have happened.

We send the data to hivemind which ends up logging to graphite something like

```
service_time.web.m2.server.shell.frontend.request:65.00005722045898|ms
service_time.web.m2.server.shell.frontend.response:0.9999275207519531|ms
service_time.web.m2.server.shell.frontend.dom_loading:83.9998722076416|ms
service_time.web.m2.server.shell.frontend.mount:90|ms
```

Note that we'll need to set the `process.env.ACTION_NAME_SECRET` in configuration for this to work.

👓 @schwers @phil303 @nramadas 