### PR TITLE
Send loid in ad request headers

### DIFF
--- a/src/app/actions/ads.js
+++ b/src/app/actions/ads.js
@@ -135,7 +135,7 @@ export const fetchAddBasedOnResults = async (dispatch, state, adId, postsList, p
     // If the user is not logged in, send the loid in the promo request.
     // In theory loid should be set in a header as well now, but the endpoint
     // takes it as a parameter.
-    data.loid = state.loid;
+    data.loid = state.loid.loid;
   }
 
   try {


### PR DESCRIPTION
We were sending an object string because state.loid is an object. Send the actual loid from state
Before:
![image](https://cloud.githubusercontent.com/assets/2382537/19128652/19dfc5ac-8af9-11e6-981b-cc7e0b1c9095.png)
After:
![image](https://cloud.githubusercontent.com/assets/2382537/19128666/2b901838-8af9-11e6-8583-35db0e75fd85.png)
👓 @schwers 