### PR TITLE
Pageview events for most popular pages

### DIFF
--- a/blueprints.config.js
+++ b/blueprints.config.js
@@ -6,14 +6,28 @@ module.exports = function(isProduction) {
 
   // Copy static files for deploying / serving. We also use these in debug
   // to more closely mimic production.
-  serverConfig.webpack.plugins = serverConfig.webpack.plugins.concat([{
-    generator: 'copy-static-files',
-    staticPaths: [
-      ['assets/favicon', 'build/favicon'],
-      ['assets/fonts', 'build/fonts'],
-      ['assets/img', 'build/img'],
-    ],
-  }]);
+  serverConfig.webpack.plugins = serverConfig.webpack.plugins.concat([
+    {
+      generator: 'copy-static-files',
+      staticPaths: [
+        ['assets/favicon', 'build/favicon'],
+        ['assets/fonts', 'build/fonts'],
+        ['assets/img', 'build/img'],
+      ],
+    },
+  ]);
+
+  clientConfig.webpack.plugins = clientConfig.webpack.plugins.concat([
+    {
+      generator: 'set-node-env',
+      'process.env': {
+        TRACKER_KEY: JSON.stringify(process.env.TRACKER_KEY || 'XXX'),
+        TRACKER_ENDPOINT: JSON.stringify(process.env.TRACKER_ENDPOINT || 'XXX'),
+        TRACKER_SECRET: JSON.stringify(process.env.TRACKER_SECRET || 'XXX'),
+        TRACKER_CLIENT_NAME: JSON.stringify(process.env.TRACKER_CLIENT_NAME || 'XXX'),
+      },
+    },
+  ]);
 
   return [ clientConfig, serverConfig ];
 };

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@r/api-client": "~3.22.3",
-    "@r/build": "~0.9.4",
+    "@r/build": "~0.10.0",
     "@r/flags": "^1.5.0",
     "@r/middleware": "~0.8.0",
     "@r/platform": "~0.14.0",
@@ -30,6 +30,7 @@
     "babel-polyfill": "^6.7.4",
     "Base64": "1.0.0",
     "cluster": "^0.7.7",
+    "event-tracker": "git://github.com/reddit/event-tracker.git#28bc2dd9ce3b80540fdf189e1b003f8264cd0d08",
     "js-cookie": "^2.1.1",
     "json-stable-stringify": "^1.0.1",
     "koa": "2.0.0",

--- a/src/Client.js
+++ b/src/Client.js
@@ -1,4 +1,6 @@
 import 'babel-polyfill';
+import './lib/dnt';
+
 import React from 'react';
 import Client from '@r/platform/Client';
 import * as actions from '@r/platform/actions';

--- a/src/app/actions/ads.js
+++ b/src/app/actions/ads.js
@@ -70,7 +70,7 @@ const nextAdId = () => (uniqueId('ad_'));
 // We could look up page params from state, but having them passed in
 // is more explicit and safer if the page were to change while we await.
 export const fetchNewAdForPostsList = (postsListId, pageParams) =>
