### PR TITLE
Set X-Frame-Options to SAMEORIGIN

### DIFF
--- a/src/Server.js
+++ b/src/Server.js
@@ -98,6 +98,10 @@ export function startServer() {
     },
     preRouteServerMiddleware: [
       buildFiles,
+      async (ctx, next) => {
+        await next();
+        ctx.set('X-Frame-Options', 'SAMEORIGIN');
+      },
     ],
     getServerRouter: router => {
       // middleware


### PR DESCRIPTION
Enforce a same origin policy for frames (iframes, frames, or objects).
In other words, only hosts of the same domain as the app will be able to
serve it via an iframe. This prevents clickjacking based attacks.

The other options here are DENY or ALLOW-FROM <some origin>. The former
disallows the app from being displayed in iframes entirely, which feels
overly restrictive right now. The latter only allows the app to be
hosted by explictly selected domains, which we don't have a use case for.