### PR TITLE
Send timings data on all visits

### DIFF
--- a/src/lib/timing.js
+++ b/src/lib/timing.js
@@ -2,7 +2,9 @@ import { DEFAULT_API_TIMEOUT } from 'app/constants';
 
 import makeRequest from './makeRequest';
 
-const CLIENT_PERCENTAGE = 0.1;    // 10% of requests
+// We're getting all timings for now, but this is here for if/when
+// we decide to scale back (like '0.1' for 10% of users).
+const CLIENT_PERCENTAGE = 1.0;
 
 export function getTimes() {
   const performance = global.performance ||


### PR DESCRIPTION
Since we'll do a smaller launch of 2X initially,
we'll get numbers for all visitors instead of 10%
for now and scale back later if needed.

👓  @schwers @umbrae 