### PR TITLE
2 x fixups

### DIFF
--- a/src/app/pages/AppMain.jsx
+++ b/src/app/pages/AppMain.jsx
@@ -42,8 +42,16 @@ const AppMain = props => {
   } = props;
 
   if (statusCode !== 200) {
+    // NOTE: this manually renders TopNav, see below for an explanation
+    // of how TopNav rendering is working in general. It's manually rendered here
+    // instead of in `<ErrorPage />` as it seems easier to refactor out later
     return (
-      <ErrorPage status={ statusCode } url={ url } referrer={ referrer } />
+      <div className='AppMainPage'>
+        <TopNav />
+        <div className='BelowTopNav'>
+          <ErrorPage status={ statusCode } url={ url } referrer={ referrer } />
+        </div>
+      </div>
     );
   }
 

--- a/src/lib/gtm.js
+++ b/src/lib/gtm.js
@@ -1,7 +1,10 @@
 import frames from './frames';
 import { GTM_JAIL_ID } from 'app/constants';
 
-export const getGTMJail = () => document.getElementById(GTM_JAIL_ID);
+export const getGTMJail = () => {
+  const jailEL = document.getElementById(GTM_JAIL_ID);
+  return jailEL && jailEL.contentWindow ? jailEL : null;
+};
 
 export const trigger = (eventName, payload) => {
   const jailEl = getGTMJail();


### PR DESCRIPTION
Just some quick fixups:

1) GTM is proxies its event tracking through an iframe via `postMessage`, seeing some errors in the logs where `gtmIFrame.contentWindow` is undefined. I think this is either because the frame times out or the browser isn't letting us access the iframe. The latter might require more work so this is intended to be a stopgap for now so the logs are cleaner

2) The AppMain refactor made ErrorPages _not_ have a TopNav, second commit adds it back in.

👓  @uzi @phil303 