### PR TITLE
Don't pass loidCreated header if we don't have it.

### DIFF
--- a/src/lib/apiOptionsFromState.js
+++ b/src/lib/apiOptionsFromState.js
@@ -12,10 +12,15 @@ export const apiOptionsFromState = state => {
   // grab loids if we have them, and set the cookie if on the server
   const { loid: { loid, loidCreated }, meta } = state;
   if (loid && meta.env !== 'CLIENT') {
+    const cookieHeaders = [ `loid=${loid}` ];
+    if (loidCreated) {
+      cookieHeaders.push(`loidcreated=${(new Date(loidCreated)).toISOString()}`);
+    }
+
     return merge(options, {
       appName: '2x-server',
       headers: {
-        'Cookie': `loid=${loid}; loidcreated=${(new Date(loidCreated)).toISOString()}`,
+        'Cookie': cookieHeaders.join(';'),
       },
     });
   }


### PR DESCRIPTION
It's possible to have loid and not loidCreated cookies
from inbound requests. In fact, this will always be the
case when we have server-signed loids. This patch fixes
an exception when we try to call `toISOString()` on an
invalid date, that was being created because we passed the
default empty string value for `loidCreated` to the Date
constructor. In general, we just shouldn't pass the
cookie header if we don't really have a loidCreated anyway.

👓  @uzi 