### PR TITLE
Add back the desktop redirect on mdot servers

### DIFF
--- a/src/Server.js
+++ b/src/Server.js
@@ -108,6 +108,13 @@ export function startServer() {
         await next();
         ctx.set('X-Frame-Options', 'SAMEORIGIN');
       },
+      async (ctx, next) => {
+        await next();
+        const redirectToDesktop = !!ctx.cookies.get('mweb-no-redirect');
+        if (redirectToDesktop) {
+          ctx.redirect(config.reddit);
+        }
+      },
     ],
     getServerRouter: router => {
       // middleware


### PR DESCRIPTION
This fixes a regression from 1X. When a user arrives via an m link url
and they have the mweb-no-redirect cookie, the most expected behavior
is to redirect to desktop, their preferred experience. We're currently
not respecting that preference.

Details:
This adds the redirect to `preRouteServerMiddleware`, which is where
we're doing all our global route handling. Just by virtue of the cookie
existing the redirect should happen. If it doesn't then continue on with
the mweb experience.

:eyeglasses: @nramadas || @uzi 
cc @powerlanguage 