### PR TITLE
Get "go to desktop" working

### DIFF
--- a/blueprints.config.js
+++ b/blueprints.config.js
@@ -25,6 +25,7 @@ module.exports = function(isProduction) {
         TRACKER_ENDPOINT: JSON.stringify(process.env.TRACKER_ENDPOINT || 'XXX'),
         TRACKER_SECRET: JSON.stringify(process.env.TRACKER_SECRET || 'XXX'),
         TRACKER_CLIENT_NAME: JSON.stringify(process.env.TRACKER_CLIENT_NAME || 'XXX'),
+        REDDIT: JSON.stringify(process.env.REDDIT),
       },
     },
   ]);

--- a/src/app/components/OverlayMenu/OverlayMenuRow.jsx
+++ b/src/app/components/OverlayMenu/OverlayMenuRow.jsx
@@ -95,6 +95,7 @@ LinkRow.propTypes = {
   href: T.string.isRequired,
   noRoute: T.bool,
   clickHandler: T.func,
+  onClick: T.func,
 };
 
 function LinkRow(props) {
@@ -108,7 +109,7 @@ function LinkRow(props) {
   };
 
   return (
-    <li className='OverlayMenu-row'>
+    <li className='OverlayMenu-row' onClick={ props.onClick }>
       { props.noRoute
         ? <a { ...linkElementProps } />
         : <Anchor { ...linkElementProps } />

--- a/src/app/components/OverlayMenu/index.jsx
+++ b/src/app/components/OverlayMenu/index.jsx
@@ -4,11 +4,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import * as overlayMenuActions from 'app/actions/overlayMenu';
-
-import {
-  OVERLAY_MENU_CSS_CLASS,
-  OVERLAY_MENU_CSS_TOP_NAV_MODIFIER,
-} from 'app/constants';
+import cx from 'lib/classNames';
 
 const T = React.PropTypes;
 
@@ -16,18 +12,9 @@ const stopClickPropagation = (e) => {
   e.stopPropagation();
 };
 
-const overlayClassName = (props) => {
-  let className = OVERLAY_MENU_CSS_CLASS;
-  if (!props.fullscreen) {
-    className += ` ${OVERLAY_MENU_CSS_TOP_NAV_MODIFIER}`;
-  }
-
-  return className;
-};
-
-export const OverlayMenu = (props) => (
+export const OverlayMenu = props => (
   <nav
-    className={ overlayClassName(props) }
+    className={ cx('OverlayMenu', { 'm-with-top-nav': !props.fullscreen }) }
     onClick={ props.closeOverlayMenu }
   >
     <ul className='OverlayMenu-ul list-unstyled' onClick={ stopClickPropagation }>
@@ -44,4 +31,4 @@ const mapDispatchProps = (dispatch) => ({
   closeOverlayMenu: () => dispatch(overlayMenuActions.closeOverlayMenu()),
 });
 
-export default connect(() => ({}), mapDispatchProps)(OverlayMenu);
+export default connect(null, mapDispatchProps)(OverlayMenu);

--- a/src/app/constants.js
+++ b/src/app/constants.js
@@ -16,10 +16,6 @@ export const OVERLAY_MENU_OPEN = 'overlayMenuOpen';
 
 export const OVERLAY_MENU_OFFSET = -10; // from cs;
 
-export const OVERLAY_MENU_CSS_CLASS = 'OverlayMenu';
-
-export const OVERLAY_MENU_CSS_TOP_NAV_MODIFIER = 'm-with-top-nav';
-
 export const OVERLAY_MENU_VISIBLE_CSS_CLASS = 'OverlayMenu-visible';
 
 export const DROPDOWN_CSS_CLASS = 'Dropdown';


### PR DESCRIPTION
This works by first settings the `mweb-no-redirect` cookie on click, and then
going to the www analogue of the current url using a normal anchor.

Assumptions:

- This assumes that the onclick handler fires synchronously before the browser
  takes the user to the new location. From browser testing, this seems true.

Notes:

- Right now, we define the www url as separate than the m. url. Eventually,
  when both clients are on the www urls, we can (if we wanted to - there might
  be reasons not to) update this patch to just use the relative path.

This is semi-blocked on https://github.com/reddit/reddit-mobile/pull/730, which has some DefinePlugin updates. I could technically just add `REDDIT` to `process.env` right now but that'd result in a merge conflict. So I'll just wait.

:eyeglasses: @schwers @nramadas 