### PR TITLE
Increase toaster font size

### DIFF
--- a/src/app/actions/posts.js
+++ b/src/app/actions/posts.js
@@ -87,7 +87,7 @@ export const failedUpdateSelfText = (postId, error) => ({
   type: FAILED_UPDATE_SELF_TEXT,
   thingId: postId,
   error,
-  message: 'Sorry, something went wrong with updating your post',
+  message: 'Sorry, something went wrong with updating your post.',
 });
 
 export const updateSelfText = (postId, newSelfText) => async (dispatch, getState) => {

--- a/src/app/components/CaptchaBox/styles.less
+++ b/src/app/components/CaptchaBox/styles.less
@@ -51,7 +51,6 @@
       width: 100%;
       padding: 14px;
       border-radius: 0;   // handle ios safari's native border rounding
-      font-size: 16px;
 
       .themeify({
         color: @theme-body-text-color;

--- a/src/app/components/DirectMessage/Composition.less
+++ b/src/app/components/DirectMessage/Composition.less
@@ -12,7 +12,6 @@
   &__textarea {
     width: 100%;
     margin-bottom: @grid-size;
-    font-size: 16px;
     padding: @grid-size;
 
     .themeify({

--- a/src/app/components/EditForm/styles.less
+++ b/src/app/components/EditForm/styles.less
@@ -14,7 +14,6 @@
     width: 100%;
     height: 100%;
     resize: none;
-    font-size: 16px; // prevent iOS zooming
 
     .themeify({
       background-color: @theme-modal-body-color;

--- a/src/app/components/Toaster/styles.less
+++ b/src/app/components/Toaster/styles.less
@@ -49,6 +49,9 @@
   &__message {
     display: inline-block;
     padding: 15px;
+    padding-right: 0;
+    font-size: 15px;
+
     .themeify({
       color: @theme-body-color;
     });

--- a/src/app/less/normalizers/redditReset.less
+++ b/src/app/less/normalizers/redditReset.less
@@ -76,3 +76,13 @@ img {
 [role="button"] {
   cursor: pointer;
 }
+
+// iOS will automatically zoom in when an input is selected but not reset the
+// zoom level when the user is done. This allows for horizontal panning which
+// is not expected behavior from a UX perspective.
+input[type="text"],
+input[type="number"],
+input[type="password"],
+textarea {
+  font-size: 16px;
+}


### PR DESCRIPTION
Seeing the toaster pop up on my iPhone 6, I felt like I was squinting
to read the text. Increasing the font-size up to 15px puts it at a
comfortable reading level. This is especially important with the
toaster because it auto-dismisses after 3 seconds.

I tested this down to iPhone 4 dimensions with some of the longer
messages. Sometimes the toaster text ended up taking 3 lines but still
looked pretty good even in those cases.

I removed the right padding on the text because there's already padding
around the close button to right, which was making it look like there
was too much padding in total between the two elements.