### PR TITLE
Mount default VCL instead of copying over.

### DIFF
--- a/Dockerfile.varnish
+++ b/Dockerfile.varnish
@@ -1,5 +1,7 @@
 FROM quay.io/reddit/varnish-fastly
 
+VOLUME ["/etc/varnish"]
+
 # FIXME(wting|2016-09-13): Port overrides aren't working, Varnish is still
 # running on port 80 instead.
 ENV VARNISH_PORTS 8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,5 +14,7 @@ services:
       dockerfile: Dockerfile.varnish
     ports:
     - "4301:80"
+    volumes:
+    - .:/etc/varnish
     depends_on:
     - mweb


### PR DESCRIPTION
By mounting the file we can guarantee that Docker doesn't cache the
config file (default.vcl) and will always use the newest one.

:eyeglasses: @spladug 

cc: @gtaylor @telaviv 