### PR TITLE
Add originalUrl to loginRedirect

### DIFF
--- a/assets/js/appMethods.es6.js
+++ b/assets/js/appMethods.es6.js
@@ -1,5 +1,6 @@
 import ReactDOM from 'react-dom';
 import cookies from 'cookies-js';
+import querystring from 'querystring';
 
 import { setMetaColor, setTitle, refreshToken } from './clientLib';
 import constants from '../../src/constants';
@@ -51,8 +52,18 @@ export default function(app, $body, render, history) {
   // This would make the consuming code a oneliner but it's not really
   // an error. Plus it will simplfy things for the client-side errors.
   app.needsToLogInUser = function() {
-    if (!app.getState('ctx').redditSession) {
-      app.redirect(app.config.registerPath);
+    const ctx = app.getState('ctx');
+    if (!ctx.redditSession) {
+      const originalUrl = ctx.path;
+      const qs = querystring.stringify({originalUrl});
+      // Only append originalUrl query string if it is not the frontpage.
+      // Otherwise the app query parsing would override the originalUrl
+      // property of ctx and redirect to frontpage
+      if (originalUrl !== '/') {
+        app.redirect(`${app.config.registerPath}/?${qs}`);
+      } else {
+        app.redirect(app.config.registerPath);
+      }
       return true;
     }
   };


### PR DESCRIPTION
👓 @uzi 

Problem: Any action that requires an account redirects to the registration page. Unfortunately, when a user comes in from SEO or direct link causes `ctx.originalUrl` not to be set and closing the register window causes them to be redirected to the frontpage instead of the original post. 

The problem is that `ctx.originalUrl` is not set when a comment page is directly accessed, so a login page cannot access that property and therefore falls back to returning to frontpage.

The fix is easy. Whenever actions are called that requires a logged in user, add a query parameter to the redirect if it exists, and if the path is the frontpage, silence the query parameter for `ctx.originalUrl` to override.