### PR TITLE
Stop loginproxy 401 from causing errors

### DIFF
--- a/src/app/models/Session.js
+++ b/src/app/models/Session.js
@@ -12,7 +12,7 @@ const fetchLogin = (username, password) => new Promise((resolve, reject) => {
       // NOTE: this isn't the best way to handle this but validation errors
       // seem to fail with a response key whereas api failures don't
       if (err && err.response) {
-        reject(new ValidationError('/loginproxy', [err.response.text], err.status));
+        reject(new ValidationError('/loginproxy', [err.response.body], err.status));
       } else if (err || !res.body) {
         reject(new ResponseError(err, '/loginproxy'));
       } else {

--- a/src/server/meta/stats.js
+++ b/src/server/meta/stats.js
@@ -40,7 +40,7 @@ export default router => {
       errorLog({
         error,
         requestUrl: ctx.request.url,
-        userAgent: 'SERVER',
+        userAgent: ctx.headers['user-agent'],
       }, {
         hivemind: config.statsURL,
       });

--- a/src/server/session/loginproxy.js
+++ b/src/server/session/loginproxy.js
@@ -1,6 +1,10 @@
 import writeSessionToResponse from './writeSessionToResponse';
 import { PrivateAPI } from '@r/private';
 
+import config from 'config';
+import errorLog from 'lib/errorLog';
+
+
 export default (router, apiOptions) => {
   router.post('/loginproxy', async (ctx/*, next*/) => {
     const { username, password } = ctx.request.body;
@@ -11,16 +15,21 @@ export default (router, apiOptions) => {
 
       // writeSessionToResponse will set the cookies
       writeSessionToResponse(ctx, data);
-    } catch (e) {
-      console.log(e);
-      let errormsg = 'UNKNOWN_ERROR';
-
-      if (e && (typeof e === 'string')) {
-        errormsg = e;
+    } catch (error) {
+      // TODO: the errors we get back aren't helpful, in most cases we
+      // only get back 'WRONG_PASSWORD' even if the user field is blank
+      ctx.status = 401;
+      if (error === 'WRONG_PASSWORD') {
+        ctx.body = { error };
+      } else { // we're not sure what this error is, log it for now
+        errorLog({
+          error,
+          requestUrl: ctx.request.url,
+          userAgent: ctx.headers['user-agent'],
+        }, {
+          hivemind: config.statsURL,
+        });
       }
-
-      // TODO: figure out how to get this to return json content type
-      ctx.throw(401, JSON.stringify({error: errormsg}));
     }
   });
 };


### PR DESCRIPTION
👓  @phil303 similar to your patch, this will fix the server from throwing errors when the user enters a wrong password. The errors we get back from node-private seem to always be 'WRONG_PASSWORD' so I'm logging the error when it's anything _but_ that.