### PR TITLE
Fix loidcreated getting reset

### DIFF
--- a/src/lib/apiOptionsFromState.js
+++ b/src/lib/apiOptionsFromState.js
@@ -25,7 +25,7 @@ export const apiOptionsFromState = state => {
     }
 
     if (loidCreated) {
-      cookieHeaders.push(`loidcreated=${loidCreated}}`);
+      cookieHeaders.push(`loidcreated=${loidCreated}`);
     }
 
     return merge(options, {

--- a/src/server/initialState/dispatchInitialUser.js
+++ b/src/server/initialState/dispatchInitialUser.js
@@ -25,7 +25,11 @@ export const dispatchInitialUser = async (ctx, dispatch, getState) => {
     ctx.cookies.set('loid', loid, options);
   }
 
-  if (loidCreated && (loidCreated !== oldLoidCreated)) {
+  // oldLoidCreated is always an ISO string, since that's how it's stored in the
+  // cookie. loidCreated, however, is in ms since that's how we get it back from
+  // the api. so, to compare the two, we need to convert loidCreated to an
+  // ISO string.
+  if (loidCreated && ((new Date(loidCreated)).toISOString() !== oldLoidCreated)) {
     ctx.cookies.set('loidcreated', new Date(loidCreated).toISOString(), options);
   }
 };


### PR DESCRIPTION
Two issues here:

0. We were comparing the `ms` value of the loidcreated we got back from the api to the ISO string version we had stored in the cookie. They obviously would not match, and so we were continuously re-writing the cookie. This in itself isn't that bad if we were constantly re-writing the same value. But we weren't. Because....
0. When sending the `loidcreated` cookie in the request, there was an extra `}` character in there. Which meant that the `loidcreated` we were sending the api was always invalid, so it was getting re-issued. FML.

:eyeglasses: @schwers @phil303 