### PR TITLE
Add search events

### DIFF
--- a/src/app/actions/overlay.js
+++ b/src/app/actions/overlay.js
@@ -1,3 +1,6 @@
+import { getEventTracker } from 'lib/eventTracker';
+import { getBasePayload, buildSubredditData } from 'lib/eventUtils';
+
 export const TOGGLE_OVERLAY = 'TOGGLE_OVERLAY';
 export const toggle = kind => ({
   type: TOGGLE_OVERLAY,
@@ -12,11 +15,29 @@ export const closeOverlay = () => ({
 export const COMMUNITY_MENU = 'COMMUNITY_MENU';
 export const toggleCommunityMenu = () => toggle(COMMUNITY_MENU);
 
-export const SEARCH_BAR = 'SEARCH_BAR';
-export const toggleSearchBar = () => toggle(SEARCH_BAR);
 
 export const SETTINGS_MENU = 'SETTINGS_MENU';
 export const toggleSettingsMenu = () => toggle(SETTINGS_MENU);
 
 export const POST_SUBMIT = 'POST_SUBMIT';
 export const togglePostSubmit = () => toggle(POST_SUBMIT);
+
+
+export const SEARCH_BAR = 'SEARCH_BAR';
+
+export const openSearchBar = () => async (dispatch, getState) => {
+  trackSearchBar('cs.search_opened', getState());
+  dispatch(toggle(SEARCH_BAR));
+};
+
+export const closeSearchBar = () => async (dispatch, getState) => {
+  trackSearchBar('cs.search_cancelled', getState());
+  dispatch(toggle(SEARCH_BAR));
+};
+
+function trackSearchBar(event_topic, state) {
+  getEventTracker().track('search_events', event_topic, {
+    ...getBasePayload(state),
+    ...buildSubredditData(state),
+  });
+}

--- a/src/app/components/OverlayMenu/index.jsx
+++ b/src/app/components/OverlayMenu/index.jsx
@@ -12,23 +12,29 @@ const stopClickPropagation = (e) => {
   e.stopPropagation();
 };
 
-export const OverlayMenu = props => (
-  <nav
-    className={ cx('OverlayMenu', { 'm-with-top-nav': !props.fullscreen }) }
-    onClick={ props.closeOverlayMenu }
-  >
-    <ul className='OverlayMenu-ul list-unstyled' onClick={ stopClickPropagation }>
-      { props.children }
-    </ul>
-  </nav>
-);
+export const OverlayMenu = props => {
+  return (
+    <nav
+      className={ cx('OverlayMenu', { 'm-with-top-nav': !props.fullscreen }) }
+      onClick={ props.onCloseOverlay }
+    >
+      <ul className='OverlayMenu-ul list-unstyled' onClick={ stopClickPropagation }>
+        { props.children }
+      </ul>
+    </nav>
+  );
+};
 
 OverlayMenu.propTypes = {
+  onCloseOverlay: T.func.isRequired,
   fullscreen: T.bool,
 };
 
-const mapDispatchProps = (dispatch) => ({
-  closeOverlayMenu: () => dispatch(overlayActions.closeOverlay()),
+const mapDispatchProps = (dispatch, { onCloseOverlay }) => ({
+  // We need to fire a different action in order to track search bar closes.
+  // This is passed in from outside props.
+  onCloseOverlay: () => onCloseOverlay
+    ? onCloseOverlay() : dispatch(overlayActions.closeOverlay()),
 });
 
 export default connect(null, mapDispatchProps)(OverlayMenu);

--- a/src/app/components/SearchBarOverlay/SearchBar/index.js
+++ b/src/app/components/SearchBarOverlay/SearchBar/index.js
@@ -47,8 +47,9 @@ export default class SearchBar extends React.Component {
         className='SearchBar'
         action={ '/search' }
       >
-        <input type='hidden' name='subreddit' value={ subreddit } />
+        <input key='search-hidden' type='hidden' name='subreddit' value={ subreddit } />
         <input
+          key='search'
           className='SearchBar__input'
           defaultValue={ initialValue }
           name='q'

--- a/src/app/components/SearchBarOverlay/index.js
+++ b/src/app/components/SearchBarOverlay/index.js
@@ -11,17 +11,17 @@ import SearchBar from './SearchBar';
 
 
 export const SearchBarOverlay = (props) => {
-  const { pageData, closeOverlay } = props;
+  const { pageData, closeSearchBar } = props;
   const { queryParams, urlParams } = pageData;
   const { subredditName } = urlParams;
   const { q: initialQuery } = queryParams;
 
   return (
-    <OverlayMenu fullscreen={ true }>
+    <OverlayMenu fullscreen={ true } onCloseOverlay={ closeSearchBar }>
       <div className='SearchBarOverlay__searchArea'>
         <div
           className='SearchBarOverlay__close'
-          onClick={ closeOverlay }
+          onClick={ closeSearchBar }
         >
           <span className='icon icon-nav-arrowback' />
         </div>
@@ -42,6 +42,6 @@ export default connect(
     (pageData) => ({ pageData }),
   ),
   dispatch => ({
-    closeOverlay() { dispatch(overlayActions.closeOverlay()); },
+    closeSearchBar: () => dispatch(overlayActions.closeSearchBar()),
   }),
 )(SearchBarOverlay);

--- a/src/app/components/TopNav/index.jsx
+++ b/src/app/components/TopNav/index.jsx
@@ -42,7 +42,7 @@ export const TopNav = props => {
   const {
     toggleCommunityMenu,
     togglePostSubmit,
-    toggleSearchBar,
+    openSearchBar,
     toggleSettingsMenu,
   } = props;
 
@@ -78,7 +78,7 @@ export const TopNav = props => {
         </div>
         <div
           className='MobileButton TopNav-floaty'
-          onClick={ toggleSearchBar }
+          onClick={ openSearchBar }
         >
           <span className='icon icon-search icon-large' />
         </div>
@@ -117,7 +117,7 @@ const mapDispatchProps = dispatch => ({
       dispatch(platformActions.navigateToUrl(METHODS.GET, '/register'));
     }
   },
-  toggleSearchBar: () => { dispatch(overlayActions.toggleSearchBar()); },
+  openSearchBar: () => { dispatch(overlayActions.openSearchBar()); },
   toggleSettingsMenu: () => { dispatch(overlayActions.toggleSettingsMenu()); },
 });
 
@@ -128,7 +128,7 @@ const mergeProps = (stateProps, dispatchProps) => {
   return {
     ...stateProps,
     ...dispatchProps,
-    togglePostSubmit: () => { togglePostSubmit(isLoggedIn); },
+    togglePostSubmit: () => togglePostSubmit(isLoggedIn),
   };
 };
 


### PR DESCRIPTION
The search event types are:
- `cs.search_executed`
- `cs.search_cancelled`
- `cs.search_opened`

Caveats:
In order to track search bar closing accurately, I needed a specific
"close search" action to fire. What was available to me was a more
generic action for closing the overlays. To get around this, I pass in
the "close search" handler from the SearchBarOverlay into the generic
OverlayMenu component. If the close handler from the outside props
exists then it uses that else it uses the generic one.

:eyeglasses: @nramadas || @uzi 
:eyeglasses: @drunken-economist 