### PR TITLE
Various comments page cleanups

### DIFF
--- a/src/app/components/Comment/CommentHeader/styles.less
+++ b/src/app/components/Comment/CommentHeader/styles.less
@@ -81,6 +81,7 @@
 
   &__caron {
     margin-right: @grid-size;
+    transition: 0.2s;
 
     &.icon {
       font-size: 12px;

--- a/src/app/components/Comment/index.jsx
+++ b/src/app/components/Comment/index.jsx
@@ -35,12 +35,13 @@ export function Comment(props) {
     onToggleCollapse,
   } = props;
 
+  const commentClasses = cx('Comment', { 'in-comment-tree': !preview });
   const bodyClasses = cx('Comment__body', {
     'm-hidden': commentCollapsed && !isUserActivityPage,
   });
 
   return (
-    <div className={ cx('Comment', { 'in-comment-tree': !preview }) }>
+    <div className={ commentClasses }>
       <div className='Comment__header' id={ comment.id }>
         <CommentHeader
           id={ comment.id }
@@ -169,18 +170,14 @@ function renderReplies(props) {
 }
 
 function renderMoreCommentsButton(props) {
-  const { comment, moreCommentStatus, onLoadMore, nestingLevel } = props;
+  const { comment, moreCommentStatus, onLoadMore } = props;
 
   const loadingText = moreCommentStatus.loading
     ? LOADING_MORE_COMMENTS
     : `${LOAD_MORE_COMMENTS} (${comment.numReplies})`;
 
-  const className = cx('Comment__loadMore', {
-    'm-no-indent': nestingLevel >= NESTING_STOP_LEVEL,
-  });
-
   return (
-    <div className={ className } onClick={ onLoadMore }>
+    <div className='Comment__loadMore' onClick={ onLoadMore }>
       <div className='icon icon-caron-circled' />
       <span className='Comment__loadMore-text'>{ loadingText }</span>
     </div>

--- a/src/app/components/Comment/styles.less
+++ b/src/app/components/Comment/styles.less
@@ -6,7 +6,6 @@
   &.in-comment-tree {
     .themeify({
       background-color: @theme-comment-body-color;
-      border-top: @theme-border;
     });
   }
 
@@ -59,10 +58,16 @@
   }
 
   &__replies {
-    margin-left: 8px;
+    padding-left: 2 * @grid-size;
+
+    .themeify({
+      border-left: @theme-border;
+    });
 
     &.m-no-indent {
-      margin-left: 0;
+      padding-left: 0;
+      // can't get the specificity high enough to override this otherwise
+      border-left: none !important;
     }
   }
 
@@ -85,15 +90,6 @@
   }
 
   &__loadMore {
-    .themeify({
-      border-top: @theme-border;
-    });
-
-    &.m-no-indent {
-      margin-left: 0px;
-    }
-
-    margin-left: 6px;
     padding: 7px 0;   // using padding here to ensure a large hitbox
 
     .icon-caron-circled {
@@ -101,6 +97,7 @@
       margin-right: 8px;
       transform: rotate(-90deg);
       margin-top: -4px;
+      font-size: 12px;
     }
   }
 

--- a/src/app/components/CommentsList/styles.less
+++ b/src/app/components/CommentsList/styles.less
@@ -3,5 +3,5 @@
 @import (reference) '~app/less/themes/themeify';
 
 .CommentsList__topLevel {
-  margin: @grid-size + @grid-size/2;
+  margin: @grid-size * 2;
 }


### PR DESCRIPTION
- Instead of a horizontal line dividing comments, have a vertical line
  encapsulating comment branches. This is aligns with how native clients
  show comments.
- Fix the over-indendation of the "more comments" text.
- Make the collapse caron animate as it rotates from down to right.
- Make the caron for "more comments" the same size as the rest of the
  comment carons.

### Old comments
<img width="387" alt="screen shot 2016-09-22 at 5 07 24 pm" src="https://cloud.githubusercontent.com/assets/787203/18770079/51aa0f4a-80e7-11e6-851a-7c518bb24852.png">

### New comments
<img width="396" alt="screen shot 2016-09-22 at 5 08 44 pm" src="https://cloud.githubusercontent.com/assets/787203/18770081/584c89fe-80e7-11e6-85b1-f3af6339f640.png">

:eyeglasses: @schwers @uzi @dhunten