### PR TITLE
Support GTM and adblock events

### DIFF
--- a/blueprints.config.js
+++ b/blueprints.config.js
@@ -21,6 +21,8 @@ module.exports = function(isProduction) {
     {
       generator: 'set-node-env',
       'process.env': {
+        GOOGLE_TAG_MANAGER_ID: JSON.stringify(process.env.GOOGLE_TAG_MANAGER_ID),
+        MEDIA_DOMAIN: JSON.stringify(process.env.MEDIA_DOMAIN),
         REDDIT: JSON.stringify(process.env.REDDIT),
         STATS_URL: JSON.stringify(process.env.STATS_URL),
         TRACKER_CLIENT_NAME: JSON.stringify(process.env.TRACKER_CLIENT_NAME),

--- a/src/app/components/AdblockTester/index.jsx
+++ b/src/app/components/AdblockTester/index.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { ADBLOCK_TEST_ID } from 'app/constants';
+import config from 'config';
+
+const { adblockTestClassName } = config;
+
+// Renders a component, hidden offscreen, used to detect if adblock is
+// enabled. If it's enabled, the div will either be removed entirely from
+// the dom, or hidden via css or style modifications. The checks
+// for being hidden currently live in `lib/eventUtils`
+
+export default function AdblockTester() {
+  return (
+    <div
+      id={ ADBLOCK_TEST_ID }
+      className={ adblockTestClassName }
+      style={ {
+        height: 1,
+        width: 1,
+        position: 'absolute',
+        left: '-1000%',
+      } }
+    />
+  );
+}

--- a/src/app/components/AdsTracking/index.jsx
+++ b/src/app/components/AdsTracking/index.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { createSelector } from 'reselect';
+
+import config from 'config';
+import GoogleTagManager from 'app/components/GoogleTagManager';
+
+// This component renders things that are needed for ads tracking.
+// Right now this is:
+// * GoogleTagManager -- used for tracking screenviews for ad targetting
+// * AdblockTester -- used to determine if adblock is enabled, this info is
+//    included on the base events payload
+export const AdsTracking = props => {
+  const { subredditName } = props;
+  const { mediaDomain, googleTagManagerId } = config;
+
+  return (
+    <div>
+      { !!googleTagManagerId &&
+          <GoogleTagManager
+            key='gtm'
+            mediaDomain={ mediaDomain }
+            googleTagManagerId={ googleTagManagerId }
+            subredditName={ subredditName }
+          />
+      }
+    </div>
+  );
+};
+
+const selector = createSelector(
+  state => state.platform.currentPage.urlParams.subredditName,
+  subredditName => ({ subredditName }),
+);
+
+export default connect(selector)(AdsTracking);

--- a/src/app/components/AdsTracking/index.jsx
+++ b/src/app/components/AdsTracking/index.jsx
@@ -3,6 +3,8 @@ import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 
 import config from 'config';
+
+import AdblockTester from 'app/components/AdblockTester';
 import GoogleTagManager from 'app/components/GoogleTagManager';
 
 // This component renders things that are needed for ads tracking.
@@ -24,6 +26,7 @@ export const AdsTracking = props => {
             subredditName={ subredditName }
           />
       }
+      <AdblockTester />
     </div>
   );
 };

--- a/src/app/components/GoogleTagManager/index.jsx
+++ b/src/app/components/GoogleTagManager/index.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { GTM_JAIL_ID } from 'app/constants';
+
+const T = React.PropTypes;
+
+const GoogleTagManager = props => {
+  const script = `
+    <script type='text/javascript'>
+      if (!window.DO_NOT_TRACK) {
+        var frame = document.createElement('iframe');
+
+        frame.style.display = 'none';
+        frame.referrer = 'no-referrer';
+        frame.id = '${GTM_JAIL_ID}';
+        frame.name = JSON.stringify({
+          subreddit: '${props.subredditName || ''}',
+          origin: location.origin,
+          pathname: location.pathname,
+        });
+        frame.src = 'https://${props.mediaDomain}/gtm/jail?id=${props.googleTagManagerId}';
+        document.body.appendChild(frame);
+      }
+    </script>
+  `;
+
+  return <div dangerouslySetInnerHTML={ { __html: script } } />;
+};
+
+GoogleTagManager.propTypes = {
+  nonce: T.string.isRequired,
+  mediaDomain: T.string.isRequired,
+  googleTagManagerId: T.string.isRequired,
+  subredditName: T.string,
+};
+
+export default GoogleTagManager;

--- a/src/app/components/PostsList/index.jsx
+++ b/src/app/components/PostsList/index.jsx
@@ -9,8 +9,6 @@ import Post from 'app/components/Post';
 import Loading from 'app/components/Loading';
 import adLocationForPostRecords from 'lib/adLocationForPostRecords';
 
-import map from 'lodash/map';
-
 const T = React.PropTypes;
 
 export const PostsList = props => {
@@ -51,7 +49,7 @@ const renderPostsList = props => {
   const { postRecords, ad, adId, forceCompact, subredditIsNSFW } = props;
   const records = ad ? recordsWithAd(postRecords, ad) : postRecords;
 
-  return map(records, postRecord => {
+  return records.map((postRecord, index) => {
     const postId = postRecord.uuid;
 
     const postProps = {
@@ -63,7 +61,7 @@ const renderPostsList = props => {
 
     if (ad && postId === ad.uuid) {
       // Ad wants the adId for tracking the ad impression
-      return <Ad postProps={ postProps } adId={ adId } />;
+      return <Ad postProps={ postProps } adId={ adId } placementIndex={ index }/>;
     }
 
     return <Post { ...postProps } />;

--- a/src/app/constants.js
+++ b/src/app/constants.js
@@ -1,5 +1,7 @@
 export const AD_LOCATION = 11;
 
+export const GTM_JAIL_ID = 'gtm-jail';
+
 export const TOGGLE_OVER_18 = 'toggleOver18';
 
 export const USER_MENU_TOGGLE = 'sideNavToggle';

--- a/src/app/constants.js
+++ b/src/app/constants.js
@@ -2,6 +2,8 @@ export const AD_LOCATION = 11;
 
 export const GTM_JAIL_ID = 'gtm-jail';
 
+export const ADBLOCK_TEST_ID = 'adblock-test';
+
 export const TOGGLE_OVER_18 = 'toggleOver18';
 
 export const USER_MENU_TOGGLE = 'sideNavToggle';

--- a/src/app/index.jsx
+++ b/src/app/index.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { UrlSync } from '@r/platform/components';
 import { TooltipShutter } from '@r/widgets/tooltip';
 
+import AdsTracking from './components/AdsTracking';
 import AppMainPage from './pages/AppMain';
 import AppOverlayMenu from './components/AppOverlayMenu';
 import CookieSync from './side-effect-components/CookieSync';
@@ -25,6 +26,7 @@ export default class App extends React.Component {
         <DomModifier />
         <SessionRefresher />
         <TooltipShutter />
+        <AdsTracking />
       </div>
     );
   }

--- a/src/config.js
+++ b/src/config.js
@@ -63,7 +63,6 @@ const config = () => ({
   reddit,
   rootReddit,
 
-  googleAnalyticsId: process.env.GOOGLE_ANALYTICS_ID,
   googleTagManagerId: process.env.GOOGLE_TAG_MANAGER_ID,
 
   adblockTestClassName: process.env.ADBLOCK_TEST_CLASSNAME || 'ad adsense-ad googad gemini-ad openx',

--- a/src/lib/dom.js
+++ b/src/lib/dom.js
@@ -1,0 +1,18 @@
+export const isHidden = el => {
+  if (!el || el.hidden) {
+    return true;
+  }
+
+  const style = window.getComputedStyle(el);
+
+  if (style.display === 'none' ||
+      style.visibility === 'hidden') {
+    return true;
+  }
+
+  if (!el.parentElement) {
+    return false;
+  }
+
+  return isHidden(el.parentElement);
+};

--- a/src/lib/eventUtils.js
+++ b/src/lib/eventUtils.js
@@ -4,6 +4,7 @@ import url from 'url';
 
 import isFakeSubreddit from 'lib/isFakeSubreddit';
 import { getEventTracker } from 'lib/eventTracker';
+import * as gtm from 'lib/gtm';
 
 const ID_REGEX = /(?:t\d+_)?(.*)/;
 
@@ -87,5 +88,16 @@ export function logClientScreenView(buildScreenViewData, state) {
     if (data) {
       getEventTracker().track('screenview_events', 'cs.screenview_mweb', data);
     }
+
+    gtmPageView(state);
   }
 }
+
+const gtmPageView = state => {
+  const { platform: { currentPage }} = state;
+
+  gtm.trigger('pageview', {
+    subreddit: currentPage.urlParams.subredditName || '',
+    pathname: currentPage.url || '/',
+  });
+};

--- a/src/lib/frames.js
+++ b/src/lib/frames.js
@@ -1,0 +1,262 @@
+const ALLOW_WILDCARD = '.*';
+const DEFAULT_MESSAGE_NAMESPACE = '.postMessage';
+const DEFAULT_POSTMESSAGE_OPTIONS = {
+  targetOrigin: '*',
+};
+const RE_HAS_NAMESPACE = /\..+$/;
+
+let allowedOrigins = [ALLOW_WILDCARD];
+let re_postMessageAllowedOrigin = compileOriginRegExp(allowedOrigins);
+const messageNamespaces = [DEFAULT_MESSAGE_NAMESPACE];
+let re_messageNamespaces = compileNamespaceRegExp(messageNamespaces);
+const proxies = {};
+let listening = false;
+
+function receiveMessage(e) {
+  if (e.origin !== global.location.origin &&
+      !re_postMessageAllowedOrigin.test(e.origin)
+      && e.origin !== 'null') {
+    return;
+  }
+
+
+  const message = JSON.parse(e.data);
+  const type = message.type;
+
+  // Namespace doesn't match, ignore
+  if (!re_messageNamespaces.test(type)) {
+    return;
+  }
+
+  const namespace = type.split('.', 2)[1];
+
+  if (proxies[namespace]) {
+    const proxyWith = proxies[namespace];
+
+    proxyWith.targets.forEach(function(target) {
+      frames.postMessage(target, type, message.data, message.options);
+    });
+  }
+
+  const customEvent = new CustomEvent(type, {detail: message.data});
+  customEvent.source = e.source;
+
+  global.dispatchEvent(customEvent);
+}
+
+function _addEventListener(type, handler, useCapture) {
+  if (global.addEventListener) {
+    global.addEventListener(type, handler, useCapture);
+  } else if (global.attachEvent) {
+    global.attachEvent(`on${type}`, handler);
+  }
+}
+
+function _removeEventListener(type, handler) {
+  if (global.removeEventListener) {
+    global.removeEventListener(type, handler);
+  } else if (global.detachEvent) {
+    global.detachEvent(`on${type}`, handler);
+  }
+}
+
+function compileOriginRegExp(origins) {
+  return new RegExp(`^http(s)?:\\/\\/${origins.join('|')}$`, 'i');
+}
+
+function compileNamespaceRegExp(namespaces) {
+  return new RegExp(`\\.(?:${namespaces.join('|')})$`);
+}
+
+function isWildcard(origin) {
+  return /\*/.test(origin);
+}
+
+/** @module frames */
+/* @example
+ * // parent window
+ * // frames.listen('dfp')
+ * // frames.receiveMessageOnce('init.dfp', callback)
+ * @example
+ * // iframe
+ * // frames.postMessage(window.parent, 'init.dfp', data);
+ */
+export default {
+  /*
+   * Send a message to another window.
+   * param {Window} target The frame to deliver the message to.
+   * param {String} type The message type. (if it doesn't include a namespace
+      the default namespace will be used)
+   * param {Object} data The data to send.
+   * param {Object} options The `postMessage` options.
+   * param {String} options.targetOrigin Specifies what the origin of
+      otherWindow must be for the event to be dispatched.
+   */
+  postMessage(target, type, data, options) {
+    if (!RE_HAS_NAMESPACE.test(type)) {
+      type += DEFAULT_MESSAGE_NAMESPACE;
+    }
+
+    options = options || {};
+    let key;
+    for (key in DEFAULT_POSTMESSAGE_OPTIONS) {
+      if (!options.hasOwnProperty(key)) {
+        options[key] = DEFAULT_POSTMESSAGE_OPTIONS[key];
+      }
+    }
+
+    target.postMessage(JSON.stringify({
+      type,
+      data,
+      options,
+    }), options.targetOrigin);
+  },
+
+  /*
+   * Receive a message from another window.
+   * param {Window} [source] The frame to that send the message.
+   * param {String} type The message type. (if it doesn't include a namespace
+      the default namespace will be used)
+   * param {Function} callback The callback to invoke upon retrieval.
+   * param {Object} [context=this] The context the callback is invoked with.
+   * returns {Object} The listener.
+   */
+  receiveMessage(source, type, callback, context) {
+    if (typeof source === 'string') {
+      context = callback;
+      callback = type;
+      type = source;
+      source = null;
+    }
+
+    context = context || this;
+
+    const scoped = function(e) {
+      if (source &&
+          source !== e.source &&
+          source.contentWindow !== e.source) {
+        return;
+      }
+
+      callback.apply(context, arguments);
+    };
+
+    _addEventListener(type, scoped);
+
+    return {
+      off() { _removeEventListener(type, scoped); },
+    };
+  },
+
+  /*
+   * Proxies messages on a namespace from a frame to a specified target.
+   * param {String} namespace The namespace to proxy.
+   * targets {Array<Window>} [source] The frames to proxy messages to.
+   *  NOTE: supports a single frame as well.
+   */
+  proxy(namespace, targets) {
+    this.listen(namespace);
+
+    if (!Array.isArray(targets)) {
+      targets = [targets];
+    }
+
+    let namespaceProxies = proxies[namespace];
+
+    if (namespaceProxies) {
+      namespaceProxies.targets = [].concat(namespaceProxies.targets, targets);
+    } else {
+      namespaceProxies = {
+        targets,
+      };
+    }
+
+    proxies[namespace] = namespaceProxies;
+  },
+
+  /*
+   * Receive a message from another window once.
+   * param {Window} [source] The frame to that send the message.
+   * param {String} type The message type. (if it doesn't include a namespace
+      the default namespace will be used)
+   * param {Function} callback The callback to invoke upon retrieval.
+   * param {Object} [context=this] The context the callback is invoked with.
+   * returns {Object} The listener.
+   */
+  receiveMessageOnce(source, type, callback, context) {
+    const listener = frames.receiveMessage(source, type, function() {
+      if (callback) { callback.apply(this, arguments); }
+
+      listener.off();
+    }, context);
+
+    return listener;
+  },
+
+  /*
+   * Adds an allowed origin to be listened to.
+   * param {String} origin The origin to be added.
+   */
+  addPostMessageOrigin(origin) {
+    if (isWildcard(origin)) {
+      allowedOrigins = [ALLOW_WILDCARD];
+    } else if (allowedOrigins.indexOf(origin) === -1) {
+      frames.removePostMessageOrigin(ALLOW_WILDCARD);
+
+      allowedOrigins.push(origin);
+
+      re_postMessageAllowedOrigin = compileOriginRegExp(allowedOrigins);
+    }
+  },
+
+  /*
+   * Removes an origin from the list of those listened to.
+   * param {String} origin The origin to be removed.
+   */
+  removePostMessageOrigin(origin) {
+    const index = allowedOrigins.indexOf(origin);
+
+    if (index !== -1) {
+      allowedOrigins.splice(index, 1);
+
+      re_postMessageAllowedOrigin = compileOriginRegExp(allowedOrigins);
+    }
+  },
+
+  /*
+   * Listens to messages on of the specified namespace.
+   * param {String} namespace The namespace to be listened to.
+   */
+  listen(namespace) {
+    if (messageNamespaces.indexOf(namespace) === -1) {
+      messageNamespaces.push(namespace);
+      re_messageNamespaces = compileNamespaceRegExp(messageNamespaces);
+    }
+
+    if (!listening) {
+      _addEventListener('message', receiveMessage);
+
+      listening = true;
+    }
+  },
+
+  /*
+   * Stops listening to messages on of the specified namespace.
+   * param {String} namespace The namespace to stop listening to.
+   */
+  stopListening(namespace) {
+    const index = messageNamespaces.indexOf(namespace);
+
+    if (index !== -1) {
+      messageNamespaces.splice(index, 1);
+
+      if (messageNamespaces.length) {
+        re_messageNamespaces = compileNamespaceRegExp(messageNamespaces);
+      } else {
+        _removeEventListener('message', receiveMessage);
+        listening = false;
+      }
+    }
+  },
+
+};

--- a/src/lib/gtm.js
+++ b/src/lib/gtm.js
@@ -1,0 +1,25 @@
+import frames from './frames';
+import { GTM_JAIL_ID } from 'app/constants';
+
+export const getGTMJail = () => document.getElementById(GTM_JAIL_ID);
+
+export const trigger = (eventName, payload) => {
+  const jailEl = getGTMJail();
+  if (!jailEl) { return; }
+
+  if (payload) {
+    set(payload);
+  }
+
+  frames.postMessage(jailEl.contentWindow, 'event.gtm', {
+    event: eventName,
+  });
+};
+
+
+export const set = data => {
+  const jailEl = getGTMJail();
+  if (jailEl) {
+    frames.postMessage(jailEl.contentWindow, 'data.gtm', data);
+  }
+};


### PR DESCRIPTION
Hey all, 

This Pr started out as porting GTM from 1x. Including `adblock` events seemed to make sense, as it's sort of related. Happy to break it out into two separate PRs. For ease of reviewing / reading I'll leave links to the individual commits so it's easier to tell whats-what (though it's probably best to leave comments on this PR itself vs the individual commits)

GTM notes: `frames.js` was copied wholesale from 1X, `gtm.js` and `dom.js` were copied as well but they have some minor cleanup.

GTM Patch [link](https://github.com/reddit/reddit-mobile/commit/8493ea7f6ce42812d48e43e84293ac3a8d1ce3e3)
[GTM Jira Mobileweb-492](https://reddit.atlassian.net/browse/MOBILEWEB-492)

Adblock Patch [link](https://github.com/reddit/reddit-mobile/commit/8493ea7f6ce42812d48e43e84293ac3a8d1ce3e3)
[Adblock Jira Mobileweb-696](https://reddit.atlassian.net/browse/MOBILEWEB-696)

👓  @nramadas  || @phil303 
👓  @dwick 