### PR TITLE
Fix missing "load more" button

### DIFF
--- a/src/app/components/Comment/index.jsx
+++ b/src/app/components/Comment/index.jsx
@@ -108,10 +108,13 @@ function renderFooter(props) {
     preview,
   } = props;
 
+  // it's possible to have a comment with no visible replies but a load more button
+  const showReplies = comment.replies.length || comment.loadMoreIds.length;
+
   return [
     !commentDeleted ? renderTools(props) : null,
     !preview && commentReplying && !commentingDisabled ? renderCommentReply(props) : null,
-    !preview && !commentCollapsed && comment.replies.length ? renderReplies(props) : null,
+    !preview && !commentCollapsed && showReplies ? renderReplies(props) : null,
   ];
 }
 
@@ -175,7 +178,7 @@ function renderCommentReply(props) {
 
 
 function renderReplies(props) {
-  const { op, nestingLevel, comment, commentCollapsed } = props;
+  const { comment, nestingLevel, commentCollapsed } = props;
 
   const className = cx('Comment__replies', {
     'm-hidden': commentCollapsed,
@@ -184,16 +187,20 @@ function renderReplies(props) {
 
   return (
     <div className={ className }>
-      <CommentsList
-        op={ op }
-        commentRecords={ comment.replies }
-        parentComment={ comment }
-        nestingLevel={ nestingLevel + 1 }
-      />
-
+      { comment.replies.length ? renderCommentsList(props) : null }
       { comment.loadMoreIds.length ? renderMoreCommentsButton(props) : null }
-
     </div>
+  );
+}
+
+function renderCommentsList(props) {
+  return (
+    <CommentsList
+      op={ props.op }
+      commentRecords={ props.comment.replies }
+      parentComment={ props.comment }
+      nestingLevel={ props.nestingLevel + 1 }
+    />
   );
 }
 


### PR DESCRIPTION
Bug:
When a comment had no replies but needed a "load more" button, we were
not showing one. This was due a `replies.length` check that was
happening ahead of rendering the "load more" button.

Fix:
Allow the "load more" button to render independent of the length of
replies. This is done by making the `replies.length` check or'd with a
`loadMoreIds.length` check.

For comparison:
Before:
<img width="396" alt="screen shot 2016-10-12 at 7 48 00 pm" src="https://cloud.githubusercontent.com/assets/787203/19335006/db1602e8-90b4-11e6-9d7d-7fa0e7811b5e.png">

After:
<img width="401" alt="screen shot 2016-10-12 at 7 47 18 pm" src="https://cloud.githubusercontent.com/assets/787203/19335057/2a94efd2-90b5-11e6-852d-27a15c354113.png">

Nested comments now have "load more" button as well:
<img width="443" alt="screen shot 2016-10-12 at 7 47 38 pm" src="https://cloud.githubusercontent.com/assets/787203/19335062/35fcf400-90b5-11e6-97bd-c4662c1007d3.png">

:eyeglasses: @uzi || @schwers 