### PR TITLE
Session refreshing on visibility changes

### DIFF
--- a/src/app/side-effect-components/SessionRefresher.jsx
+++ b/src/app/side-effect-components/SessionRefresher.jsx
@@ -2,41 +2,47 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 
+import onVisibilityChange from 'lib/onVisibilityChange';
 import * as sessionRefreshingActions from 'app/actions/sessionRefreshing';
 
-class _SessionRefresh extends React.Component {
-  constructor(props) {
-    super(props);
+const FIVE_MIN = 5 * 60 * 1000;
 
-    this.timeoutId = 0;
-    this.mounted = false;
-  }
+class SessionRefresh extends React.Component {
+  refreshTimer = null;
 
   componentDidMount() {
-    this.mounted = true;
-    const { session } = this.props;
-    this.awaitSession(session);
+    // on initial render get the most up-to-date refresh token
+    this.refreshSession();
+
+    // when stale tabs come back into focus, attempt refresh as well
+    onVisibilityChange(() => this.refreshSession({ expiredOnly: true }));
   }
 
-  awaitSession(session) {
-    clearTimeout(this.timeoutId);
-    if (session.refreshToken) {
-      const now = new Date();
-      const when = (new Date(session.expires) - now) * 0.9;
-      this.timeoutId = setTimeout(this.props.refreshSession, when);
-    }
+  componentDidUpdate() {
+    // if the component gets a new session, it will update, and the timer needs
+    // to restart
+    this.startRefreshTimer();
   }
 
-  shouldComponentUpdate(nextProps) {
-    if (this.mounted && nextProps.session) {
-      this.awaitSession(nextProps.session);
-    }
+  startRefreshTimer() {
+    clearTimeout(this.refreshTimer);
+    // set up the refresh timer but defend against potentially too low timeouts
+    const when = Math.max((this.props.session.expires - Date.now()) * 0.9, FIVE_MIN);
+    this.refreshTimer = setTimeout(() => this.refreshSession(), when);
+  }
 
-    return false;
+  refreshSession({ expiredOnly=false }={}) {
+    if (this.props.session.refreshToken) {
+      if (expiredOnly && this.props.session.isValid) {
+        return;
+      }
+      this.props.refreshSession();
+    }
   }
 
   render() { return null; }
 }
+
 
 const mapStateToProps = createSelector(
   state => state.session,
@@ -47,4 +53,4 @@ const mapDispatchToProps = (dispatch) => ({
   refreshSession: () => dispatch(sessionRefreshingActions.refresh()),
 });
 
-export default connect(mapStateToProps, mapDispatchToProps)(_SessionRefresh);
+export default connect(mapStateToProps, mapDispatchToProps)(SessionRefresh);

--- a/src/lib/onVisibilityChange.js
+++ b/src/lib/onVisibilityChange.js
@@ -1,0 +1,22 @@
+import findKey from 'lodash/findKey';
+
+const NOOP = () => {};
+
+const VISIBILITY_KEYS = {
+  hidden: 'visibilitychange',
+  webkitHidden: 'webkitvisibilitychange',
+  mozHidden: 'mozvisibilitychange',
+  msHidden: 'msvisibilitychange',
+};
+
+export default (onVisible=NOOP, onHidden=NOOP) => {
+  const eventKey = findKey(VISIBILITY_KEYS, (_, k) => document[k] !== undefined);
+
+  document.addEventListener(VISIBILITY_KEYS[eventKey], () => {
+    if (document[eventKey]) {
+      onHidden();
+    } else {
+      onVisible();
+    }
+  });
+};


### PR DESCRIPTION
Bug:
When a user has a reddit tab open and comes back to it some time later,
the session has expired. Any logged in action that user tries kicks them
to the register screen because our js doesn't know to try to update the
session. A user hitting refresh fixes that since the cookies are still
valid.

Fix:
This adds a visibility check that fires every time a tab is focused,
leveraging the [visibility api](https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API), which is [well supported](http://caniuse.com/#search=visibilitychange) on mobile.
If the user had a refresh token and the token was expired, the
app will fetch a new one upon being focused again. This is a nice all
around solution since it avoids having to specially handle every logged
in action.

Caveats:
I've cleaned up the session refresh code a bit, which was handling token
refreshing for new and very long sessions. One thing I added was a
minimum to the refresh timer just for fear of ddos'ing ourselves. This
is set at 5 minutes.

Testing:
I tested this on my iPhone by dropping the expiration down to 10
seconds, opening the app in one tab, going to another, then coming back
to the first after 10 seconds. Then hitting upvote. I did a similar test
with the open app and the lock screen. Both worked. I did this in both
Chrome and Safari. This still needs testing on android.

Todo:
- [x] Test on android

:eyeglasses: @schwers || @nramadas 
