### PR TITLE
Reporting modal - fix accidentally reverted changes

### DIFF
--- a/src/app/actions/reporting.js
+++ b/src/app/actions/reporting.js
@@ -30,7 +30,7 @@ export const submit = (thingId, reason) => async (dispatch, getState) => {
       body: { reason, thing_id: thingId, api_type: 'json' },
     });
 
-    dispatch({ type: SUCCESS, message: 'Thanks for reporting!' });
+    dispatch({ type: SUCCESS, message: 'Thanks for letting us know!' });
 
   } catch (e) {
     dispatch({ type: FAILURE });

--- a/src/app/actions/toaster.js
+++ b/src/app/actions/toaster.js
@@ -1,6 +1,6 @@
 export const TYPES = {
-  SUCCESS: 'SUCCESS',
   ERROR: 'ERROR',
+  REPORT_SUCCESS: 'REPORT_SUCCESS',
 };
 
 export const CLOSE = 'TOASTER__CLOSE';

--- a/src/app/components/ModalSwitch/index.jsx
+++ b/src/app/components/ModalSwitch/index.jsx
@@ -5,14 +5,14 @@ import { createSelector } from 'reselect';
 import ReportingModal from '../ReportingModal';
 import * as reportingActions from 'app/actions/reporting';
 
-function ModalSwitch(props) {
+const ModalSwitch = props => {
   switch (props.modal.type) {
     case reportingActions.MODAL_TYPE:
       return <ReportingModal { ...props.modal } />;
     default:
       return null;
   }
-}
+};
 
 const mapStateToProps = createSelector(
   state => state.modal,

--- a/src/app/components/ReportingModal/index.jsx
+++ b/src/app/components/ReportingModal/index.jsx
@@ -40,6 +40,10 @@ class ReportingModal extends React.Component {
     reason: REASONS_ORDER[0],
   }
 
+  static propTypes = {
+    onSubmit: T.func.isRequired,
+  };
+
   render() {
     return (
       <div className='ReportingModalWrapper' onClick={ this.props.onClickOutside }>
@@ -90,10 +94,6 @@ class ReportingModal extends React.Component {
     );
   }
 }
-
-ReportingModal.propTypes = {
-  onSubmit: T.func.isRequired,
-};
 
 const selector = createSelector(
   state => state.modal.props,

--- a/src/app/components/ReportingModal/styles.less
+++ b/src/app/components/ReportingModal/styles.less
@@ -26,7 +26,7 @@
   .themeify({
     background-color: @theme-modal-body-color;
     border: @theme-border;
-  }, {
+  }, @inDayMode: {
     border: none;   // in day mode, the overlay makes the border unnecessary
   });
 

--- a/src/app/components/Toaster/index.jsx
+++ b/src/app/components/Toaster/index.jsx
@@ -54,8 +54,8 @@ function chooseBody(props) {
   switch (props.type) {
     case TYPES.ERROR:
       return renderDefaultBody(props, 'error', 'moose');
-    case TYPES.SUCCESS:
-      return renderDefaultBody(props, 'success', 'snoo');
+    case TYPES.REPORT_SUCCESS:
+      return renderDefaultBody(props, 'report-success', 'flag');
     default:
       return null;
   }

--- a/src/app/components/Toaster/styles.less
+++ b/src/app/components/Toaster/styles.less
@@ -28,18 +28,19 @@
       background-color: @ban-red;
     }
 
-    &.success {
-      background-color: @green;
+    &.report-success {
+      background-color: @warning-yellow;
     }
 
+    // normalize icons at approximately 42px high
     .icon-moose {
       font-size: 65px;
       line-height: 80px;
       color: white;
     }
 
-    .icon-snoo {
-      font-size: 80px;
+    .icon-flag {
+      font-size: 75px;
       line-height: 80px;
       color: white;
     }

--- a/src/app/reducers/modal.js
+++ b/src/app/reducers/modal.js
@@ -1,3 +1,12 @@
+/**
+ * Reducer handling the type of modal currently being displayed. When `type`
+ * is null, no modal is showing.
+ *
+ * `props` is a special unstructured field that allows you to pass properties
+ * from an initiator, such as hitting the report button, to the modal. Since
+ * modals in mweb are top level components, this is acting as a transport
+ * mechanism from lower in the React hierarchy to the top.
+*/
 import merge from '@r/platform/merge';
 
 import * as modalActions from 'app/actions/modal';

--- a/src/app/reducers/toaster.js
+++ b/src/app/reducers/toaster.js
@@ -34,7 +34,7 @@ export default function(state=DEFAULT, action={}) {
     case reportingActions.SUCCESS: {
       return merge(state, {
         isOpen: true,
-        type: toasterActions.TYPES.SUCCESS,
+        type: toasterActions.TYPES.REPORT_SUCCESS,
         message: action.message,
       });
     }


### PR DESCRIPTION
I accidentally overwrote some of the changes that addressed PR
comments. I did this by force pushing without fetching my latest changes
done from another computer (hecka dumb). This undoes that mistake.

The one major change this adds back is some UI changes to the modal
recommended by Derek. Instead of a snoo icon with a green background,
it's now a flag with a yellow background.

This looks like this:

<img width="397" alt="screen shot 2016-10-12 at 7 29 01 pm" src="https://cloud.githubusercontent.com/assets/787203/19334633/299f10c4-90b2-11e6-8fee-960025b39c88.png">

:eyeglasses: @schwers 