### PR TITLE
Experiment fix: look up recommended subreddits by postId

### DIFF
--- a/src/app/pages/Comments.jsx
+++ b/src/app/pages/Comments.jsx
@@ -65,10 +65,15 @@ const stateProps = createSelector(
     const postLoaded = !!post;
     const replying = currentPage.queryParams.commentReply === commentsPageParams.id;
 
-    const recommendedSubredditNames = recommendedSrs[currentPage.urlParams.subredditName] || [];
-    const recommendedSubreddits = recommendedSubredditNames.map(name => subreddits[name]);
+    let recommendedSubredditNames = [];
+    if (post && post.subreddit in recommendedSrs) {
+      recommendedSubredditNames = recommendedSrs[post.subreddit];
+    }
 
-    const currentSubreddit = subreddits[currentPage.urlParams.subredditName];
+    const recommendedSubreddits = recommendedSubredditNames.map(name => subreddits[name]);
+    // since we return early in the render function if !postLoaded, it's OK
+    // for currentSubreddit to be null here
+    const currentSubreddit = post ? post.subredditDetail : null;
 
     return {
       op: postLoaded ? post.author : '',

--- a/src/app/router/handlers/CommentsPage.js
+++ b/src/app/router/handlers/CommentsPage.js
@@ -59,7 +59,7 @@ export default class CommentsPage extends BaseHandler {
 
     const commentsPageParams = CommentsPage.pageParamsToCommentsPageParams(this);
     const commentsPageId = paramsToCommentsPageId(commentsPageParams);
-    const { subredditName } = state.platform.currentPage.urlParams;
+    let { subredditName } = state.platform.currentPage.urlParams;
 
     await Promise.all([
       dispatch(commentsPageActions.fetchCommentsPage(commentsPageParams)),
@@ -67,11 +67,18 @@ export default class CommentsPage extends BaseHandler {
 
       dispatch(commentsPageActions.fetchRelevantContent()),
       dispatch(commentsPageActions.visitedCommentsPage(this.urlParams.postId)),
-      fetchRecommendedSubreddits(state, dispatch, subredditName),
-
       dispatch(subredditActions.fetchSubreddit(subredditName)),
+
     ]);
 
+    // if url does not include r/subredditName, then subredditName will be
+    // undefined, even if we are on a comments page. We can ascertain the
+    // subredditName by looking it up via postId
+    if (!subredditName) {
+      subredditName = getState().posts[`t3_${state.platform.currentPage.urlParams.postId}`].subreddit;
+    }
+
+    fetchRecommendedSubreddits(state, dispatch, subredditName);
     dispatch(setStatus(getState().commentsPages[commentsPageId].responseCode));
 
     logClientScreenView(buildScreenViewData, getState());


### PR DESCRIPTION
If there is no subredditName in the urlParams, look up the
subreddit by postId, then fetch the recommended subreddit objects

These two urls should yield the same recommended subreddits:

[http://localhost:4444/r/relationships/comments/559d7x/this_is_a_difficult_question_to_ask_because_i_35m?feature_experimentrecommendedtopplain=#](http://localhost:4444/r/relationships/comments/559d7x/this_is_a_difficult_question_to_ask_because_i_35m?feature_experimentrecommendedtopplain=#)

[http://localhost:4444/comments/559d7x/this_is_a_difficult_question_to_ask_because_i_35m?feature_experimentrecommendedtopplain=#](http://localhost:4444/comments/559d7x/this_is_a_difficult_question_to_ask_because_i_35m?feature_experimentrecommendedtopplain=#)

👓 @uzi @phil303 @schwers 