### PR TITLE
Rum timings refinement

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -18,6 +18,16 @@ import reduxMiddleware from 'app/reduxMiddleware';
 import { sendTimings } from 'lib/timing';
 import Session from 'app/models/Session';
 
+// Bits to help in the gathering of client side timings to relay back
+// to the server
+const beginMount = Date.now();
+let isShell;
+
+window.onload = () => {
+  const endMount = Date.now();
+  sendTimings(beginMount, endMount, isShell);
+}
+
 // register window.onError asap so we can catch errors in the client's init
 window.onerror = (message, url, line, column) => {
   errorLog({
@@ -46,7 +56,6 @@ window.onunhandledrejection = rejection => {
 };
 
 // start the app now
-const beginRender = Date.now();
 const client = Client({
   routes,
   reducers,
@@ -101,5 +110,5 @@ const client = Client({
   debug: (process.env.NODE_ENV || 'production') !== 'production',
 })();
 
+isShell = client.getState().platform.shell;
 client.dispatch(actions.activateClient());
-sendTimings(beginRender);

--- a/src/lib/timing.js
+++ b/src/lib/timing.js
@@ -46,18 +46,23 @@ export function getTimes() {
   return timings;
 }
 
-export function sendTimings(beginRender) {
+export function sendTimings(beginMount, endMount, isShell) {
   if (Math.random() > 0.1) { // 10% of requests
     return;
   }
 
-  const actionName = 'm2.server.shell';
+  if (isShell === undefined) {
+    console.warn('Could not detect if session is shell rendered.');
+    return;
+  }
+
+  const actionName = isShell ? 'm2.server.shell' : 'm2.server.seo';
 
   const timings = Object.assign({
     actionName,
   }, getTimes());
 
-  timings.mountTiming = (Date.now() - beginRender) / 1000;
+  timings.mountTiming = (endMount - beginMount) / 1000;
 
   makeRequest
     .post('/timings')


### PR DESCRIPTION
- Send timings based on the onLoad event.
- Detect if we're shell or seo rendered.
- Resolve the promise when we exit early.
- Make server and client messaging more clear.

Examples of data sent when we're shell rendered:
```
 { actionName: 'm2.server.shell',
  startTiming: 0.02200007438659668,
  requestTiming: 0.2989997863769531,
  responseTiming: 0.002000093460083008,
  domLoadingTiming: 0.09200000762939453,
  mountTiming: 0.101 }
```

And when we're rendered for seo:
```
 { actionName: 'm2.server.seo',
  requestTiming: 1.38100004196167,
  responseTiming: 0.003000020980834961,
  domLoadingTiming: 0.17599987983703613,
  mountTiming: 0.378 }
```

👓 @schwers @nramadas @phil303 