### PR TITLE
Keep the client definePlugin fallbacks in config

### DIFF
--- a/blueprints.config.js
+++ b/blueprints.config.js
@@ -21,10 +21,10 @@ module.exports = function(isProduction) {
     {
       generator: 'set-node-env',
       'process.env': {
-        TRACKER_KEY: JSON.stringify(process.env.TRACKER_KEY || 'XXX'),
-        TRACKER_ENDPOINT: JSON.stringify(process.env.TRACKER_ENDPOINT || 'XXX'),
-        TRACKER_SECRET: JSON.stringify(process.env.TRACKER_SECRET || 'XXX'),
-        TRACKER_CLIENT_NAME: JSON.stringify(process.env.TRACKER_CLIENT_NAME || 'XXX'),
+        TRACKER_KEY: JSON.stringify(process.env.TRACKER_KEY),
+        TRACKER_ENDPOINT: JSON.stringify(process.env.TRACKER_ENDPOINT),
+        TRACKER_SECRET: JSON.stringify(process.env.TRACKER_SECRET),
+        TRACKER_CLIENT_NAME: JSON.stringify(process.env.TRACKER_CLIENT_NAME),
         REDDIT: JSON.stringify(process.env.REDDIT),
       },
     },

--- a/src/config.js
+++ b/src/config.js
@@ -53,10 +53,10 @@ const config = () => ({
   adsPath: process.env.ADS_PATH || '/api/request_promo.json',
   manifest: {},
 
-  trackerKey: process.env.TRACKER_KEY,
-  trackerEndpoint: process.env.TRACKER_ENDPOINT,
-  trackerClientSecret: process.env.TRACKER_SECRET,
-  trackerClientAppName: process.env.TRACKER_CLIENT_NAME,
+  trackerKey: process.env.TRACKER_KEY || 'XXX',
+  trackerEndpoint: process.env.TRACKER_ENDPOINT || 'XXX',
+  trackerClientSecret: process.env.TRACKER_SECRET || 'XXX',
+  trackerClientAppName: process.env.TRACKER_CLIENT_NAME || 'XXX',
 
   // If statsdHost isn't set, then statsd is skipped
   statsdHost: process.env.STATSD_HOST,


### PR DESCRIPTION
It's confusing to possibly have these types of fallbacks in two different places, so move them into config.js.

:eyeglasses: @schwers 