### PR TITLE
Call UserActivity handler on the client for u/ links

### DIFF
--- a/src/app/components/Post/PostHeader/index.jsx
+++ b/src/app/components/Post/PostHeader/index.jsx
@@ -117,7 +117,7 @@ function renderAuthorAndTimeStamp(post, single, hideWhen) {
   } = post;
 
   const authorLink = (
-    <Anchor className='PostHeader__author-link' href={ `/u/${author}` }>
+    <Anchor className='PostHeader__author-link' href={ `/user/${author}` }>
       { `u/${author}` }
     </Anchor>
   );

--- a/src/app/router/handlers/UserReroute.js
+++ b/src/app/router/handlers/UserReroute.js
@@ -1,4 +1,4 @@
-import { setPage } from '@r/platform/actions';
+import { setPage, navigateToUrl } from '@r/platform/actions';
 import { BaseHandler, METHODS } from '@r/platform/router';
 
 export default class UserReroute extends BaseHandler {
@@ -8,6 +8,12 @@ export default class UserReroute extends BaseHandler {
     let { url } = currentPage;
 
     url = url.replace('/u/', '/user/');
-    dispatch(setPage(url, { urlParams, queryParams, hashParams, referrer }));
+    if (process.env.ENV === 'client') {
+      // redirect the url and make sure platform runs the handler
+      dispatch(navigateToUrl(METHODS.GET, url, { urlParams, queryParams, hashParams }));
+    } else {
+      // redirect but don't run the handler
+      dispatch(setPage(url, { urlParams, queryParams, hashParams, referrer }));
+    }
   }
 }


### PR DESCRIPTION
So this seems like an unintended consequence of the u/ -> user/ redirect. By using setPage we don't call the handler on the server during a redirect, which is nice because we don't do extra work fetching anything, etc. However setPage doesn't run the handler, so OTOH(or the client) we don't run the handler, so you see broken user page. I would be open to just always using setPage and letting the handler run on the server, but I thought this was a good example for discussing platform in general, hence the large 👓  @uzi @ajacksified @nramadas @phil303 


Commit message:
We started redirecting `u/*` links to `user/*` because that's the cannonical
url. The redirect was using SET_PAGE, so on the client handlers weren't being
run. This made the user page sit idlely with a loading indicator forever
when you came there via the PostHeader link or u/ links in UGC text.
As a safety measure this patch also changes the PostHeader links to use
the canonical format.
