### PR TITLE
Add canonical link tags when NOT shell rendering

### DIFF
--- a/src/lib/createCanonicalLinkFromState.js
+++ b/src/lib/createCanonicalLinkFromState.js
@@ -1,0 +1,91 @@
+import { matchRoute } from '@r/platform/navigationMiddleware';
+import values from 'lodash/values';
+
+import config from 'config';
+
+export const listingCanonical = (currentPage, state) => {
+  const { subredditName } = currentPage.urlParams;
+  const subreddit = state.subreddits[subredditName];
+
+  if (subreddit) {
+    return subreddit.url;
+  }
+
+  // we might not have a subreddit loaded because it is a multi-reddit. in that
+  // case, we're going to make our best attempt at canonicalizing the url by
+  // bulding a map of lowercased subreddit names to their canonicalized
+  // versions. this map will pull the canonical subreddit names from our "Posts"
+  // data.
+  // NOTE: if there is a very obscure subreddit in the multi-reddit, we might
+  // not have any posts loaded that are in that subreddit. meaning, our attempt
+  // at canonicalization will fail. this is something we've accepted for now.
+  const canonicalSubredditNames = values(state.posts).reduce((prev, post) => {
+    if (post.subreddit) {
+      prev[post.subreddit.toLowerCase()] = post.subreddit;
+    }
+    return prev;
+  }, {});
+
+  // split the multi-reddit and sort
+  let divider = '';
+  if (subredditName.indexOf('+') > -1) { // additive multi-reddit
+    divider = '+';
+  } else if (subredditName.indexOf('-') > -1) { // subtractive multi-reddit
+    divider = '-';
+  }
+
+  // make sure we can actually understand the multi-reddit. if it's some other
+  // format, just canonicalize it to the frontpage.
+  if (divider) {
+    const newName = subredditName
+      .split(divider)
+      .sort()
+      .map(s => canonicalSubredditNames[s.toLowerCase()] || s)
+      .join(divider);
+
+    return `/r/${newName}/`;
+  }
+
+  // desperation case. we don't know how to handle this url, so just
+  // canonicalize to the frontpage.
+  return '/';
+};
+
+export const commentsCanonical = (currentPage, state) => {
+  const { postId } = currentPage.urlParams;
+  return state.posts[`t3_${postId}`].cleanPermalink;
+};
+
+export const userCanonical = currentPage => {
+  const { userName } = currentPage.urlParams;
+  return `/user/${userName}/`;
+};
+
+export const baseCanonical = currentPage => currentPage.url.endsWith('/')
+  ? currentPage.url
+  : `${currentPage.url}/`;
+
+const CANONICAL_ROUTES = [
+  // listings
+  ['/r/:subredditName', listingCanonical],
+  ['/r/:subredditName/about', listingCanonical],
+  // comment pages
+  ['/r/:subredditName/comments/:postId/comment/:commentId', commentsCanonical],
+  ['/r/:subredditName/comments/:postId/:postTitle/:commentId', commentsCanonical],
+  ['/r/:subredditName/comments/:postId/:postTitle?', commentsCanonical],
+  ['/comments/:postId/:postTitle/:commentId', commentsCanonical],
+  ['/comments/:postId/:postTitle?', commentsCanonical],
+  // user pages
+  ['/u/:userName/activity', userCanonical],
+  ['/u/:userName/gild', userCanonical],
+  ['/u/:userName/:savedOrHidden(saved|hidden)', userCanonical],
+  ['/u/:userName', userCanonical],
+  // catch-all
+  ['*', baseCanonical],
+];
+
+export default state => {
+  const currentPage = state.platform.currentPage;
+  const { handler } = matchRoute(currentPage.url, CANONICAL_ROUTES);
+  return `${config.reddit}${handler(currentPage, state)}`;
+};

--- a/src/server/templates/main.jsx
+++ b/src/server/templates/main.jsx
@@ -5,6 +5,7 @@ import App from '../../app';
 import manifest from '../../../build/manifest';
 import config from 'config';
 import { themeClass } from './themeClass';
+import createCanonicalLinkFromState from 'lib/createCanonicalLinkFromState';
 
 const env = process.env.NODE_ENV || 'production';
 const CLIENT_NAME = env === 'production' ? 'ProductionClient' : 'Client';
@@ -13,6 +14,12 @@ const JS_FILE = manifest[`${CLIENT_NAME}.js`];
 const { assetPath } = config;
 
 export default function(data, store) {
+  const state = store.getState();
+
+  const canonicalLink = !state.platform.shell
+    ? createCanonicalLinkFromState(state)
+    : '';
+
   return ReactServerDom.renderToStaticMarkup(
     <html lang='en'>
       <head>
@@ -27,6 +34,7 @@ export default function(data, store) {
         <link href={ `${assetPath}/favicon/120x120.png` } rel="apple-touch-icon" sizes="120x120" />
         <link href={ `${assetPath}/favicon/152x152.png` } rel="apple-touch-icon" sizes="152x152" />
         <link href={ `${assetPath}/favicon/180x180.png` } rel="apple-touch-icon" sizes="180x180" />
+        { canonicalLink ? <link rel='canonical' href={ canonicalLink }/> : null }
       </head>
       <body className={ themeClass(data.theme) }>
         <div


### PR DESCRIPTION
Add canonical link tags when the html is server-rendered. It only targets server renders because it assumes we don't need to worry about canonicals in non seo-bot situations.

:eyeglasses: @prashtx 