### PR TITLE
Comment collapse/expand animation

### DIFF
--- a/src/app/components/Comment/styles.less
+++ b/src/app/components/Comment/styles.less
@@ -13,13 +13,13 @@
     padding: 7px 0;
   }
 
+  &__base-mask {
+    overflow: hidden;
+  }
+
   &__body,
   &__toolsContainer,
   &__replies {
-    &.m-hidden {
-      display: none;
-    }
-
     overflow: auto;
 
     &:after {
@@ -47,10 +47,6 @@
 
   &__edit {
     margin: (2 * @grid-size) 0;
-
-    &.m-hidden {
-      display: none;
-    }
   }
 
   &__replyForm {

--- a/src/app/components/CommentsList/index.jsx
+++ b/src/app/components/CommentsList/index.jsx
@@ -1,7 +1,6 @@
 import './styles.less';
 
 import React from 'react';
-
 import map from 'lodash/map';
 
 import Comment from 'app/components/Comment';


### PR DESCRIPTION
This leverages react-motion to create a nice collapse/expand animation
when you tap the comment header. This animates both the height and the
opacity of the comment tree.

Details:
This works by wrapping everything that we want to animate in a div which
I called `Comment__base` in the css - this is the comment content, the
footer, and the replies. Once I've done this I wrap it in yet another
div. This div will effectively act as a mask whose overflow is hidden,
interpolating from the base's full height to 0 on collapse and 0 to the
base's full height on the expand - making it look as if the comment
itself is expanding or collapsing.

By doing it this way, the height of the comment base is always available
to be measured. For instance, if a comment starts off in a collapsed
state, to get its real height, you'd have to unhide/measure/rehide. This
scheme avoids a lot of that awkward handling.

The need for measuring the height in actual pixels is due to the
unfortunate fact that you can't interpolate from 0 to auto, a div's
default layout height, so a measurement must be taken before animation
begins. This is done simply in `componentWillUpdate`.

As a final detail, once the comment is finished animating, I switch the
height back to `auto`. This is a passive and simple way to deal with any
child elements changing their own heights.
### Preview

![comment animation](https://cloud.githubusercontent.com/assets/787203/19007773/9c63ce56-871b-11e6-9a12-551dc96c09d7.gif)

:eyeglasses: @schwers @nramadas @uzi @dhunten
