### PR TITLE
Log more info about navigation actions to debug HEAD issues

### DIFF
--- a/src/app/reduxMiddleware/errorLogger.js
+++ b/src/app/reduxMiddleware/errorLogger.js
@@ -23,6 +23,8 @@ import * as wikiActions from 'app/actions/wiki';
 export default function errorLogger() {
   const actionStack = new ActionStack(config.reduxActionLogSize, [
     platformActions.SET_PAGE,
+    platformActions.NAVIGATE_TO_URL,
+    platformActions.GOTO_PAGE_INDEX,
     accountActions.FETCHING_ACCOUNT,
     activityActions.FETCHING_ACTIVITIES,
     commentActions.MORE_COMMENTS_FETCHING,


### PR DESCRIPTION
This will make the ActionStack log full action objects for the `NAVIGATE_TO_URL` and `GOTO_PAGE_INDEX` action types. This should help us debug what's going on with the `HEAD` requests getting routed in through node-platform navigationMiddleware

👓  @phil303  @uzi 