### PR TITLE
Support /user/* routes

### DIFF
--- a/src/app/components/Comment/CommentDropdown/index.jsx
+++ b/src/app/components/Comment/CommentDropdown/index.jsx
@@ -32,7 +32,7 @@ export default function CommentDropdown(props) {
         ? <DropdownRow icon='save' text={ isSaved ? 'Saved' : 'Save' } isSelected={ isSaved } onClick={ onToggleSave }/>
         : null }
       { !userIsAuthor
-        ? <DropdownLinkRow href={ `/u/${commentAuthor}` } icon='user-account' text={ `${commentAuthor}'s profile` }/>
+        ? <DropdownLinkRow href={ `/user/${commentAuthor}` } icon='user-account' text={ `${commentAuthor}'s profile` }/>
         : null }
       { username
         ? <DropdownLinkRow href='/report' icon='flag' text='Report'/>

--- a/src/app/components/GoogleCarouselMetadata/index.jsx
+++ b/src/app/components/GoogleCarouselMetadata/index.jsx
@@ -63,7 +63,7 @@ const commentsPageMetaData = (pageUrl, post, comments) => ({
   author: {
     '@type': 'Person',
     name: post.author,
-    url: `${reddit}/u/${post.author}/`,
+    url: `${reddit}/user/${post.author}/`,
   },
 
   // Post content info
@@ -111,7 +111,7 @@ const formatComments = comments => (
     author: {
       '@type': 'Person',
       name: c.author,
-      url: `${reddit}/u/${c.author}/`,
+      url: `${reddit}/user/${c.author}/`,
     },
     commentCount: c.replies.length,
     aggregateRating: c.score,

--- a/src/app/components/Post/PostDropdown/index.jsx
+++ b/src/app/components/Post/PostDropdown/index.jsx
@@ -20,7 +20,7 @@ export default function PostDropdown(props) {
     <Dropdown id={ id }>
       <DropdownLinkRow href={ permalink } icon='link' text='Permalink'/>
       <DropdownLinkRow href={ `/r/${subreddit}` } icon='snoosilhouette' text={ `More from r/${subreddit}` }/>
-      <DropdownLinkRow href={ `/u/${author}` } icon='user-account' text={ `${author}'s profile` }/>
+      <DropdownLinkRow href={ `/user/${author}` } icon='user-account' text={ `${author}'s profile` }/>
       { isLoggedIn ? <DropdownRow icon='save' text={ isSaved ? 'Saved' : 'Save' } onClick={ onToggleSave } isSelected={ isSaved }/> : null }
       { isLoggedIn ? <DropdownRow icon='hide' text='Hide' onClick={ onToggleHide }/> : null }
       { isLoggedIn ? <DropdownLinkRow href='/report' icon='flag' text='Report'/> : null }

--- a/src/app/components/SettingsOverlayMenu/index.jsx
+++ b/src/app/components/SettingsOverlayMenu/index.jsx
@@ -59,7 +59,7 @@ export const renderLoggedInUserRows = (user) => {
     <LinkRow
       key='account'
       text={ user.name }
-      href={ `/u/${user.name}` }
+      href={ `/user/${user.name}` }
       icon={ userIconClassName }
     >
       <form className='OverlayMenu-row-right-item' action='/logout' method='POST'>
@@ -79,7 +79,7 @@ export const renderLoggedInUserRows = (user) => {
     <LinkRow
       key='saved'
       text='Saved'
-      href={ `/u/${user.name}/saved` }
+      href={ `/user/${user.name}/saved` }
       icon='icon-save icon-large lime'
     />,
 

--- a/src/app/components/UserProfileHeader/index.jsx
+++ b/src/app/components/UserProfileHeader/index.jsx
@@ -35,7 +35,7 @@ const UserProfileTabs = props => {
   return (
     <nav className='UserProfileHeader__tabs'>
       <UserProfileTab
-        href={ `/u/${userName}` }
+        href={ `/user/${userName}` }
         icon='icon-user-account'
         text='ABOUT'
         selected={ currentActivity === undefined }

--- a/src/app/components/UserProfileSummary/index.jsx
+++ b/src/app/components/UserProfileSummary/index.jsx
@@ -59,7 +59,7 @@ const GoldInfo = props => {
   }
 
   return (
-    <Anchor href={ `/u/${user.name}/gild` }>
+    <Anchor href={ `/user/${user.name}/gild` }>
       <UserProfileRow>
         <UserProfileBadge
           text={ `Give ${user.name} gold` }

--- a/src/app/components/UserProfileSummary/index.jsx
+++ b/src/app/components/UserProfileSummary/index.jsx
@@ -60,12 +60,14 @@ const GoldInfo = props => {
 
   return (
     <Anchor href={ `/u/${user.name}/gild` }>
-      <UserProfileBadge
-        text={ `Give ${user.name} gold` }
-        subtext='show your appreciation'
-      >
-        <UserProfileBadgeIcon iconName='gold-snoo' color='gold' />
-      </UserProfileBadge>
+      <UserProfileRow>
+        <UserProfileBadge
+          text={ `Give ${user.name} gold` }
+          subtext='show your appreciation'
+        >
+          <UserProfileBadgeIcon iconName='gold-snoo' color='gold' />
+        </UserProfileBadge>
+      </UserProfileRow>
     </Anchor>
   );
 };

--- a/src/app/pages/AppMain.jsx
+++ b/src/app/pages/AppMain.jsx
@@ -64,10 +64,10 @@ const AppMain = ({ statusCode, url, referrer, isToasterOpen }) => {
           url='/comments/:postId/:postTitle?'
           component={ CommentsPage }
         />
-        <Page url='/u/:userName/activity' component={ UserActivityPage } />
-        <Page url='/u/:userName/gild' component={ UserProfilePage } />
-        <Page url='/u/:userName/:savedOrHidden(saved|hidden)' component={ SavedAndHiddenPage } />
-        <Page url='/u/:userName/' component={ UserProfilePage } />
+        <Page url='/user/:userName/activity' component={ UserActivityPage } />
+        <Page url='/user/:userName/gild' component={ UserProfilePage } />
+        <Page url='/user/:userName/:savedOrHidden(saved|hidden)' component={ SavedAndHiddenPage } />
+        <Page url='/user/:userName/' component={ UserProfilePage } />
         <Page url='/login' component={ Login } />
         <Page url='/register' component={ Register } />
         <Page url='/message/compose' component={ DirectMessage } />

--- a/src/app/pages/UserProfile/index.jsx
+++ b/src/app/pages/UserProfile/index.jsx
@@ -74,7 +74,7 @@ const OwnUserLinks = props => {
   );
 };
 
-const userLinkPath = (userName, subpath) => `/u/${userName}/${subpath}`;
+const userLinkPath = (userName, subpath) => `/user/${userName}/${subpath}`;
 
 const UserLink = props => {
   const { text, iconName, href } = props;

--- a/src/app/router/handlers/UserActivity.js
+++ b/src/app/router/handlers/UserActivity.js
@@ -10,7 +10,7 @@ import { urlWith } from 'lib/urlWith';
 
 export default class UserActivityHandler extends BaseHandler {
   static activityURL(userName, activity) {
-    return urlWith(`/u/${userName}/activity`, { activity });
+    return urlWith(`/user/${userName}/activity`, { activity });
   }
 
   static pageParamsToActivitiesParams({ urlParams, queryParams }) {

--- a/src/app/router/handlers/UserReroute.js
+++ b/src/app/router/handlers/UserReroute.js
@@ -1,0 +1,13 @@
+import { setPage } from '@r/platform/actions';
+import { BaseHandler, METHODS } from '@r/platform/router';
+
+export default class UserReroute extends BaseHandler {
+  async [METHODS.GET](dispatch, getState) {
+    const { platform: { currentPage }} = getState();
+    const { urlParams, queryParams, hashParams, referrer } = currentPage;
+    let { url } = currentPage;
+
+    url = url.replace('/u/', '/user/');
+    dispatch(setPage(url, { urlParams, queryParams, hashParams, referrer }));
+  }
+}

--- a/src/app/router/index.js
+++ b/src/app/router/index.js
@@ -18,13 +18,14 @@ import Messages from './handlers/Messages';
 import Vote from './handlers/Vote';
 import WikiPageHandler from './handlers/WikiPage';
 import { PostSubmitHandler, PostSubmitCommunityHandler } from './handlers/PostSubmit';
+import UserRerouteHandler from './handlers/UserReroute';
 import Status404PageHandler from './handlers/Status404Page';
 
 /* eslint-disable max-len */
 export default [
   ['/', PostsFromSubredditHandler, { name: 'index' }],
   ['/r/:subredditName', PostsFromSubredditHandler, { name: 'listing' }],
-  ['/u/:user/m/:multi', PostsFromSubredditHandler, { name: 'listing' }],
+  ['/user/:user/m/:multi', PostsFromSubredditHandler, { name: 'listing' }],
   ['/r/:subredditName/comments/:postId/comment/:commentId', CommentsPageHandler, { name: 'comments' }],
   ['/r/:subredditName/comments/:postId/:postTitle/:commentId', CommentsPageHandler, { name: 'comments' }],
   ['/r/:subredditName/comments/:postId/:postTitle?', CommentsPageHandler, { name: 'comments' }],
@@ -36,10 +37,10 @@ export default [
   ['/comments/:postId/:postTitle/:commentId', CommentsPageHandler, { name: 'comments' }],
   ['/comments/:postId/:postTitle?', CommentsPageHandler, { name: 'comments' }],
   ['/comments', CommentsPageHandler],
-  ['/u/:userName/activity', UserActivityHandler],
-  ['/u/:userName/gild', UserProfilerHandler],
-  ['/u/:userName/:savedOrHidden(saved|hidden)', SavedAndHiddenHandler],
-  ['/u/:userName', UserProfilerHandler, { name: 'user' }],
+  ['/user/:userName/activity', UserActivityHandler],
+  ['/user/:userName/gild', UserProfilerHandler],
+  ['/user/:userName/:savedOrHidden(saved|hidden)', SavedAndHiddenHandler],
+  ['/user/:userName', UserProfilerHandler, { name: 'user' }],
   ['/login', Login],
   ['/register', Register],
   ['/message/compose', DirectMessage],
@@ -56,6 +57,9 @@ export default [
   ['/actions/overlay-theme-toggle', OverlayMenuThemeToggleHandler],
   ['/actions/setOver18', SetOver18Handler],
   ['/actions/toggle-subreddit-subscription', ToggleSubredditSubscriptionHandler],
+
+  // reroutes
+  ['/u/*', UserRerouteHandler],
   ['*', Status404PageHandler],
 ];
 /* eslint-enable */

--- a/src/lib/createCanonicalLinkFromState.js
+++ b/src/lib/createCanonicalLinkFromState.js
@@ -76,10 +76,10 @@ const CANONICAL_ROUTES = [
   ['/comments/:postId/:postTitle/:commentId', commentsCanonical],
   ['/comments/:postId/:postTitle?', commentsCanonical],
   // user pages
-  ['/u/:userName/activity', userCanonical],
-  ['/u/:userName/gild', userCanonical],
-  ['/u/:userName/:savedOrHidden(saved|hidden)', userCanonical],
-  ['/u/:userName', userCanonical],
+  ['/user/:userName/activity', userCanonical],
+  ['/user/:userName/gild', userCanonical],
+  ['/user/:userName/:savedOrHidden(saved|hidden)', userCanonical],
+  ['/user/:userName', userCanonical],
   // catch-all
   ['*', baseCanonical],
 ];


### PR DESCRIPTION
I've implemented this as additional valid urls in order to get this in and supported in a timely fashion.  The real thing we'll want to do of course is have the /u/* variants be 301 redirects to the /user/* ones, but this is a start.

I threw in a patch to change many of the /u/* links in the system to /user/* ones.  I'm not sure if we want any of these, but I at least wanted to call it out.

Also tossed in a small cosmetic issue while I was in the neighborhood.

👓 @schwers @phil303 @nramadas @umbrae 