### PR TITLE
Fix a missing `loadMoreIds` bug

### DIFF
--- a/src/app/components/Comment/index.jsx
+++ b/src/app/components/Comment/index.jsx
@@ -109,7 +109,10 @@ function renderFooter(props) {
   } = props;
 
   // it's possible to have a comment with no visible replies but a load more button
-  const showReplies = comment.replies.length || comment.loadMoreIds.length;
+  // NOTE: this comment should have loadMoreIds field and doesn't so this is a
+  // hack for the time being. I'm going to address this in a follow up patch.
+  const { replies, loadMoreIds } = comment;
+  const showReplies = replies.length || (loadMoreIds && loadMoreIds.length);
 
   return [
     !commentDeleted ? renderTools(props) : null,


### PR DESCRIPTION
This is somewhat of a hack for the time being just to quiet the logs.
This field should have a default value of an empty array ideally. I'm
working on that version of the fix now, which will most likely be in 
api-client, but it's taking longer than expected.

:eyeglasses: @uzi 