### PR TITLE
Add support for displaying message threads

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:watch": "npm run test -- -w"
   },
   "dependencies": {
-    "@r/api-client": "~3.22.8",
+    "@r/api-client": "~3.22.10",
     "@r/build": "~0.10.0",
     "@r/flags": "^1.5.0",
     "@r/middleware": "~0.8.1",

--- a/src/app/actions/mail.js
+++ b/src/app/actions/mail.js
@@ -23,12 +23,17 @@ export const setInboxFailure = (mailType, error) => ({
   error,
 });
 
-export const fetchInbox = mailType => async (dispatch, getState) => {
+export const fetchInbox = (mailType, threadId) => async (dispatch, getState) => {
   const apiOptions = apiOptionsFromState(getState());
   dispatch(setInboxPending(mailType));
 
+  const data = { type: mailType };
+  if (threadId) {
+    data.thread = threadId;
+  }
+
   try {
-    const apiResponse = await endpoints.MessagesEndpoint.get(apiOptions, { type: mailType });
+    const apiResponse = await endpoints.MessagesEndpoint.get(apiOptions, data);
     dispatch(setInboxSuccess(mailType, apiResponse));
   } catch (e) {
     if (e instanceof ResponseError) {

--- a/src/app/components/AppTopNav/index.jsx
+++ b/src/app/components/AppTopNav/index.jsx
@@ -9,6 +9,7 @@ export const AppTopNav = () => (
   <UrlSwitch>
     <Case url='/login' exec={ () => null } />
     <Case url='/register' exec={ () => null } />
+    <Case url='/message/messages/:threadId' exec={ () => null } />
     <Case url='/r/:subredditName/submit' exec={ () => <PostSubmitModal /> } />
     <Case url='/submit' exec={ () => <PostSubmitModal /> } />
     <Case url='/submit/to_community' exec={ () => <PostSubmitCommunityModal /> } />

--- a/src/app/components/MessageThread/Message.jsx
+++ b/src/app/components/MessageThread/Message.jsx
@@ -1,0 +1,39 @@
+import './Message.less';
+import React from 'react';
+import { Anchor } from '@r/platform/components';
+
+import { short } from 'lib/formatDifference';
+import RedditLinkHijacker from 'app/components/RedditLinkHijacker';
+
+const T = React.PropTypes;
+
+const SEPARATOR = ' \u2022 ';
+
+export default function MessageThreadMessage(props) {
+  const { message } = props;
+
+  return (
+    <div className='MessageThreadMessage'>
+      <div className='MessageThreadMessage__title'>
+        <Anchor
+          className='MessageThreadMessage__authorLink'
+          href={ `/user/${ message.author }` }
+        >
+          { message.author }
+        </Anchor>
+        { SEPARATOR }
+        { short(message.createdUTC) }
+      </div>
+      <RedditLinkHijacker>
+        <div
+          className='MessageThreadMessage__body'
+          dangerouslySetInnerHTML={ { __html: message.bodyHTML } }
+        />
+      </RedditLinkHijacker>
+    </div>
+  );
+}
+
+MessageThreadMessage.propTypes = {
+  message: T.object.isRequired,
+};

--- a/src/app/components/MessageThread/Message.less
+++ b/src/app/components/MessageThread/Message.less
@@ -1,0 +1,36 @@
+@import (reference) '~app/less/variables';
+@import (reference) '~app/less/themes/themeify';
+
+.MessageThreadMessage {
+  @caron-size: 40px;
+  position: relative;
+  width: 100%;
+
+  &__title {
+    font-size: 11px;
+    line-height: 1.2;
+
+    .themeify({
+      color: @theme-meta-text-color;
+    });
+  }
+
+  &__authorLink {
+    &, &:visited, &:active {
+      text-decoration: none;
+
+      .themeify({
+        color: @theme-meta-text-color;
+      });
+    }
+  }
+
+  &__body {
+    font-size: 11px;
+    line-height: 1.2;
+
+    .themeify({
+      color: @theme-body-text-color;
+    });
+  }
+}

--- a/src/app/components/MessageThread/index.jsx
+++ b/src/app/components/MessageThread/index.jsx
@@ -1,0 +1,64 @@
+import './styles.less';
+import React from 'react';
+import { connect } from 'react-redux';
+import { createSelector } from 'reselect';
+import { BackAnchor } from '@r/platform/components';
+
+import ThreadMessage from './Message';
+
+const T = React.PropTypes;
+
+export function MessageThread(props) {
+  const {
+    messages,
+    threadId,
+  } = props;
+  const head = messages[`t4_${threadId}`];
+
+  return (
+    <div className='MessageThread'>
+      <div className='MessageThread__header'>
+        <BackAnchor
+          className='MessageThread__backlink icon icon-x'
+          href="/message/messages/"
+        />
+        <div className='MessageThread__subject'>
+          { head.subject }
+        </div>
+      </div>
+      <div className='MessageThread__divider' />
+      <div className='MessageThread__content'>
+        { renderMessage(head) }
+        { head.replies.map(reply => renderMessage(messages[reply])) }
+      </div>
+    </div>
+  );
+}
+
+const renderMessage = message => {
+  return (
+    <div className='MessageThread__item'>
+      <ThreadMessage message={ message } />
+    </div>
+  );
+};
+
+MessageThread.propTypes = {
+  messages: T.object.isRequired,
+  threadId: T.string.isRequired,
+};
+
+const selector = createSelector(
+  state => state.messages,
+  messages => ({
+    messages,
+  })
+);
+
+const mergeProps = (stateProps, dispatchProps, ownProps) => ({
+  ...stateProps,
+  ...dispatchProps,
+  threadId: ownProps.urlParams.threadId,
+});
+
+export default connect(selector, null, mergeProps)(MessageThread);

--- a/src/app/components/MessageThread/styles.less
+++ b/src/app/components/MessageThread/styles.less
@@ -1,0 +1,59 @@
+@import (reference) '~app/less/variables';
+@import (reference) '~app/less/themes/themeify';
+
+.MessageThread {
+  &__header,
+  &__divider {
+    .themeify({
+      border-bottom: @theme-border;
+    });
+  }
+
+  &__divider {
+    height: @grid-size;
+
+    .themeify({
+      background-color: @theme-disabled-color;
+    });
+  }
+
+  &__subject {
+    padding: @grid-size 16px;
+    display: block;
+    vertical-align: middle;
+    box-sizing: border-box;
+    text-align: center;
+  }
+
+  &__backlink {
+    position: absolute;
+    padding: @grid-size;
+    font-size: 22px;
+
+    &, &:visited, &:active {
+      text-decoration: none;
+
+      .themeify({
+        color: @theme-nav-icon-color;
+      });
+    }
+  }
+
+  &__content {
+    padding: 0 2 * @grid-size;
+
+    .themeify({
+      background-color: @theme-body-color;
+    });
+  }
+
+  &__item {
+    padding: 2 * @grid-size 0;
+
+    & ~ & {
+      .themeify({
+        border-top: @theme-border;
+      });
+    }
+  }
+}

--- a/src/app/components/Messages/Comment.jsx
+++ b/src/app/components/Messages/Comment.jsx
@@ -7,7 +7,7 @@ import RedditLinkHijacker from 'app/components/RedditLinkHijacker';
 
 const T = React.PropTypes;
 
-const SEPARATOR = '\u2022';
+const SEPARATOR = ' \u2022 ';
 
 export default function MessagesComment(props) {
   const { comment } = props;

--- a/src/app/components/Messages/Message.jsx
+++ b/src/app/components/Messages/Message.jsx
@@ -7,7 +7,7 @@ import RedditLinkHijacker from 'app/components/RedditLinkHijacker';
 
 const T = React.PropTypes;
 
-const SEPARATOR = '\u2022';
+const SEPARATOR = ' \u2022 ';
 
 export default function MessagesMessage(props) {
   const { message } = props;
@@ -18,7 +18,7 @@ export default function MessagesMessage(props) {
         <div className='MessagesMessage__title'>
           <Anchor
             className='MessagesMessage__titleLink'
-            href={ `/message/messages/${ message.id }` }
+            href={ message.cleanPermalink }
           >
             { message.subject }
           </Anchor>
@@ -35,7 +35,7 @@ export default function MessagesMessage(props) {
         </div>
         <Anchor
           className='MessagesMessage__link icon icon-nav-arrowforward'
-          href={ `/message/messages/${ message.id }` }
+          href={ message.cleanPermalink }
         />
       </div>
       <RedditLinkHijacker>

--- a/src/app/pages/AppMain.jsx
+++ b/src/app/pages/AppMain.jsx
@@ -14,6 +14,7 @@ import { UserProfilePage } from './UserProfile';
 import { WikiPage } from './WikiPage';
 
 import Messages from 'app/components/Messages';
+import MessageThread from 'app/components/MessageThread';
 import DirectMessage from 'app/components/DirectMessage';
 import Login from 'app/components/Login';
 import Register from 'app/components/Register';
@@ -72,6 +73,7 @@ const AppMain = ({ statusCode, url, referrer, isToasterOpen }) => {
         <Page url='/register' component={ Register } />
         <Page url='/message/compose' component={ DirectMessage } />
         <Page url='/message/:mailType' component={ Messages } />
+        <Page url='/message/messages/:threadId' component={ MessageThread } />
         <Page url='/report' component={ Report } />
       </UrlSwitch>
 

--- a/src/app/router/handlers/Messages.js
+++ b/src/app/router/handlers/Messages.js
@@ -1,4 +1,5 @@
 import { BaseHandler, METHODS } from '@r/platform/router';
+import * as platformActions from '@r/platform/actions';
 
 import * as mailActions from 'app/actions/mail';
 import { fetchUserBasedData } from './handlerCommon';
@@ -6,7 +7,13 @@ import { getBasePayload, logClientScreenView } from 'lib/eventUtils';
 
 export default class Messages extends BaseHandler {
   async [METHODS.GET](dispatch, getState) {
-    dispatch(mailActions.fetchInbox(this.urlParams.mailType));
+    if (!getState().session.isValid) {
+      return dispatch(platformActions.setPage('/register'));
+    }
+
+    const mailType = this.urlParams.mailType ? this.urlParams.mailType : 'messages';
+    dispatch(mailActions.fetchInbox(mailType, this.urlParams.threadId));
+
     await fetchUserBasedData(dispatch);
 
     logClientScreenView(getBasePayload, getState());

--- a/src/app/router/index.js
+++ b/src/app/router/index.js
@@ -45,6 +45,7 @@ export default [
   ['/register', Register],
   ['/message/compose', DirectMessage],
   ['/message/:mailType', Messages],
+  ['/message/messages/:threadId', Messages],
   ['/report', ReportHandler],
   ['/r/:subredditName/submit', PostSubmitHandler],
   ['/submit', PostSubmitHandler],


### PR DESCRIPTION
Adds another page in which we display all of the
messages in a conversation. This is still read-only
support, but now the user should be able to see
everything at least.

Also guard the message endpoints against logged
out users while in the neighborhood

👓  @schwers @phil303 