### PR TITLE
Add VCL rules for whitelisting valid 2X endpoints.

### DIFF
--- a/default.vcl
+++ b/default.vcl
@@ -15,11 +15,10 @@ sub vcl_recv {
   # easy programmatic testing.
   if (req.http.Cookie !~ "(^|;\s*)(mweb-no-redirect=1)(;|$)"
       && (req.http.X-UA-Device ~ "^mobile-" || req.http.X-UA-Device ~ "^tablet-")) {
-    # set req.backend = mweb;
-    error 444;
+    set req.backend = mweb;
   } else {
     # set req.backend = www;
-    error 451;
+    error 400;
   }
 }
 

--- a/test/test_vcl.py
+++ b/test/test_vcl.py
@@ -95,11 +95,57 @@ MOBILE_BROWSER_UA = [
     # Firefox OS phone
     'Mozilla/5.0 (Mobile; rv:26.0) Gecko/26.0 Firefox/26.0',
 ]
+WHITELISTED_ROUTES = [
+    '/',
+    '/comments/',
+    '/login',
+    '/message/',
+    '/r/nba',
+    '/register/',
+    '/report',
+    '/search',
+    '/submit',
+    '/submit_to_community',
+    '/u/wting',
+    '/vote/',
+    '/help',
+    '/w',
+    '/wiki',
+    '/apple-app-site-association',
+    '/csp-report',
+    '/error',
+    '/favicon/64x64.png',
+    '/favicon.ico',
+    '/fonts/',
+    '/health',
+    '/img/',
+    '/loginproxy',
+    '/refreshproxy',
+    '/registerproxy',
+    '/logout',
+    '/ProductionClient.feijofejoiefjio12343.css',
+    '/ProductionClient.feijofejoiefjio12343.js',
+    '/robots.txt',
+    '/routes',
+    '/timings',
+    '/XXX?key=1239034&jijio132jio23',
+    '/u/XXX?key=1239034&jijio132jio23',
+]
+BLACKLISTED_ROUTES = [
+    '/gilded',
+    '/thebutton',
+]
 
 
 def is_mweb(resp):
     # We force www site to its own status code.
     return resp.status_code == 200
+
+
+def is_soft_mweb(resp):
+    # We're testing endpoints that may or may not exist, but really we just
+    # care if we're routing to the www backend instead of actually 200'ing.
+    return resp.status_code != 400
 
 
 def is_www(resp):
@@ -161,6 +207,22 @@ def test_cookie_override(user_agent_string, cookies, validation_fn):
     assert validation_fn(resp) is True
 
 
+@pytest.mark.parametrize(
+    'path, validation_fn',
+    chain(
+        zip(WHITELISTED_ROUTES, cycle([is_soft_mweb])),
+        zip(BLACKLISTED_ROUTES, cycle([is_www])),
+    )
+)
+def test_whitelisted_routes(path, validation_fn):
+    resp = requests.get(
+        'http://%s:%s%s' % (TEST_HOSTNAME, TEST_PORT, path),
+        headers={'User-Agent': MOBILE_BROWSER_UA[0]},
+        cookies=None,
+    )
+    assert validation_fn(resp) is True
+
+
 if __name__ == '__main__':
-    print('Run Python tests via tox.')
+    print('Make sure the docker-compose is up and run Python tests via tox.')
     sys.exit(1)

--- a/test/test_vcl.py
+++ b/test/test_vcl.py
@@ -98,13 +98,12 @@ MOBILE_BROWSER_UA = [
 
 
 def is_mweb(resp):
-    # We don't have a second backend to use, so instead we set a status code
-    # that means mobile UA detected.
-    return resp.status_code == 444
+    # We force www site to its own status code.
+    return resp.status_code == 200
 
 
 def is_www(resp):
-    return resp.status_code == 451
+    return resp.status_code == 400
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
For all non-whitelisted 2X endpoints, we want to fallback to the desktop site.

:eyeglasses: @phil303 @schwers @uzi 

A few caveats:

- I can't test logged in behavior because login proxy isn't working for me
- We don't fall back to desktop for unsupported, deeper subreddit and user paths (e.g. `/u/wting/submitted`)
- This is a dev-only local change.