### PR TITLE
Update expiry on desktop redirect cookie to 1 year

### DIFF
--- a/src/app/components/SettingsOverlayMenu/index.jsx
+++ b/src/app/components/SettingsOverlayMenu/index.jsx
@@ -20,6 +20,8 @@ const DESKTOP_TRACKING_PARAMS = {
   utm_name: 'desktop_link',
 };
 
+const DESKTOP_REDIRECT_EXPIRY = 365;
+
 const userIconClassName = 'icon-user-account icon-large blue';
 
 
@@ -169,7 +171,10 @@ const mergeProps = stateProps => ({
   onGoToDesktop: () => {
     // this cookie is telling our CDN, "when you see the www url, do NOT
     // direct user to the mweb experience"
-    cookies.set('mweb-no-redirect', '1', { domain: config.rootReddit });
+    cookies.set('mweb-no-redirect', '1', {
+      domain: config.rootReddit,
+      expires: DESKTOP_REDIRECT_EXPIRY,
+    });
   },
 });
 

--- a/src/app/reducers/replyingComments.test.js
+++ b/src/app/reducers/replyingComments.test.js
@@ -74,7 +74,7 @@ createTest({ reducers: { replyingComments } }, ({ getStore, expect }) => {
 
         store.dispatch(replyActions.replied(id, text));
         replyingComments = store.getState().replyingComments;
-        expect(replyingComments[id]).to.be.undefined;
+        expect(replyingComments[id]).to.equal(undefined);
       });
     });
   });


### PR DESCRIPTION
This was an oversight on the desktop redirect patch. The expiry is
currently just a session cookie. It needs to stick around for 1 year
for parity with the 1X implementation.

I also added a linter fix in `replyingComments.test`.

:eyeglasses: @uzi || @nramadas 