### PR TITLE
Fix a bug in pageview tracking

### DIFF
--- a/src/app/router/handlers/CommentsPage.js
+++ b/src/app/router/handlers/CommentsPage.js
@@ -66,8 +66,7 @@ export default class CommentsPage extends BaseHandler {
 
     dispatch(setStatus(getState().commentsPages[commentsPageId].responseCode));
 
-    const _tempState = getState();
-    logClientScreenView(buildScreenViewData(getState()), _tempState);
+    logClientScreenView(buildScreenViewData, getState());
   }
 
   async [METHODS.POST](dispatch, getState, { waitForState }) {

--- a/src/app/router/handlers/DirectMessage.js
+++ b/src/app/router/handlers/DirectMessage.js
@@ -9,8 +9,7 @@ export default class DirectMessage extends BaseHandler {
   async [METHODS.GET](dispatch, getState) {
     await fetchUserBasedData(dispatch);
 
-    const _tempState = getState();
-    logClientScreenView(getBasePayload(getState()), _tempState);
+    logClientScreenView(getBasePayload, getState());
   }
 
   async [METHODS.POST](dispatch, getState/*, utils*/) {

--- a/src/app/router/handlers/Login.js
+++ b/src/app/router/handlers/Login.js
@@ -9,8 +9,7 @@ import { getBasePayload, logClientScreenView } from 'lib/eventUtils';
 
 export default class Login extends BaseHandler {
   async [METHODS.GET](dispatch, getState) {
-    const _tempState = getState();
-    logClientScreenView(getBasePayload(getState()), _tempState);
+    logClientScreenView(getBasePayload, getState());
   }
 
   async [METHODS.POST](dispatch) {

--- a/src/app/router/handlers/Messages.js
+++ b/src/app/router/handlers/Messages.js
@@ -9,7 +9,6 @@ export default class Messages extends BaseHandler {
     dispatch(mailActions.fetchInbox(this.urlParams.mailType));
     await fetchUserBasedData(dispatch);
 
-    const _tempState = getState();
-    logClientScreenView(getBasePayload(getState()), _tempState);
+    logClientScreenView(getBasePayload, getState());
   }
 }

--- a/src/app/router/handlers/PostSubmit.js
+++ b/src/app/router/handlers/PostSubmit.js
@@ -15,8 +15,7 @@ export class PostSubmitHandler extends BaseHandler {
 
     await fetchUserBasedData(dispatch);
 
-    const _tempState = getState();
-    logClientScreenView(getBasePayload(getState()), _tempState);
+    logClientScreenView(getBasePayload, getState());
   }
 }
 
@@ -34,7 +33,6 @@ export class PostSubmitCommunityHandler extends BaseHandler {
 
     await fetchUserBasedData(dispatch);
 
-    const _tempState = getState();
-    logClientScreenView(getBasePayload(getState()), _tempState);
+    logClientScreenView(getBasePayload, getState());
   }
 }

--- a/src/app/router/handlers/PostsFromSubreddit.js
+++ b/src/app/router/handlers/PostsFromSubreddit.js
@@ -53,8 +53,7 @@ export default class PostsFromSubreddit extends BaseHandler {
 
     dispatch(setStatus(getState().postsLists[postsListId].responseCode));
 
-    const _tempState = getState();
-    logClientScreenView(buildScreenViewData(getState()), _tempState);
+    logClientScreenView(buildScreenViewData, getState());
   }
 }
 

--- a/src/app/router/handlers/Register.js
+++ b/src/app/router/handlers/Register.js
@@ -9,8 +9,7 @@ import { getBasePayload, logClientScreenView } from 'lib/eventUtils';
 
 export default class Register extends BaseHandler {
   async [METHODS.GET](dispatch, getState) {
-    const _tempState = getState();
-    logClientScreenView(getBasePayload(getState()), _tempState);
+    logClientScreenView(getBasePayload, getState());
   }
 
   async [METHODS.POST](dispatch) {

--- a/src/app/router/handlers/UserProfile.js
+++ b/src/app/router/handlers/UserProfile.js
@@ -18,8 +18,7 @@ export default class UserProfilerHandler extends BaseHandler {
       fetchUserBasedData(dispatch),
     ]);
 
-    const _tempState = getState();
-    logClientScreenView(buildScreenViewData(getState()), _tempState);
+    logClientScreenView(buildScreenViewData, getState());
   }
 }
 

--- a/src/lib/eventUtils.js
+++ b/src/lib/eventUtils.js
@@ -62,17 +62,17 @@ export function getBasePayload(state) {
 const IGNORE_PARAMS = ['overlayMenu', 'commentReply'];
 let lastUrlToken = null;
 
-export function logClientScreenView(data, _state) {
+export function logClientScreenView(buildScreenViewData, state) {
   // NOTE: This block is a total hack to fix multiple pageviews. The way it
   // works is by normalizing urls and their parameters. If a query parameter
   // is in the ignore list, then it doesn't dirty the url and doesn't
   // contribute to a page view.
   // DELETE after ephemeral views having urls is fixed.
-  const paramToken = values(omit(_state.platform.currentPage.queryParams, IGNORE_PARAMS))
+  const paramToken = values(omit(state.platform.currentPage.queryParams, IGNORE_PARAMS))
     .sort()
     .join('-');
 
-  const urlToken = _state.platform.currentPage.url + paramToken;
+  const urlToken = state.platform.currentPage.url + paramToken;
   if (urlToken !== lastUrlToken) {
     lastUrlToken = urlToken;
   } else {
@@ -81,6 +81,10 @@ export function logClientScreenView(data, _state) {
   // end hack
 
   if (process.env.ENV === 'client') {
-    getEventTracker().track('screenview_events', 'cs.screenview_mweb', data);
+    getEventTracker().track(
+      'screenview_events',
+      'cs.screenview_mweb',
+      buildScreenViewData(state),
+    );
   }
 }


### PR DESCRIPTION
Problem:
When shell was set to false, we were server rendering. Also, since shell
was set to false, we were running a function that was building tracking
data for us. This function relied on the window object, which obviously
doesn't exist server-side, and was causing an exception.

Fix:
Because we want to make a client side check before we build this data,
I'm now passing the data building function as a callback to the
`logClientScreenView` function.

:eyeglasses: @uzi 