### PR TITLE
move client check to process.env.ENV

### DIFF
--- a/src/app/actions/search.js
+++ b/src/app/actions/search.js
@@ -42,8 +42,8 @@ export const search = searchParams => async (dispatch, getState) => {
     const apiResponse = await SearchEndpoint.get(apiOptionsFromState(state), searchParams);
     dispatch(received(id, apiResponse));
 
-    const latestState = getState();
-    if (latestState.meta.env === 'CLIENT') {
+    if (process.env.ENV === 'client') {
+      const latestState = getState();
       getEventTracker().track('search_events', 'cs.search_executed', {
         ...getBasePayload(latestState),
         ...buildSubredditData(latestState),


### PR DESCRIPTION
I missed this before I deployed the search events patch but for
consistency with the other client checks in the app, move this to
`process.env.ENV`.

:eyeglasses: @schwers 