### PR TITLE
Don't fail on tagging errors, should reveal hidden errors

### DIFF
--- a/src/lib/errorLog.js
+++ b/src/lib/errorLog.js
@@ -17,7 +17,8 @@ export default function errorLog(details={}, errorEndpoints={}, options={ SHOULD
   // parse the stack for location details if we're passed
   // an Error or PromiseRejectionEvent
   const { error, rejection } = details;
-  if ((error || rejection)._SEEN_BY_ERROR_LOG) {
+  const failure = error || rejection;
+  if (!failure || failure._SEEN_BY_ERROR_LOG) {
     // we've already seen this error and rethrew it so chrome will do it's default logging
     return;
   }
@@ -146,6 +147,10 @@ const buildLogJSON = details => {
     column,
     requestUrl='NO REQUEST URL',
     stack,
+    possibleDuplicate, // This is for cases when an error might have
+    // already been logged. e.g. a promise chains can lead to the same
+    // error getting passed to multiple .catch handlers or the
+    // same error reaching the .catch handler twice.
   } = details;
 
   return {
@@ -159,6 +164,7 @@ const buildLogJSON = details => {
     line,
     column,
     stack,
+    possibleDuplicate,
   };
 };
 


### PR DESCRIPTION
This tries to catch errors in setting a property on errors (which is for deduping error logs). If this works we might reveal a new error that's hidden behind the error for setting this property.

👓  @uzi @phil303 