### PR TITLE
Pass loidcreated cookie header in UTC format.

### DIFF
--- a/src/lib/apiOptionsFromState.js
+++ b/src/lib/apiOptionsFromState.js
@@ -15,7 +15,7 @@ export const apiOptionsFromState = state => {
     return merge(options, {
       appName: '2x-server',
       headers: {
-        'Cookie': `loid=${loid}; loidcreated=${loidCreated}`,
+        'Cookie': `loid=${loid}; loidcreated=${(new Date(loidCreated)).toISOString()}`,
       },
     });
   }


### PR DESCRIPTION
The api expects loidcreated to be in UTC format, passing
unix time as we've been doing makes all of our server-side api
calls fail. This only really matters for googlebot right now,
hence why we didn't notice it sooner.

Test this by making a fake device profile in chrome with user agent 'googlebot', and making server side requests.

👓  @nramadas @uzi 