### PR TITLE
Make dropdowns close on IOS when clicking outside the menu

### DIFF
--- a/src/app/components/DropdownCover/styles.less
+++ b/src/app/components/DropdownCover/styles.less
@@ -7,6 +7,7 @@
   bottom: 0;
   left: 0;
   right: 0;
+  cursor: pointer;
   z-index: @z-index-overlay;
 
   .themeify({


### PR DESCRIPTION
Thanks Apple. This is silly, but described by links like
  http://stackoverflow.com/questions/3705937/
in which setting `cursor: pointer;`to the DropdownCover
tricks mobile safari into handling the click event...
you know, because it's not a touch event.

👓 @umbrae @phil303 @schwers 