### PR TITLE
Normalize z-indexes across app

### DIFF
--- a/src/app/components/CaptchaBox/styles.less
+++ b/src/app/components/CaptchaBox/styles.less
@@ -2,7 +2,7 @@
 @import (reference) '~app/less/themes/themeify';
 
 .CaptchaBox {
-  z-index: 3;
+  z-index: @z-index-modal;
   position: fixed;
   top: 50px;
   left: 20px;

--- a/src/app/components/Dropdown/index.jsx
+++ b/src/app/components/Dropdown/index.jsx
@@ -9,14 +9,16 @@ const T = React.PropTypes;
 
 export function Dropdown(props) {
   return (
-    <Tooltip
-      id={ props.id }
-      alignment={ Tooltip.ALIGN.BELOW }
-      offset={ 8 }
-      className='Dropdown'
-    >
-      { props.children }
-    </Tooltip>
+    <div className='DropdownWrapper'>
+      <Tooltip
+        id={ props.id }
+        alignment={ Tooltip.ALIGN.BELOW }
+        offset={ 8 }
+        className='Dropdown'
+      >
+        { props.children }
+      </Tooltip>
+    </div>
   );
 }
 

--- a/src/app/components/Dropdown/styles.less
+++ b/src/app/components/Dropdown/styles.less
@@ -1,6 +1,11 @@
 @import (reference) '~app/less/variables';
 @import (reference) '~app/less/themes/themeify';
 
+.DropdownWrapper {
+  position: relative;
+  z-index: @z-index-dropdown;
+}
+
 .Dropdown {
   width: 600px;
 

--- a/src/app/components/DropdownCover/styles.less
+++ b/src/app/components/DropdownCover/styles.less
@@ -7,7 +7,7 @@
   bottom: 0;
   left: 0;
   right: 0;
-  z-index: 2;
+  z-index: @z-index-overlay;
 
   .themeify({
     background-color: @theme-overlay-color;

--- a/src/app/components/OverlayMenu/styles.less
+++ b/src/app/components/OverlayMenu/styles.less
@@ -11,7 +11,7 @@
 }
 
 .OverlayMenu {
-  z-index: 11;
+  z-index: @z-index-menu;
   position: fixed;
   top: 0;
   left: 0;
@@ -36,7 +36,7 @@
 
 .OverlayMenu-ul {
   margin-bottom: 0;
-  z-index: 2;
+  z-index: @z-index-menu;
 }
 
 .OverlayMenu-row {

--- a/src/app/components/Post/PostHeader/styles.less
+++ b/src/app/components/Post/PostHeader/styles.less
@@ -106,7 +106,6 @@
       right: 0;
       bottom: 0;
       width: 3em;
-      z-index: 1;
 
       .themeify({
         background: linear-gradient(to right,

--- a/src/app/components/RelevantContent/styles.less
+++ b/src/app/components/RelevantContent/styles.less
@@ -92,7 +92,6 @@
         right: 0;
         bottom: 0;
         width: 3em;
-        z-index: 1;
 
         .themeify({
           .linear-gradient-background(0, fade(@theme-body-color, 0%), fade(@theme-body-color, 100%));

--- a/src/app/components/SubNav/styles.less
+++ b/src/app/components/SubNav/styles.less
@@ -13,7 +13,6 @@
     position: absolute;
     right: @grid-size;
     top: @grid-size;
-    z-index: 2;
 
     &:before {
       content: '';

--- a/src/app/components/Toaster/styles.less
+++ b/src/app/components/Toaster/styles.less
@@ -4,7 +4,7 @@
 .Toaster {
   width: 100%;
   position: fixed;
-  z-index: 1000;
+  z-index: @z-index-toaster;
 
   &__content {
     display: flex;

--- a/src/app/components/TopNav/styles.less
+++ b/src/app/components/TopNav/styles.less
@@ -6,7 +6,7 @@
   height: @top-nav-height;
   position: fixed;
   width: 100%;
-  z-index: 11;
+  z-index: @z-index-navbar;
   -webkit-user-select: none;
   top: 0;
 

--- a/src/app/less/variables.less
+++ b/src/app/less/variables.less
@@ -30,6 +30,18 @@
 
 @compact-listing-thumbnail-size: 70px;
 
+// Window stack precedences
+// Designed to be relative to the DOM root. Also intended to be a guide and 
+// not overly-restrictive
+@z-index-overlay: 10;
+@z-index-dropdown: 20;
+@z-index-tooltip: 20;
+@z-index-navbar: 30;
+@z-index-menu: 30;
+@z-index-modal: 40;
+@z-index-toaster: 50;
+
+
 // Colors (from the internal brandbook)
 
 // Primary


### PR DESCRIPTION
This is a prep patch/hopeful cleanup for the way we handle z-indexes.
The goal is to have a finite and easy to remember amount of stacking
levels components can live at. This is to lower the chance of
unforeseen visual bugs future devs might run into. The z-indexes are
meant to be in a stacking context that is always relative to the dom
root and therefore easier to reason about.

Based on a 50 point scale - with the majority of components having 
the implicit z-index of 0 - the z-indexes of anything above the default 
are as follows (the higher in the list, the higher the stacking precedence):

- Toasters: 50
- Modals: 40    (Reporting, CaptchaBox)
- Nav Bar and menus: 30
- Dropdowns/tooltips: 20
- Opaque overlay: 10

This is meant to handle the most general cases, which is what our
current situation is now anyway, and not meant as a strict ruleset. 

I'm also totally open to thoughts on the stacking precedences.

:eyeglasses: @nramadas