### PR TITLE
Fix coloring of upvote/downvote icons on :hover

### DIFF
--- a/src/app/components/Comment/CommentTools/styles.less
+++ b/src/app/components/Comment/CommentTools/styles.less
@@ -93,7 +93,7 @@
     }
 
     &.upvoted {
-      color: @orangered;
+      color: @orangered !important;
     }
   }
 
@@ -103,7 +103,7 @@
     }
 
     &.downvoted {
-      color: @periwinkle;
+      color: @periwinkle !important;
     }
   }
 


### PR DESCRIPTION
Themed .icon:hover classes were overriding comment upvote and downvote
colors. This makes it so that upvoted and downvoted colors are applied
appropriately by following the same method the link uses - namely,
!important.

👓 @schwers 