### PR TITLE
Whitelist /user/ for 2X.

### DIFF
--- a/default.vcl
+++ b/default.vcl
@@ -35,6 +35,7 @@ sub vcl_recv {
       || req.url ~ "^/submit/?$"
       || req.url ~ "^/submit_to_community/?$"
       || req.url ~ "^/u/"
+      || req.url ~ "^/user/"
       || req.url ~ "^/vote/"
       || req.url ~ "^/(help|w|wiki)/?"
       # Whitelisted 2X Ajax endpoints


### PR DESCRIPTION
2X currently redirects /u/wting to /user/wting. Since that path isn't
whitelisted it results in showing the desktop version instead.

:eyeglasses: @schwers @prashtx 