### PR TITLE
2x more verbose errors

### DIFF
--- a/blueprints.config.js
+++ b/blueprints.config.js
@@ -21,11 +21,12 @@ module.exports = function(isProduction) {
     {
       generator: 'set-node-env',
       'process.env': {
-        TRACKER_KEY: JSON.stringify(process.env.TRACKER_KEY),
-        TRACKER_ENDPOINT: JSON.stringify(process.env.TRACKER_ENDPOINT),
-        TRACKER_SECRET: JSON.stringify(process.env.TRACKER_SECRET),
-        TRACKER_CLIENT_NAME: JSON.stringify(process.env.TRACKER_CLIENT_NAME),
         REDDIT: JSON.stringify(process.env.REDDIT),
+        STATS_URL: JSON.stringify(process.env.STATS_URL),
+        TRACKER_CLIENT_NAME: JSON.stringify(process.env.TRACKER_CLIENT_NAME),
+        TRACKER_ENDPOINT: JSON.stringify(process.env.TRACKER_ENDPOINT),
+        TRACKER_KEY: JSON.stringify(process.env.TRACKER_KEY),
+        TRACKER_SECRET: JSON.stringify(process.env.TRACKER_SECRET),
       },
     },
   ]);

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@r/api-client": "~3.22.3",
     "@r/build": "~0.10.0",
     "@r/flags": "^1.5.0",
-    "@r/middleware": "~0.8.0",
+    "@r/middleware": "~0.8.1",
     "@r/platform": "~0.14.0",
     "@r/private": "~0.2.3",
     "@r/redux-state-archiver": "~0.0.5",

--- a/src/Server.js
+++ b/src/Server.js
@@ -36,10 +36,10 @@ const processes = process.env.PROCESSES || cpus().length;
 
 // If we miss catching an exception, format and log it before exiting the
 // process.
-process.on('uncaughtException', function (err) {
+process.on('uncaughtException', function (error) {
   // errorLog will be console.logging the formatted output
   errorLog({
-    error: err,
+    error,
     userAgent: 'SERVER',
   }, {
     hivemind: config.statsURL,

--- a/src/server/meta/index.js
+++ b/src/server/meta/index.js
@@ -1,8 +1,8 @@
 import crypto from 'crypto';
 
-import { isString } from 'lodash/lang';
 import superagent from 'superagent';
 
+import { formatLogJSON } from 'lib/errorLog';
 import { DEFAULT_API_TIMEOUT } from 'app/constants';
 
 const mServerName = name => `m2.server.${name}`;
@@ -117,8 +117,8 @@ export default (router, apiOptions) => {
     // log it out if it's a legit origin
     if (ctx.headers.origin &&
         apiOptions.servedOrigin.indexOf(ctx.headers.origin) === 0 &&
-        isString(error)) {
-      console.log(error.substring(0,1000));
+        typeof error === 'object') {
+      console.log(formatLogJSON(error));
     }
 
     ctx.body = null;

--- a/src/server/meta/stats.js
+++ b/src/server/meta/stats.js
@@ -33,16 +33,19 @@ export default router => {
     activeRequests += 1;
 
     const start = Date.now();
+
     try {
       await next();
-    } catch (e) {
+    } catch (error) {
       errorLog({
-        error: `${e.name}: ${e.message}`,
+        error,
+        requestUrl: ctx.request.url,
         userAgent: 'SERVER',
       }, {
         hivemind: config.statsURL,
       });
     }
+
     const delta = Math.ceil(Date.now() - start);
     statsd.timing('response_time', delta);
 


### PR DESCRIPTION
👓  @nramadas  @uzi  @phil303 

This patch is a start of making errors more useful in dev and production in mweb. My plan is to get this reviewed asap to find out pain points with this applied, and add more updates next week.

I'll roll the details into the commit body when review is finished, but at a high-level:

* Fixed an issue where client wasn't sending errors to the server `/error` endpoint. This prevented errors from being logged to the server logs, which in turn hides the errors from the log file.

* Fixed an issue where client errors weren't properly setting the `CLIENT|SERVER` env when formatting logs.

* Fixed an issue with parsing stack traces that prevent error messages from showing up.

* Fixed an issue where the `try/catch` handler in the stats timing middleware was preventing error info from being gathered correctly. (I should have caught this in review, whoops!)

* Started using `console.error` in the client if available, this makes errors more prominent, and we can expand this section like a stack trace to have source map'd stack traces in dev. You'll see the whole log we're sending to the server, so there's a bit of stack repeat but it seems worth it.
**  Note: Chrome is logging some errors in promises as uncaught, even though we're clearly catching and logging the error milliseconds before. Not sure what's going on there, but I think it has to do with how errors are getting caught. I plan to continue looking into this next week, this is just a first past to get dev experience better for now.

* Started passing stack traces to the `/error` endpoint. In dev newlines are preserved so it looks as expected, in production newlines are escaped so we can continue to use `tail -f $logfile | grep....`.
** Note: sourcemaps are not being parsed in stack traces we send, but I think we'll be able to use https://github.com/mozilla/source-map#consuming-a-source-map in a subsequent patch to fill in that info either in the logs we send to the server, or in a tool like `Uzitry` that sits above our logs and filters / displays them to us.

Before & Afters

One thing that's bitten us in the past is we get useless errors in the server, this happened a lot when trying to parse cookies in `dispatchSession`. So let's see what happens if we add

```js
  JSON.parse('{invalidjson:}');
```

to `dispatchSession` before there's any error handling. (we expect server only errors here)

Current 2X:

![image](https://cloud.githubusercontent.com/assets/307983/18603450/75b8d94a-7c26-11e6-815b-282d9b2cb2fc.png)


With this Path:

![image](https://cloud.githubusercontent.com/assets/307983/18603377/b68e4f64-7c25-11e6-9386-6d9494739c50.png)


Now what about if we have an error in an async action? For example, if we add an undefined variable reference to the beginning of the fetch action in `app/actions/postsList.js`

```js
helloImUndefined;
```

Current 2X:

Client console:

![image](https://cloud.githubusercontent.com/assets/307983/18603441/5f00bc18-7c26-11e6-804f-121244caa310.png)

Server:
[Crickets -- nothing is getting logged at present]

With this patch:

Client console:

![image](https://cloud.githubusercontent.com/assets/307983/18603427/3cb9cfa0-7c26-11e6-8550-14094bb768fd.png)

Server:

![image](https://cloud.githubusercontent.com/assets/307983/18603429/42ff06c8-7c26-11e6-999d-0fbb05bdb91d.png)




