### PR TITLE
Normalize all input font sizes to prevent zooming

### DIFF
--- a/src/app/components/CaptchaBox/styles.less
+++ b/src/app/components/CaptchaBox/styles.less
@@ -51,7 +51,6 @@
       width: 100%;
       padding: 14px;
       border-radius: 0;   // handle ios safari's native border rounding
-      font-size: 16px;
 
       .themeify({
         color: @theme-body-text-color;

--- a/src/app/components/DirectMessage/Composition.less
+++ b/src/app/components/DirectMessage/Composition.less
@@ -12,7 +12,6 @@
   &__textarea {
     width: 100%;
     margin-bottom: @grid-size;
-    font-size: 16px;
     padding: @grid-size;
 
     .themeify({

--- a/src/app/components/EditForm/styles.less
+++ b/src/app/components/EditForm/styles.less
@@ -14,7 +14,6 @@
     width: 100%;
     height: 100%;
     resize: none;
-    font-size: 16px; // prevent iOS zooming
 
     .themeify({
       background-color: @theme-modal-body-color;

--- a/src/app/less/normalizers/redditReset.less
+++ b/src/app/less/normalizers/redditReset.less
@@ -76,3 +76,13 @@ img {
 [role="button"] {
   cursor: pointer;
 }
+
+// iOS will automatically zoom in when an input is selected but not reset the
+// zoom level when the user is done. This allows for horizontal panning which
+// is not expected behavior from a UX perspective.
+input[type="text"],
+input[type="number"],
+input[type="password"],
+textarea {
+  font-size: 16px;
+}


### PR DESCRIPTION
iOS will automatically zoom in when an input is selected but not reset
the zoom level when the user is done. This allows for horizontal panning
which is not expected behavior from a UX perspective. (Also, it annoys
the crap out of me :P)

Rationale:
I'm normalizing all inputs because I'd never expect a dev of any
experience level to know/remember this while writing an input
component. By doing this everywhere, it's just taken care of. And b/c
it's css, it's easy to overwrite should the need arise.

It's pretty annoying that iOS forces this but it still looks pretty good
so I feel more ok making a universal rule. BUT in general, this kind of
thing screams "stop and think about what you're doing here" which is why
it's an RFC.

Details:
- This applies to text, number, and password inputs and also textareas.
I specified types on the inputs to limit the scope of change (there's a
ton of input types that I don't want to mess with).

:eyeglasses: @schwers 