### PR TITLE
Make sure client can update cookies

### DIFF
--- a/src/server/initialState/dispatchInitialCompact.js
+++ b/src/server/initialState/dispatchInitialCompact.js
@@ -18,9 +18,10 @@ export const dispatchInitialCompact = async (ctx, dispatch) => {
     compact = `${DEFAULT}`;
   }
 
-  if (compact !== compactFromCookie) {
-    ctx.cookies.set('compact', compact, permanentCookieOptions());
-  }
+  // NOTE: there was a bug were we set HTTP_ONLY cookies so the client' couldn't
+  // override them. Set this cookie no matter what so httpOnly flag is removed
+  // for those users affected
+  ctx.cookies.set('compact', compact, permanentCookieOptions());
 
   const compactBool = compact === 'true';
   dispatch(compactActions.setCompact(compactBool));

--- a/src/server/initialState/dispatchInitialTheme.js
+++ b/src/server/initialState/dispatchInitialTheme.js
@@ -12,9 +12,10 @@ export const dispatchInitialTheme = async (ctx, dispatch) => {
     theme = DEFAULT;
   }
 
-  if (theme !== themeCookie) {
-    ctx.cookies.set('theme', theme, permanentCookieOptions());
-  }
+  // NOTE: there was a bug were we set HTTP_ONLY cookies so the client' couldn't
+  // override them. Set this cookie no matter what so httpOnly flag is removed
+  // for those users affected
+  ctx.cookies.set('theme', theme, permanentCookieOptions());
 
   dispatch(themeActions.setTheme(theme));
 };

--- a/src/server/initialState/permanentCookieOptions.js
+++ b/src/server/initialState/permanentCookieOptions.js
@@ -16,9 +16,10 @@ export const permanentCookieOptions = () => {
     // In theory, now that it's deprecated, we should be passing `secure: true`
     // to the `new Cookies({})` constructor, but that's called by `Koa`
     // so we'll have to fork/pull-request that in the future.
-    httpOnly: true, // This flag isn't what you think it means. It tells
-    // browsers to not expose these headers to XMLHTTPRequestss, but still
-    // set the cookies
+    httpOnly: false, // This flag isn't what you think it means. Passing true
+    // would prevent cookies from being accessible from javascript. This sounds
+    // good at first but if you ever need to update cookies on the client,
+    // this needs to be set to false.
     expires,
   };
 };

--- a/src/server/session/logoutproxy.js
+++ b/src/server/session/logoutproxy.js
@@ -1,10 +1,19 @@
+import config from 'config';
 import clearSessionCookies from './clearSessionCookies';
 
 export default (router) => {
   router.post('/logout', async (ctx/*, next*/) => {
+    // NOTE: this is only temporary for now. Desktop uses a separate cookie
+    // called `reddit_session`. On any request to mweb, the server checks for it
+    // and attempts to convert it to an oauth session. To really log out
+    // we have to clear this cookie. The `token` cookie stores mweb oauth
+    // (and amp, modmail, etc) is now available on the root reddit domain, so
+    // we can unify these sessions and only have one cookie to clear.
+    ctx.cookies.set('reddit_session', { domain: config.rootReddit });
+    ctx.cookies.set('reddit_session');
+
     clearSessionCookies(ctx);
     ctx.cookies.set('over18');
-    ctx.cookies.set('reddit_session');
     ctx.cookies.set('compact');
     ctx.cookies.set('theme');
     ctx.redirect('/');

--- a/src/server/session/setSessionCookies.js
+++ b/src/server/session/setSessionCookies.js
@@ -4,7 +4,10 @@ import { SEPERATOR, VERSION } from './constants';
 export default (ctx, session) => {
   // Set the token cookie to be on the root reddit domain if we're not
   // running on localhost
-  const options = permanentRootCookieOptions(ctx);
+  const options = {
+    ...permanentRootCookieOptions(ctx),
+    httpOnly: true, // don't let client-side javascript access session cookies
+  };
 
   ctx.cookies.set(
     'token',


### PR DESCRIPTION
All of our cookies were getting set with the `httpOnly` flag.
This was intended to increase security, but had the sideeffect
of preventing the client from updating cookies. A symptom of this
is your theme or compact preference not sticking. Session
cookies are still written with the `httpOnly` flag to protect
your tokens.

👓  @uzi @phil303 @nramadas 