### PR TITLE
Add autocomplete attribute to LoginInput

### DIFF
--- a/src/app/components/Login/index.jsx
+++ b/src/app/components/Login/index.jsx
@@ -117,6 +117,7 @@ class Login extends React.Component {
             type={ passwordFieldType }
             placeholder='Password'
             showTopBorder={ false }
+            shouldAutocomplete={ false }
             error={ error.password }
             onChange={ this.updatePassword }
             value={ password }

--- a/src/app/components/LoginRegistrationForm/Input.jsx
+++ b/src/app/components/LoginRegistrationForm/Input.jsx
@@ -6,7 +6,18 @@ import cx from 'lib/classNames';
 const T = React.PropTypes;
 
 function LoginInput(props) {
-  const { showTopBorder, name, type, placeholder, error, onChange, value, children } = props;
+  const {
+    showTopBorder,
+    name,
+    type,
+    placeholder,
+    error,
+    onChange,
+    value,
+    children,
+    shouldAutocomplete,
+  } = props;
+
   const inputClasses = cx('LoginInput__input', {
     'error': !!error,
     'show-top': showTopBorder,
@@ -25,6 +36,7 @@ function LoginInput(props) {
           placeholder={ placeholder }
           type={ type }
           value={ value }
+          autoComplete={ shouldAutocomplete ? null : 'off' }
         />
         { children }
       </div>
@@ -41,9 +53,11 @@ LoginInput.propTypes = {
   showTopBorder: T.bool,
   type: T.string,
   value: T.string.isRequired,
+  shouldAutocomplete: T.bool,
 };
 
 LoginInput.defaultProps = {
+  shouldAutocomplete: true,
   showTopBorder: false,
   type: 'text',
 };

--- a/src/app/components/Register/index.jsx
+++ b/src/app/components/Register/index.jsx
@@ -173,6 +173,7 @@ class Register extends React.Component {
             type='password'
             placeholder='Choose a unique password'
             showTopBorder={ false }
+            shouldAutocomplete={ false }
             error={ error.password }
             onChange={ this.updatePassword }
             value={ password }


### PR DESCRIPTION
Bug:
User was able to get passwords to autocomplete in plaintext by
originally typing them in with the "eyeball" enabled (makes password
input plaintext), logging out, going back to the login and enabling the
eyeball. Chrome would try to autocomplete his passwords.

Fix:
Make it possible to add the autocomplete attr onto the input dom nodes.
This works on [all mobile clients](http://caniuse.com/#search=autocomplete).

:eyeglasses: @uzi 