### PR TITLE
Fix z-index issue with dropdowns

### DIFF
--- a/src/app/components/Dropdown/styles.less
+++ b/src/app/components/Dropdown/styles.less
@@ -2,7 +2,7 @@
 @import (reference) '~app/less/themes/themeify';
 
 .DropdownWrapper {
-  position: relative;
+  position: fixed;
   z-index: @z-index-dropdown;
 }
 


### PR DESCRIPTION
In order to create a new stacking context, `position: fixed` must be
used. This was using `position: relative`. This wasn't occurring on
desktop Chrome so I missed it unfortunately.

I tested this on ios browsers Chrome and Safari and desktop browsers
Chrome, Safari, and Firefox.

:eyeglasses: @nramadas 