### PR TITLE
Don't parse loidCreated or pass it to Date constructor

### DIFF
--- a/src/lib/apiOptionsFromState.js
+++ b/src/lib/apiOptionsFromState.js
@@ -16,14 +16,16 @@ export const apiOptionsFromState = state => {
     loid: { loid, loidCreated },
     meta,
   } = state;
+
   if (meta.env !== 'CLIENT') {
     // We fake cookie headers to pass loid and loidCreated to the server
     const cookieHeaders = [];
     if (loid) {
       cookieHeaders.push(`loid=${loid}`);
     }
+
     if (loidCreated) {
-      cookieHeaders.push(`loidcreated=${(new Date(loidCreated)).toISOString()}`);
+      cookieHeaders.push(`loidcreated=${loidCreated}}`);
     }
 
     return merge(options, {


### PR DESCRIPTION
The value we get is from cookies, by default a string.
We don't have to send the ISO string anymore so there's
no reason to parse it, and circumvents an issue when
we tried to call the Date constructor on a unixtimestamp
string (it wants integers).

👓  @uzi 