### PR TITLE
Don't buildScreenViewData in UserProfile with no user

### DIFF
--- a/src/app/router/handlers/UserProfile.js
+++ b/src/app/router/handlers/UserProfile.js
@@ -33,6 +33,11 @@ function buildScreenViewData(state) {
 
   const user = find(state.accounts, (_, k) => k.toLowerCase() === name.toLowerCase());
 
+  // another thing to track in the future -- if the user somehow isn't in our state
+  if (!user) {
+    return null;
+  }
+
   return {
     target_name: user.name,
     target_fullname: user.id,


### PR DESCRIPTION
Fixes errors in the log like:
"Error: undefined is not an object (evaluating 'r.name')"
and
"Rejection: TypeError: undefined is not an object (evaluating 'r.name')"

👓  @phil303 @schwers @nramadas 