### PR TITLE
Preserve dissapearing post selftext and previews

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:watch": "npm run test -- -w"
   },
   "dependencies": {
-    "@r/api-client": "~3.26.2",
+    "@r/api-client": "~3.26.3",
     "@r/build": "~0.10.0",
     "@r/flags": "^1.5.0",
     "@r/middleware": "~0.8.1",


### PR DESCRIPTION
This patch solves two frequent instances of self text
and previews dissapearing. The first case is voting
on a selfpost often makes selftext disappear. This seems
like partially a bug from api-client, the version is bumped herein.
The other case is some api endpoints don't return the full media
preview. This mostly seems to impact NSFW posts returned by
the comments page api. You could see this when a NSFW post
had a preview in the listing, but lost it when going to the comments page.

Depends on https://github.com/reddit/node-api-client/pull/170

👓  @nramadas @phil303 