### PR TITLE
RFC: Remove month abbreviation

### DIFF
--- a/src/app/reducers/replying.test.js
+++ b/src/app/reducers/replying.test.js
@@ -24,7 +24,7 @@ createTest({ reducers: { replying } }, ({ getStore, expect }) => {
 
     it('should set the reply state to false when submitted successfully', () => {
       const { store } = getStore({ replying: { [ID]: true } });
-      store.dispatch({ id: '1', type: replyActions.SUCCESS });
+      store.dispatch(replyActions.success(ID, {}));
 
       const { replying } = store.getState();
       expect(replying[ID]).to.be.equal(false);

--- a/src/lib/formatDifference.js
+++ b/src/lib/formatDifference.js
@@ -15,7 +15,6 @@ const SECONDS = 1000;
 const MINUTES = 60 * SECONDS;
 const HOURS = 60 * MINUTES;
 const DAYS = 24 * HOURS;
-const MONTHS = 30 * DAYS; // ignoring odd 31 / 28 day months
 const YEARS = 365 * DAYS; // ignoring leap years ...
 
 export const differenceFromNow = unixTime => {
@@ -27,8 +26,7 @@ export const differenceFromNow = unixTime => {
 
   return {
     years: Math.floor(diff / YEARS),
-    months: Math.floor(diff % YEARS / MONTHS),
-    days: Math.floor(diff % MONTHS / DAYS),
+    days: Math.floor(diff % YEARS / DAYS),
     hours: Math.floor((diff % DAYS) / HOURS),
     minutes: Math.floor((diff % HOURS) / MINUTES),
   };
@@ -38,14 +36,10 @@ export const differenceFromNow = unixTime => {
 // that are returned from `differenceFromNow`
 export const formatPartsFromNow = (unixTime, format) => {
   const parts = [];
-  const { years, months, days, hours, minutes } = differenceFromNow(unixTime);
+  const { years, days, hours, minutes } = differenceFromNow(unixTime);
 
   if (years !== 0 && format.years) {
     parts.push(`${years}${format.years}`);
-  }
-
-  if (months !== 0 && format.months) {
-    parts.push(`${months}${format.months}`);
   }
 
   if (days !== 0 && format.days) {
@@ -71,7 +65,6 @@ export const short = unixTime => {
   // use short names for the parts, and only use the first part
   return formatPartsFromNow(unixTime, {
     years: 'y',
-    months: 'm',
     days: 'd',
     hours: 'h',
     minutes: 'm',
@@ -85,7 +78,6 @@ export const short = unixTime => {
 export const long = unixTime => {
   return formatPartsFromNow(unixTime, {
     years: ' years',
-    months: ' months',
     days: ' days',
   }).join(', ');
 };


### PR DESCRIPTION
As a possible solution to the ambiguous "m" problem, this patch removes
the month abbreviation entirely. I chose this path for a few reasons.
1. The "mo" abbreviation looks weird to me (could just be me on this). 
   Ex text would be:
   - `r/foobarsub ● 5mo ● u/thephilthe`
2. The math for calculating the month was an approximation based on 30
   day months, which seems too inaccurate.
3. Finally, native apps don't show months either and in my opinion, it
   looks ok.

General notes:
I'm not entirely happy with this quick solution but I think it's better
than what we have. Looking around at how other apps handle this, most
seem to fallback to the full date text after a day or so, giving more
time info as more time goes by. Taking our example above, depending on
the "time ago" date, the text might look something like:
- `r/foobarsub ● 5 mins ● u/thephilthe`
- `r/foobarsub ● 8 hrs ● u/thephilthe`
- `r/foobarsub ● 1 day ● u/thephilthe`
- `r/foobarsub ● Aug 18 ● u/thephilthe`
- `r/foobarsub ● Dec 20, 2015 ● u/thephilthe`

I find this to be far more informative than our ambiguous "2 years ago"
format. Auditing the places where we show this type of info, I think
this would work everywhere but obviously I'd like to get a designer's
POV on it.

What this patch looks like:
**Comments**
<img width="390" alt="screen shot 2016-10-31 at 10 01 36 am" src="https://cloud.githubusercontent.com/assets/787203/19863328/1a158072-9f51-11e6-9ca8-632a1c61821b.png">

**Listing**
<img width="396" alt="screen shot 2016-10-31 at 10 01 02 am" src="https://cloud.githubusercontent.com/assets/787203/19863351/2aa4234e-9f51-11e6-9a23-fde87a7eab2f.png">


:eyeglasses: @schwers 
