### PR TITLE
Update config and respect server headers

### DIFF
--- a/src/Server.js
+++ b/src/Server.js
@@ -19,6 +19,7 @@ import logoutproxy from 'server/session/logoutproxy';
 import registerproxy from 'server/session/registerproxy';
 import refreshproxy from 'server/session/refreshproxy';
 import dispatchSession from 'server/session/dispatchSession';
+import dispatchAPIPassThroughHeaders from 'server/initialState/dispatchAPIPassThroughHeaders';
 import { dispatchInitialCompact } from 'server/initialState/dispatchInitialCompact';
 import { dispatchInitialMeta } from 'server/initialState/dispatchInitialMeta';
 import { dispatchInitialOver18 } from 'server/initialState/dispatchInitialOver18';
@@ -85,6 +86,7 @@ export function startServer() {
     reduxMiddleware,
     dispatchBeforeNavigation: async (ctx, dispatch, getState) => {
       dispatchInitialShell(ctx, dispatch);
+      dispatchAPIPassThroughHeaders(ctx, dispatch);
       await dispatchSession(ctx, dispatch, ConfigedAPIOptions);
       dispatchInitialTheme(ctx, dispatch);
       dispatchInitialCollapsedComments(ctx, dispatch);

--- a/src/app/actions/apiRequestHeaders.js
+++ b/src/app/actions/apiRequestHeaders.js
@@ -1,0 +1,2 @@
+export const SET = 'SET_API_REQUEST_HEADERS';
+export const set = headers => ({ type: SET, headers });

--- a/src/app/reducers/apiRequestHeaders.js
+++ b/src/app/reducers/apiRequestHeaders.js
@@ -1,0 +1,18 @@
+// We need to pass along some headers on all api requests made on the server
+// We store them here in a dictionary of header name to value so that
+// `apiOptionsFromState` can add them to the api request options
+
+import * as apiRequestHeadersActions from 'app/actions/apiRequestHeaders';
+
+export const DEFAULT = {};
+
+export default function(state=DEFAULT, action={}) {
+  switch (action.type) {
+    case apiRequestHeadersActions.SET: {
+      const { headers } = action;
+      return headers;
+    }
+
+    default: return state;
+  }
+}

--- a/src/app/reducers/apiRequestHeaders.test.js
+++ b/src/app/reducers/apiRequestHeaders.test.js
@@ -1,0 +1,29 @@
+import createTest from '@r/platform/createTest';
+
+import apiRequestHeaders, { DEFAULT } from './apiRequestHeaders';
+import * as apiRequestHeadersActions from 'app/actions/apiRequestHeaders';
+
+createTest({ reducers: { apiRequestHeaders }}, ({ getStore, expect }) => {
+  describe('DEFAULT', () => {
+    it('should return the default value on start', () => {
+      const { store } = getStore();
+      const { apiRequestHeaders } = store.getState();
+      expect(apiRequestHeaders).to.eql(DEFAULT);
+    });
+  });
+
+  describe('SET', () => {
+    it('should update to use the value from the set action', () => {
+      const { store } = getStore({
+        apiRequestHeaders: { 'Cookie': 'nightmode=true;' },
+      });
+
+      const newHeaders = {
+        'accept-language': 'en',
+      };
+      store.dispatch(apiRequestHeadersActions.set(newHeaders));
+      const { apiRequestHeaders } = store.getState();
+      expect(apiRequestHeaders).to.eql(newHeaders);
+    });
+  });
+});

--- a/src/app/reducers/index.js
+++ b/src/app/reducers/index.js
@@ -4,6 +4,7 @@ import accountRequests from './accountRequests';
 import accounts from './accounts';
 import activitiesRequests from './activitiesRequests';
 import adRequests from './adRequests';
+import apiRequestHeaders from './apiRequestHeaders';
 import autocompleteSubreddits from './autocompleteSubreddits';
 import collapsedComments from './collapsedComments';
 import comments from './comments';
@@ -45,6 +46,7 @@ export default {
   accountRequests,
   activitiesRequests,
   adRequests,
+  apiRequestHeaders,
   autocompleteSubreddits,
   collapsedComments,
   comments,

--- a/src/config.js
+++ b/src/config.js
@@ -1,9 +1,29 @@
 /*eslint max-len: 0*/
 
-// This configuration is shared with the client. Any hidden, server-only config
-// belongs in ./server instead.
+// This config is shared with the client -- but the client will only see ENV
+// variables that are defined in `blueprints.config.js` -- so be sure to have
+// sane defaults
 
 import localStorageAvailable from 'lib/localStorageAvailable';
+
+
+// takes a ';' separated string of key value pairs and turns them into an
+// object of { key -> value}
+const parseSemiColonKeyValues = (list='') => {
+  return list.split(';').reduce((obj, pair) => {
+    // check that we have a key value pair with an '=' in the middle.
+    // the '=' can't be the first character because there'd be no key
+    if (pair && pair.indexOf('=') > 0) {
+      const [key, value] = pair.split('=');
+      obj[key.trim()] = value.trim();
+    }
+
+    return obj;
+  }, {});
+};
+
+// takes a ';' separated string and returns a list
+const parseSemiColonList = (list='') => list.split(';');
 
 const reddit = process.env.REDDIT || 'https://www.reddit.com';
 
@@ -27,6 +47,9 @@ const config = () => ({
   postErrorURL: '/error',
 
   minifyAssets: process.env.MINIFY_ASSETS === 'true',
+
+  apiHeaders: parseSemiColonKeyValues(process.env.API_HEADERS),
+  apiPassThroughHeaders: parseSemiColonList(process.env.API_PASS_THROUGH_HEADERS),
 
   assetPath: process.env.STATIC_BASE || '',
 

--- a/src/lib/apiOptionsFromState.js
+++ b/src/lib/apiOptionsFromState.js
@@ -1,5 +1,6 @@
 import APIOptions, { optionsWithAuth } from '@r/api-client';
 import merge from '@r/platform/merge';
+import config from 'config';
 
 export const apiOptionsFromState = state => {
   if (!state) { return APIOptions; }
@@ -10,9 +11,17 @@ export const apiOptionsFromState = state => {
     : { ...APIOptions };
 
   // grab loids if we have them, and set the cookie if on the server
-  const { loid: { loid, loidCreated }, meta } = state;
-  if (loid && meta.env !== 'CLIENT') {
-    const cookieHeaders = [ `loid=${loid}` ];
+  const {
+    apiRequestHeaders,
+    loid: { loid, loidCreated },
+    meta,
+  } = state;
+  if (meta.env !== 'CLIENT') {
+    // We fake cookie headers to pass loid and loidCreated to the server
+    const cookieHeaders = [];
+    if (loid) {
+      cookieHeaders.push(`loid=${loid}`);
+    }
     if (loidCreated) {
       cookieHeaders.push(`loidcreated=${(new Date(loidCreated)).toISOString()}`);
     }
@@ -20,6 +29,8 @@ export const apiOptionsFromState = state => {
     return merge(options, {
       appName: '2x-server',
       headers: {
+        ...config.apiHeaders, // default headers that are kept on the server
+        ...apiRequestHeaders, // request dependant headers
         'Cookie': cookieHeaders.join(';'),
       },
     });

--- a/src/server/initialState/dispatchAPIPassThroughHeaders.js
+++ b/src/server/initialState/dispatchAPIPassThroughHeaders.js
@@ -1,0 +1,16 @@
+import config from 'config';
+import * as apiRequestHeadersActions from 'app/actions/apiRequestHeaders';
+
+export default (ctx, dispatch) => {
+  const headers = {};
+  config.apiPassThroughHeaders.forEach(key => {
+    const value = ctx.headers[key];
+    if (value) {
+      headers[key] = value;
+    }
+  });
+
+  if (Object.keys(headers).length) {
+    dispatch(apiRequestHeadersActions.set(headers));
+  }
+};


### PR DESCRIPTION
This adds support for the env variables `API_HEADERS` and`API_PASS_THROUGH_HEADERS`. The former is a list of default key/value pairs to send as headers on server-side api requests. The latter is a list of headers to copy from the client request onto server-side api requests.

I included an update for the root cookie domain update we wanted to make. I can take it out if we want to get internal testing going asap, but if we like it and want to include it we'll have to get this puppet patch landed too: https://github.com/reddit/puppet/compare/master...schwers:2X-root-cookie-domain?expand=1 

👓  @phil303 @uzi 

