### PR TITLE
Add autocomplete attribute to LoginInput

### DIFF
--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -1015,4 +1015,3 @@ function routes(app) {
 }
 
 export default routes;
-export { buildProps };

--- a/src/views/components/formElements/minimalinput.jsx
+++ b/src/views/components/formElements/minimalinput.jsx
@@ -4,7 +4,7 @@ const T = React.PropTypes;
 
 function Input(props) {
   const { showTopBorder, name, type, placeholder,
-          onChange, error, children, value } = props;
+          onChange, error, children, value, autocomplete } = props;
   const showTop = showTopBorder ? 'show-top' : '';
 
   let errorClass = '';
@@ -27,6 +27,7 @@ function Input(props) {
           value={ value }
           className={ `minimalInput__input ${showTop} ${errorClass}` }
           placeholder={ placeholder }
+          autoComplete={ autocomplete }
           onChange={ onChange }
         />
         { children }
@@ -44,11 +45,13 @@ Input.propTypes = {
   name: T.string.isRequired,
   type: T.string,
   placeholder: T.string.isRequired,
+  autocomplete: T.string,
 };
 
 Input.defaultProps = {
   type: 'text',
   showTopBorder: false,
+  autocomplete: null,
 };
 
 export default Input;

--- a/src/views/pages/login.jsx
+++ b/src/views/pages/login.jsx
@@ -484,6 +484,7 @@ class LoginPage extends BasePage {
             error={ error.password ? errorMessage : '' }
             onChange={ this.updatePassword }
             value={ password }
+            autocomplete='off'
           >
             { error.password ? this.renderClear('clearPassword') :
                                this.renderEye(blue, this.toggleType) }

--- a/test/helpers/components.es6.js
+++ b/test/helpers/components.es6.js
@@ -71,7 +71,6 @@ export {
     CaptchaBox,
     Comment,
     CommentPreview,
-    Comment,
     CommunityHeader,
     CommunityOverlayMenu,
     CommunitySearchRow,


### PR DESCRIPTION
Bug:
User was able to get passwords to autocomplete in plaintext by
originally typing them in with the "eyeball" enabled (makes password
input plaintext), logging out, going back to the login and enabling the
eyeball. Chrome would try to autocomplete his passwords.

Fix:
Make it possible to add the autocomplete attr onto the input dom nodes.
This works on [all mobile
clients](http://caniuse.com/#search=autocomplete).

:eyeglasses: @uzi 