### PR TITLE
remove superagent-retry

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,8 +49,7 @@
     "sha1": "^1.1.1",
     "source-map-support": "^0.4.0",
     "statsd-client": "^0.2.2",
-    "superagent": "1.8.3",
-    "superagent-retry": "git://github.com/ajacksified/superagent-retry#d39d7adbcd021d8ed09df440dba970c91fed9cd4"
+    "superagent": "1.8.3"
   },
   "devDependencies": {
     "babel-core": "^6.8.0",


### PR DESCRIPTION
Rationale:
This no longer seems to be a dependency for 2X specifically. 

Testing:
I tested this by removing it from package.json, removing node_modules, and re-installing everything just to be extra sure it was gone. Then spot checking around the app and making sure no requests were failing.

:eyeglasses: @schwers @nramadas