### PR TITLE
Fix a few of event tracking errors

### DIFF
--- a/src/app/router/handlers/CommentsPage.js
+++ b/src/app/router/handlers/CommentsPage.js
@@ -104,6 +104,10 @@ function buildScreenViewData(state) {
   const fullName =`t3_${urlParams.postId}`;
   const post = state.posts[fullName];
 
+  if (!post) {
+    return null;
+  }
+
   return cleanObject({
     target_fullname: fullName,
     target_id: convertId(post.id),

--- a/src/app/router/handlers/PostsFromSubreddit.js
+++ b/src/app/router/handlers/PostsFromSubreddit.js
@@ -93,6 +93,13 @@ function buildScreenViewData(state) {
     listing_name = subredditName;
   } else {
     const subreddit = state.subreddits[subredditName.toLowerCase()];
+
+    // for the time being, if the api fetch fails (such as a user not having
+    // access to this subreddit), then we don't want to track
+    if (!subreddit) {
+      return null;
+    }
+
     target_id = convertId(subreddit.id);
     target_fullname = subreddit.name;
     listing_name = subreddit.uuid;

--- a/src/app/router/handlers/UserProfile.js
+++ b/src/app/router/handlers/UserProfile.js
@@ -24,6 +24,13 @@ export default class UserProfilerHandler extends BaseHandler {
 
 function buildScreenViewData(state) {
   const { userName: name } = state.platform.currentPage.urlParams;
+
+  // if a user doesn't exist, this check will catch it. We may want to track
+  // this in the future.
+  if (!name) {
+    return null;
+  }
+
   const user = find(state.accounts, (_, k) => k.toLowerCase() === name.toLowerCase());
 
   return {

--- a/src/lib/eventUtils.js
+++ b/src/lib/eventUtils.js
@@ -81,10 +81,9 @@ export function logClientScreenView(buildScreenViewData, state) {
   // end hack
 
   if (process.env.ENV === 'client') {
-    getEventTracker().track(
-      'screenview_events',
-      'cs.screenview_mweb',
-      buildScreenViewData(state),
-    );
+    const data = buildScreenViewData(state);
+    if (data) {
+      getEventTracker().track('screenview_events', 'cs.screenview_mweb', data);
+    }
   }
 }


### PR DESCRIPTION
- Profile page - handle an error where `name` is undefined. Occurs when
  someone hits a profile page for a non-existent user.
- Comments page - handle an error where the post is undefined. Haven't
  seen yet but it's probably possible so being defensive here.
- Listings page - handle an error where the listing page is undefined.
  Occurs when a user doesn't have access to that subreddit.

Details:
If the important info is not present, return `null` in its stead. When
we're about to make the tracking call, check for `null` and if it
exists, don't make the call.

There might be more of these out there but I'll start with this as a foundation. 
:eyeglasses: @schwers @uzi @nramadas 