### PR TITLE
Comment and post events

### DIFF
--- a/src/app/actions/reply.js
+++ b/src/app/actions/reply.js
@@ -2,8 +2,11 @@
 // Thus all actions related to replying, opening the form, and making the reply
 // are kept in this file.
 
+import { getEventTracker } from 'lib/eventTracker';
+import { getBasePayload, buildSubredditData, convertId } from 'lib/eventUtils';
 import { apiOptionsFromState } from 'lib/apiOptionsFromState';
 import modelFromThingId from 'app/reducers/helpers/modelFromThingId';
+
 
 export const TOGGLE_REPLY_FORM = 'TOGGLE_REPLY_FORM';
 export const toggleReplyForm = id => ({ type: TOGGLE_REPLY_FORM, id });
@@ -29,4 +32,29 @@ export const reply = (id, text) => async (dispatch, getState) => {
   // TODO the replyable mixin should just be returning a CommentModel from this...
   const reply = apiResponse.getModelFromRecord(apiResponse.results[0]);
   dispatch(replied(id, reply));
+
+  logReply(reply, getState());
 };
+
+
+function logReply(reply, state) {
+  // If the parent starts with a t1, then its parent is a comment. If not,
+  // then its parent is a post.
+  const stateKey = reply.parentId.startsWith('t1') ? 'comments' : 'posts';
+  const parent = state[stateKey][reply.parentId];
+  const post = state.posts[reply.linkId];
+
+  getEventTracker().track('comment_events', 'cs.comment', {
+    ...getBasePayload(state),
+    ...buildSubredditData(state),
+    comment_id: convertId(reply.name),
+    comment_fullname: reply.name,
+    comment_body: reply.bodyMD,
+    post_id: convertId(post.name),
+    post_fullname: post.name,
+    post_created_ts: post.createdUTC * 1000,
+    parent_id: convertId(parent.name),
+    parent_fullname: parent.name,
+    parent_created_ts: parent.createdUTC * 1000,
+  });
+}

--- a/src/lib/eventUtils.js
+++ b/src/lib/eventUtils.js
@@ -40,6 +40,7 @@ export function getBasePayload(state) {
     domain,
     geoip_country: state.meta.country,
     user_agent: state.meta.userAgent,
+    base_url: state.platform.currentPage.url,
     referrer_domain: url.parse(referrer).host || domain,
     referrer_url: referrer,
     language: state.preferences.lang,


### PR DESCRIPTION
Feature:
This adds comment events via the `reply` action and submit events via
the `submitPost` action.

Details:
- With comment events, you can have parent data values that are derived
from the OP's data or just a parent comment. There's some logic around
that.
- With post events, some keys change depending on whether a post is a
link or a self, so there's some logic around that as well.
- I noticed I was missing `base_url` in the `getBasePayload` function,
so I added that in.

Testing:
For comments, tested on replies to comments and posts and for posting,
tested on link and self posts.

I think you guys are doing the other events so eyeglassing you all.
:eyeglasses: @uzi @nramadas @ajacksified 