### PR TITLE
Allow self posts to have empty text fields

### DIFF
--- a/src/app/components/PostSubmitModal/index.jsx
+++ b/src/app/components/PostSubmitModal/index.jsx
@@ -164,8 +164,13 @@ const mapStateToProps = createSelector(
 
     const subredditMetaData = subreddits[subredditName];
     const iconUrl = subredditMetaData ? subredditMetaData.iconImage : null;
-    const readyToPost = every([title, meta, subredditName], v => !isEmpty(v));
     const captchaImgUrl = CAPTCHA_URL_BASE + captchaIden;
+
+    const readyFields = submissionType === 'self'
+      ? [title, subredditName]
+      : [title, meta, subredditName];
+
+    const readyToPost = every(readyFields, v => !isEmpty(v));
 
     return {
       title,


### PR DESCRIPTION
Problem:
Currently, self posts require both the title and the text field to be
filled. That's not an actual requirement and in fact, some subreddits,
like AskReddit require the text field to be empty.

Fix:
On self posts, just check for the subreddit and the title. For link
posts, continue to check for subreddit, title, and the link.

:eyeglasses: @schwers @uzi