### PR TITLE
Remove unused ReportHandler and its endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,8 +49,7 @@
     "sha1": "^1.1.1",
     "source-map-support": "^0.4.0",
     "statsd-client": "^0.2.2",
-    "superagent": "1.8.3",
-    "superagent-retry": "git://github.com/ajacksified/superagent-retry#d39d7adbcd021d8ed09df440dba970c91fed9cd4"
+    "superagent": "1.8.3"
   },
   "devDependencies": {
     "babel-core": "^6.8.0",

--- a/src/app/router/handlers/ReportHandler.js
+++ b/src/app/router/handlers/ReportHandler.js
@@ -1,8 +1,0 @@
-import { BaseHandler, METHODS } from '@r/platform/router';
-import { fetchUserBasedData } from './handlerCommon';
-
-export default class ReportHandler extends BaseHandler {
-  async [METHODS.GET](dispatch) {
-    fetchUserBasedData(dispatch);
-  }
-}

--- a/src/app/router/index.js
+++ b/src/app/router/index.js
@@ -5,7 +5,6 @@ import Login from './handlers/Login';
 import Register from './handlers/Register';
 import OverlayMenuCompactToggleHandler from './handlers/OverlayMenuCompactToggle';
 import OverlayMenuThemeToggleHandler from './handlers/OverlayMenuThemeToggle';
-import ReportHandler from './handlers/ReportHandler';
 import SavedAndHiddenHandler from './handlers/SavedAndHidden';
 import SearchPageHandler from './handlers/SearchPage';
 import SetOver18Handler from './handlers/SetOver18';
@@ -46,7 +45,6 @@ export default [
   ['/message/compose', DirectMessage],
   ['/message/:mailType', Messages],
   ['/message/messages/:threadId', Messages],
-  ['/report', ReportHandler],
   ['/r/:subredditName/submit', PostSubmitHandler],
   ['/submit', PostSubmitHandler],
   ['/submit/to_community', PostSubmitCommunityHandler],


### PR DESCRIPTION
This was a placeholder component from the no-js days. It's going unused
now so remove it from the codebase.

:eyeglasses: @nramadas 