### PR TITLE
Add a "refresh this page" message to the ErrorPage

### DIFF
--- a/src/app/components/ErrorPage/index.jsx
+++ b/src/app/components/ErrorPage/index.jsx
@@ -6,10 +6,15 @@ import './styles.less';
 const T = React.PropTypes;
 
 const GO_BACK = 'Go Back!';
-const GO_TO_FRONTPAGE = 'To the front page!';
+const GO_TO_FRONTPAGE = 'Go to the front page!';
 const ERROR_404 = 'Page Not Found';
 const ERROR_403 = 'Sorry, you don\'t have access to this.';
-const ERROR_GENERIC = 'Something went wrong.';
+const ERROR_GENERIC = (
+  <div>
+    <div>Something went wrong.</div>
+    <div>Please refresh this page or</div>
+  </div>
+);
 
 const ERROR_MAP = {
   '403': ERROR_403,

--- a/src/app/components/ErrorPage/styles.less
+++ b/src/app/components/ErrorPage/styles.less
@@ -15,5 +15,6 @@
 
   &__error {
     margin-bottom: 5px;
+    line-height: 1.5;
   }
 }


### PR DESCRIPTION
This is for the case of an auth token refresh issue
that can occur if you require a refresh token on a
consecutive action on a page. This makes things
slightly friendlier to the user.

👓 @schwers @phil303 

What it looks like:

<img width="423" alt="screen shot 2016-10-12 at 6 20 40 pm" src="https://cloud.githubusercontent.com/assets/25475/19333301/5e74a0ba-90a9-11e6-9388-dfb44878941f.png">
