### PR TITLE
Prevent nsfw show button from opening link

### DIFF
--- a/src/app/components/Post/PostContent/index.jsx
+++ b/src/app/components/Post/PostContent/index.jsx
@@ -320,7 +320,7 @@ export default class PostContent extends React.Component {
     }
 
     if (previewImage) {
-      const callback = isNSFW ? this.props.toggleShowNSFW : null;
+      const callback = isNSFW ? e => { e.preventDefault(); this.props.toggleShowNSFW(); } : null;
       return this.buildImagePreview(
         previewImage, sourceURL, linkDescriptor, callback, needsNSFWBlur, isCompact, playableType);
     }


### PR DESCRIPTION
Without `e.preventDefault()`, nsfw links will open up in a new tab as
well as revealing the blurred image below.

👓 @schwers 