-  async (dispatch, getState, { waitForState }) => {
+  async (dispatch, getState) => {
     const state = getState();
     const adRequest = state.adRequests[postsListId];
     if (adRequest && adRequest.loading) { return; }
@@ -78,13 +78,6 @@ export const fetchNewAdForPostsList = (postsListId, pageParams) =>
     const adId = nextAdId();
 
     dispatch(fetching(adId, postsListId));
-
-    // We don't want to show ads if there are no posts to render, so we need
-    // to wait for the postsList to load.
-    await waitForState(state => {
-      const postList = state.postsLists[postsListId];
-      return postList && !postList.loading;
-    });
 
     const loadedState = getState();
     const postsList = loadedState.postsLists[postsListId];

--- a/src/app/reduxMiddleware/errorLogger.js
+++ b/src/app/reduxMiddleware/errorLogger.js
@@ -20,7 +20,7 @@ import * as subscribedSubredditActions from 'app/actions/subscribedSubreddits';
 import * as voteActions from 'app/actions/vote';
 import * as wikiActions from 'app/actions/wiki';
 
-export const errorLogger = () => {
+export default function errorLogger() {
   const actionStack = new ActionStack(config.reduxActionLogSize, [
     platformActions.SET_PAGE,
     accountActions.FETCHING_ACCOUNT,
@@ -67,7 +67,7 @@ export const errorLogger = () => {
       logErrorWithConfig(error, store.getState(), actionStack);
     }
   };
-};
+}
 
 const checkForSpecificErrors = action => {
   switch (action.type) {

--- a/src/app/reduxMiddleware/index.js
+++ b/src/app/reduxMiddleware/index.js
@@ -1,4 +1,4 @@
-import { errorLogger } from './errorLogger';
+import errorLogger from './errorLogger';
 
 export default [
   errorLogger(),

--- a/src/app/router/handlers/DirectMessage.js
+++ b/src/app/router/handlers/DirectMessage.js
@@ -3,10 +3,14 @@ import { endpoints } from '@r/api-client';
 
 import { fetchUserBasedData } from './handlerCommon';
 import { apiOptionsFromState } from 'lib/apiOptionsFromState';
+import { getBasePayload, logClientScreenView } from 'lib/eventUtils';
 
 export default class DirectMessage extends BaseHandler {
-  async [METHODS.GET](dispatch/*, getState, utils*/) {
-    fetchUserBasedData(dispatch);
+  async [METHODS.GET](dispatch, getState) {
+    await fetchUserBasedData(dispatch);
+
+    const _tempState = getState();
+    logClientScreenView(getBasePayload(getState()), _tempState);
   }
 
   async [METHODS.POST](dispatch, getState/*, utils*/) {

--- a/src/app/router/handlers/Login.js
+++ b/src/app/router/handlers/Login.js
@@ -4,13 +4,16 @@ import * as platformActions from '@r/platform/actions';
 import Session from 'app/models/Session';
 import * as sessionActions from 'app/actions/session';
 import * as loginActions from 'app/actions/login';
+import { getBasePayload, logClientScreenView } from 'lib/eventUtils';
+
 
 export default class Login extends BaseHandler {
-  async [METHODS.GET](/*dispatch, getState, utils*/) {
-    return;
+  async [METHODS.GET](dispatch, getState) {
+    const _tempState = getState();
+    logClientScreenView(getBasePayload(getState()), _tempState);
   }
 
-  async [METHODS.POST](dispatch/*, getState, utils*/) {
+  async [METHODS.POST](dispatch) {
     const { username, password } = this.bodyParams;
 
     try {
@@ -18,6 +21,7 @@ export default class Login extends BaseHandler {
       dispatch(sessionActions.setSession(newSession));
       dispatch(loginActions.loggedIn());
       dispatch(platformActions.navigateToUrl(METHODS.GET, '/'));
+
     } catch (e) {
       const error = JSON.parse(e);
       dispatch(sessionActions.sessionError(error.error));

--- a/src/app/router/handlers/Messages.js
+++ b/src/app/router/handlers/Messages.js
@@ -1,12 +1,15 @@
 import { BaseHandler, METHODS } from '@r/platform/router';
 
-import { fetchUserBasedData } from './handlerCommon';
 import * as mailActions from 'app/actions/mail';
+import { fetchUserBasedData } from './handlerCommon';
+import { getBasePayload, logClientScreenView } from 'lib/eventUtils';
 
 export default class Messages extends BaseHandler {
-  async [METHODS.GET](dispatch/*, getState, utils*/) {
-    const { mailType } = this.urlParams;
-    fetchUserBasedData(dispatch);
-    dispatch(mailActions.fetchInbox(mailType));
+  async [METHODS.GET](dispatch, getState) {
+    dispatch(mailActions.fetchInbox(this.urlParams.mailType));
+    await fetchUserBasedData(dispatch);
+
+    const _tempState = getState();
+    logClientScreenView(getBasePayload(getState()), _tempState);
   }
 }

--- a/src/app/router/handlers/PostSubmit.js
+++ b/src/app/router/handlers/PostSubmit.js
@@ -1,8 +1,9 @@
 import { BaseHandler, METHODS } from '@r/platform/router';
 import * as platformActions from '@r/platform/actions';
-import * as subredditActions from 'app/actions/subreddits';
 
+import * as subredditActions from 'app/actions/subreddits';
 import { fetchUserBasedData } from 'app/router/handlers/handlerCommon';
+import { getBasePayload, logClientScreenView } from 'lib/eventUtils';
 
 export class PostSubmitHandler extends BaseHandler {
   async [METHODS.GET](dispatch, getState) {
@@ -11,7 +12,11 @@ export class PostSubmitHandler extends BaseHandler {
       dispatch(platformActions.setPage('/login'));
       return;
     }
-    fetchUserBasedData(dispatch);
+
+    await fetchUserBasedData(dispatch);
+
+    const _tempState = getState();
+    logClientScreenView(getBasePayload(getState()), _tempState);
   }
 }
 
@@ -23,10 +28,13 @@ export class PostSubmitCommunityHandler extends BaseHandler {
       return;
     }
 
-    fetchUserBasedData(dispatch);
-
     state.recentSubreddits.forEach(subredditName => {
       dispatch(subredditActions.fetchSubreddit(subredditName));
     });
+
+    await fetchUserBasedData(dispatch);
+
+    const _tempState = getState();
+    logClientScreenView(getBasePayload(getState()), _tempState);
   }
 }

--- a/src/app/router/handlers/PostsFromSubreddit.js
+++ b/src/app/router/handlers/PostsFromSubreddit.js
@@ -5,11 +5,15 @@ import * as adActions from 'app/actions/ads';
 import * as postsListActions from 'app/actions/postsList';
 import * as subredditActions from 'app/actions/subreddits';
 import { paramsToPostsListsId } from 'app/models/PostsList';
+import { FAKE_SUBS } from 'lib/isFakeSubreddit';
 import { cleanObject } from 'lib/cleanObject';
 import { listingTime } from 'lib/listingTime';
 import { fetchUserBasedData } from './handlerCommon';
+import { getBasePayload, buildSubredditData, convertId, logClientScreenView } from 'lib/eventUtils';
+
 
 export default class PostsFromSubreddit extends BaseHandler {
+
   static pageParamsToSubredditPostsParams({ urlParams, queryParams}) {
     const { multi, multiUser } = urlParams;
     const { sort, after, before } = queryParams;
@@ -27,27 +31,81 @@ export default class PostsFromSubreddit extends BaseHandler {
     });
   }
 
-  async [METHODS.GET](dispatch, getState, { waitForState }) {
+  async [METHODS.GET](dispatch, getState) {
     const state = getState();
 
     if (state.platform.shell) { return; }
 
     const subredditPostsParams = PostsFromSubreddit.pageParamsToSubredditPostsParams(this);
-    dispatch(postsListActions.fetchPostsFromSubreddit(subredditPostsParams));
-
     const postsListId = paramsToPostsListsId(subredditPostsParams);
+    const { subredditName } = subredditPostsParams;
+
+    await Promise.all([
+      fetchUserBasedData(dispatch),
+      dispatch(postsListActions.fetchPostsFromSubreddit(subredditPostsParams)),
+      dispatch(subredditActions.fetchSubreddit(subredditName)),
+    ]);
+
     dispatch(adActions.fetchNewAdForPostsList(postsListId, {
       urlParams: this.urlParams,
       queryParams: this.queryParams,
     }));
 
-    const { subredditName } = subredditPostsParams;
-    dispatch(subredditActions.fetchSubreddit(subredditName));
-    fetchUserBasedData(dispatch);
+    dispatch(setStatus(getState().postsLists[postsListId].responseCode));
 
-    await waitForState(state => {
-      const postsList = state.postsLists[postsListId];
-      return postsList && !!postsList.responseCode;
-    }, state => dispatch(setStatus(state.postsLists[postsListId].responseCode)));
+    const _tempState = getState();
+    logClientScreenView(buildScreenViewData(getState()), _tempState);
   }
+}
+
+
+const LINK_LIMIT = 25;
+
+function buildSortOrderData(state) {
+  const { currentPage: { queryParams: { sort, time, before, after } } } = state.platform;
+
+  return {
+    target_sort: sort || 'hot',
+    target_count: LINK_LIMIT,
+    target_filter_time: sort === 'top' ? (time || 'all') : null,
+    target_before: before ? before : null,
+    target_after: after ? after : null,
+  };
+}
+
+
+function buildScreenViewData(state) {
+  const { subredditName } = state.platform.currentPage.urlParams;
+
+  let target_id = null;
+  let target_fullname = null;
+  let listing_name = null;
+
+  // There's some unfortunate special handling here. The frontpage doesn't
+  // have a subredditName, multi's are delimited by a '+', filters by a '-',
+  // and some "fake" subreddits have special listing names.
+  if (!subredditName) {
+    listing_name = 'frontpage';
+  } else if (subredditName.indexOf('+') > -1) {
+    listing_name = 'multi';
+  } else if (subredditName.indexOf('-') > -1) {
+    listing_name = 'all (filtered)';
+  } else if (FAKE_SUBS.includes(subredditName)) {
+    listing_name = subredditName;
+  } else {
+    const subreddit = state.subreddits[subredditName.toLowerCase()];
+    target_id = convertId(subreddit.id);
+    target_fullname = subreddit.name;
+    listing_name = subreddit.uuid;
+  }
+
+  return cleanObject({
+    listing_name,
+    target_id,
+    target_fullname,
+    target_type: 'listing',
+    ...getBasePayload(state),
+    ...buildSortOrderData(state),
+    ...buildSubredditData(state),
+  });
 }

--- a/src/app/router/handlers/Register.js
+++ b/src/app/router/handlers/Register.js
@@ -4,14 +4,16 @@ import * as platformActions from '@r/platform/actions';
 import { registerUser } from 'app/models/Register';
 import * as sessionActions from 'app/actions/session';
 import * as loginActions from 'app/actions/login';
+import { getBasePayload, logClientScreenView } from 'lib/eventUtils';
 
 
 export default class Register extends BaseHandler {
-  async [METHODS.GET](/*dispatch, getState, utils*/) {
-    return;
+  async [METHODS.GET](dispatch, getState) {
+    const _tempState = getState();
+    logClientScreenView(getBasePayload(getState()), _tempState);
   }
 
-  async [METHODS.POST](dispatch/*, getState, utils*/) {
+  async [METHODS.POST](dispatch) {
     const { username, password, email, newsletter, gRecaptchaResponse } = this.bodyParams;
     try {
       const newSession = await registerUser(username, password, email,
@@ -19,6 +21,7 @@ export default class Register extends BaseHandler {
       dispatch(sessionActions.setSession(newSession));
       dispatch(loginActions.loggedIn());
       dispatch(platformActions.navigateToUrl(METHODS.GET, '/'));
+
     } catch (e) {
       const error = JSON.parse(e);
       dispatch(sessionActions.sessionError(error.error));

--- a/src/app/router/handlers/handlerCommon.js
+++ b/src/app/router/handlers/handlerCommon.js
@@ -3,7 +3,9 @@ import * as preferenceActions from 'app/actions/preferences';
 import * as userActions from 'app/actions/user';
 
 export const fetchUserBasedData = (dispatch) => {
-  dispatch(subscribedSubredditsActions.fetchSubscribedSubreddits(true));
-  dispatch(userActions.fetchMyUser());
-  dispatch(preferenceActions.fetch());
+  return Promise.all([
+    dispatch(subscribedSubredditsActions.fetchSubscribedSubreddits(true)),
+    dispatch(userActions.fetchMyUser()),
+    dispatch(preferenceActions.fetch()),
+  ]);
 };

--- a/src/lib/eventTracker.js
+++ b/src/lib/eventTracker.js
@@ -1,0 +1,78 @@
+import crypto from 'crypto';
+import EventTracker from 'event-tracker';
+
+import config from 'config';
+import makeRequest from 'lib/makeRequest';
+import { objectToHash } from 'lib/objectToHash';
+import { DEFAULT_API_TIMEOUT } from 'app/constants';
+
+function calculateHash(key, string) {
+  const hmac = crypto.createHmac('sha256', key);
+  hmac.setEncoding('hex');
+  hmac.write(string);
+  hmac.end();
+
+  return hmac.read();
+}
+
+function post({url, data, query, headers, done}) {
+  return makeRequest
+    .post(url)
+    .query(query)
+    .set(headers)
+    .timeout(DEFAULT_API_TIMEOUT)
+    .send(data)
+    .then(done);
+}
+
+function stubbedPost({ data }) {
+  try {
+    const eventData = JSON.parse(data);
+    const eventTopics = eventData.map(e => e.event_topic).join(', ');
+    console.info(`Tracking ${eventTopics} with data:`, eventData);
+  } catch (e) {
+    return;
+  }
+}
+
+const trackers = {};
+
+export function getEventTracker() {
+  const {
+    trackerKey,
+    trackerClientSecret,
+    trackerEndpoint,
+    trackerClientAppName,
+  } = config;
+
+  const hash = objectToHash({
+    trackerKey,
+    trackerEndpoint,
+    trackerClientSecret,
+    trackerClientAppName,
+  });
+
+  let tracker = trackers[hash];
+
+  if (!tracker) {
+    const sendEvent = process.env.NODE_ENV === 'production' ? post : stubbedPost;
+    const base64Secret = new Buffer(trackerClientSecret, 'base64').toString();
+
+    tracker = new EventTracker(
+      trackerKey,
+      base64Secret,
+      sendEvent,
+      trackerEndpoint,
+      trackerClientAppName,
+      calculateHash,
+      {
+        appendClientContext: true,
+        bufferLength: 1,
+      }
+    );
+
+    trackers[hash] = tracker;
+  }
+
+  return tracker;
+}

--- a/src/lib/eventUtils.js
+++ b/src/lib/eventUtils.js
@@ -1,0 +1,86 @@
+import omit from 'lodash/omit';
+import values from 'lodash/values';
+import url from 'url';
+
+import isFakeSubreddit from 'lib/isFakeSubreddit';
+import { getEventTracker } from 'lib/eventTracker';
+
+const ID_REGEX = /(?:t\d+_)?(.*)/;
+
+export function convertId(id) {
+  const unprefixedId = ID_REGEX.exec(id)[1];
+  return parseInt(unprefixedId, 36);
+}
+
+
+export function buildSubredditData(state) {
+  const { subredditName } = state.platform.currentPage.urlParams;
+
+  if (!isFakeSubreddit(subredditName)) {
+    const subreddit = state.subreddits[subredditName.toLowerCase()];
+    return {
+      sr_id: convertId(subreddit.name),
+      sr_name: subreddit.uuid,
+    };
+  }
+  return {};
+}
+
+
+export function getBasePayload(state) {
+  // NOTE: this is only for usage on the client since it has references to window
+  const { user, accounts } = state;
+  const referrer = state.platform.currentPage.referrer || '';
+  const domain = window.location.host;
+
+  const userAccount = user.loggedOut ? null : accounts[user.name];
+
+  const payload = {
+    domain,
+    geoip_country: state.meta.country,
+    user_agent: state.meta.userAgent,
+    referrer_domain: url.parse(referrer).host || domain,
+    referrer_url: referrer,
+    language: state.preferences.lang,
+    dnt: !!window.DO_NOT_TRACK,
+    compact_view: state.compact,
+  };
+
+  if (userAccount) {
+    payload.user_name = userAccount.name;
+    payload.user_id = convertId(userAccount.id);
+  } else {
+    payload.loid = state.loid.loid;
+    payload.loid_created = state.loid.loidCreated;
+  }
+
+  return payload;
+}
+
+
+
+const IGNORE_PARAMS = ['overlayMenu', 'commentReply'];
+let lastUrlToken = null;
+
+export function logClientScreenView(data, _state) {
+  // NOTE: This block is a total hack to fix multiple pageviews. The way it
+  // works is by normalizing urls and their parameters. If a query parameter
+  // is in the ignore list, then it doesn't dirty the url and doesn't
+  // contribute to a page view.
+  // DELETE after ephemeral views having urls is fixed.
+  const paramToken = values(omit(_state.platform.currentPage.queryParams, IGNORE_PARAMS))
+    .sort()
+    .join('-');
+
+  const urlToken = _state.platform.currentPage.url + paramToken;
+  if (urlToken !== lastUrlToken) {
+    lastUrlToken = urlToken;
+  } else {
+    return;
+  }
+  // end hack
+
+  if (process.env.ENV === 'client') {
+    getEventTracker().track('screenview_events', 'cs.screenview_mweb', data);
+  }
+}

--- a/src/lib/isFakeSubreddit.js
+++ b/src/lib/isFakeSubreddit.js
@@ -1,8 +1,13 @@
-const randomSubs = ['random', 'randnsfw', 'myrandom'];
-const fakeSubs = ['all', 'mod', 'friends'].concat(randomSubs);
+const RANDOM_SUBS = ['random', 'randnsfw', 'myrandom'];
+const FAKE_SUBS = ['all', 'mod', 'friends'].concat(RANDOM_SUBS);
 
-export { fakeSubs, randomSubs };
+export { FAKE_SUBS, RANDOM_SUBS };
 
 export default function isFakeSubreddit(subredditName) {
-  return !subredditName || (subredditName.indexOf('+') > -1 || fakeSubs.includes(subredditName));
+  return (
+    !subredditName ||                     // the frontpage
+    subredditName.indexOf('+') > -1 ||    // multis
+    subredditName.indexOf('-') > -1 ||    // reddit gold filtering
+    FAKE_SUBS.includes(subredditName)     // special subreddits
+  );
 }

--- a/test/lib/isFakeSubreddit.test.js
+++ b/test/lib/isFakeSubreddit.test.js
@@ -1,7 +1,8 @@
 import chai from 'chai';
 import sinonChai from 'sinon-chai';
-import isFakeSubreddit from '../../src/lib/isFakeSubreddit';
-import { fakeSubs } from '../../src/lib/isFakeSubreddit';
+
+import isFakeSubreddit, { FAKE_SUBS } from 'lib/isFakeSubreddit';
+
 
 chai.use(sinonChai);
 const expect = chai.expect;
@@ -21,7 +22,7 @@ describe('lib: isFakeSubreddit', () => {
   });
 
   it('returns true for any of the special fake fubs', () => {
-    fakeSubs.forEach((fakeSub) => {
+    FAKE_SUBS.forEach((fakeSub) => {
       expect(isFakeSubreddit(fakeSub)).to.be.true;
     });
   });


### PR DESCRIPTION
The pages this adds events to are the following:

- subreddits
- special subreddits (frontpage, all, etc)
- profiles
- messages
- login
- registration
- posting

This list is derived from Justin's comment on this [ticket](https://reddit.atlassian.net/browse/DA-638?focusedCommentId=55474&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-55474).

This does things differently than the original events patch. The original patch had middleware listening for `SET_PAGE`. The problem with this approach is that pages have very different field requirements. Sometimes the data for those fields wasn't even available unless it was asynchronously fetched for. The code was fast becoming a mess of special handling statements.

The approach this takes is to ask for the required data explicitly in the handler and wait for their responses to make the event request. This obviously comes at the expense of DRY-ness but I think overall is a win for clarity/maintainability.

One thing to note, is that tracking should only be happening server side. Each tracking call is protected by an "is client" check. One thing we might want to consider is putting this check into the eventTracker code directly.

TODO:
- [x] `screenview` name should have `mweb` in it? (check with Justin on this)
- [x] blocked on @umbrae checking with data team on the multi-logging issue
- [x] correct tracking endpoint and credentials

:eyeglasses: @schwers @nramadas 
