### PR TITLE
Small tweak to the formatDifference library

### DIFF
--- a/src/lib/formatDifference.js
+++ b/src/lib/formatDifference.js
@@ -20,7 +20,6 @@ const YEARS = 365 * DAYS; // ignoring leap years ...
 
 export const differenceFromNow = unixTime => {
   const now = new Date();
-  now.setMinutes(now.getMinutes(), -1 * now.getTimezoneOffset());
   // Get a diff of now versus the given time, but we assume negatives / in the future
   // shouldn't display with `-` signs everywhere. This should be safe because
   // in the context of most ui's this is probably what you want anyway.


### PR DESCRIPTION
The function signature for Date.setMinutes is
Date.setMinutes(min,sec,millisec), and
Date.getTimezoneOffset returns the value in minutes.

Therefore in California, being 7 hours off UTC at
the moment, the timezoneOffset is 420 minutes...
but if you put that as seconds, it ends up being
7 minutes.  Because of that, times being returned
by this library were off by 7 minutes.  Removing
the errant line fixes the problem.

👓 @schwers @phil303 

(It was bugging me that a brand new message or post said it was `7m` old... now it'll say `0m`.)