### PR TITLE
Fix broken reducer test

### DIFF
--- a/src/app/reducers/replying.test.js
+++ b/src/app/reducers/replying.test.js
@@ -24,7 +24,7 @@ createTest({ reducers: { replying } }, ({ getStore, expect }) => {
 
     it('should set the reply state to false when submitted successfully', () => {
       const { store } = getStore({ replying: { [ID]: true } });
-      store.dispatch({ id: '1', type: replyActions.SUCCESS });
+      store.dispatch(replyActions.success(ID, {}));
 
       const { replying } = store.getState();
       expect(replying[ID]).to.be.equal(false);


### PR DESCRIPTION
Bug:
One of the replying tests is currently broken due to my not using the
action creator. When I updated the payload in the action creator, I
forgot to update the payload in the test.

Fix:
Just use the action creator foo.

:eyeglasses: @uzi 
