### PR TITLE
Add amphtml link tags for self posts

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -63,6 +63,8 @@ const config = () => ({
   reddit,
   rootReddit,
 
+  amp: process.env.AMP,
+
   googleTagManagerId: process.env.GOOGLE_TAG_MANAGER_ID,
 
   adblockTestClassName: process.env.ADBLOCK_TEST_CLASSNAME || 'ad adsense-ad googad gemini-ad openx',

--- a/src/lib/createAmpHtmlLinkFromState.js
+++ b/src/lib/createAmpHtmlLinkFromState.js
@@ -1,0 +1,41 @@
+import { matchRoute } from '@r/platform/navigationMiddleware';
+
+import config from 'config';
+
+export const ampLink = (currentPage, state) => {
+  const { postId } = currentPage.urlParams;
+  const post = state.posts[`t3_${postId}`];
+  if (!post || !post.cleanPermalink) {
+    // We were unable to get the info from the server, which probably means
+    // the subreddit was banned or the like.
+    return null;
+  }
+
+  if (!post.isSelf) {
+    // We only support AMP'd self posts.
+    return null;
+  }
+
+  return post.cleanPermalink;
+};
+
+const AMP_ROUTES = [
+  // comment pages
+  ['/r/:subredditName/comments/:postId/comment/:commentId', ampLink],
+  ['/r/:subredditName/comments/:postId/:postTitle/:commentId', ampLink],
+  ['/r/:subredditName/comments/:postId/:postTitle?', ampLink],
+  ['/comments/:postId/:postTitle/:commentId', ampLink],
+  ['/comments/:postId/:postTitle?', ampLink],
+  ['*', () => null],
+];
+
+export default state => {
+  if (!config.amp) {
+    return null;
+  }
+
+  const currentPage = state.platform.currentPage;
+  const { handler } = matchRoute(currentPage.url, AMP_ROUTES);
+  const path = handler(currentPage, state);
+  return path ? `${config.amp}${path}` : null;
+};

--- a/src/server/templates/main.jsx
+++ b/src/server/templates/main.jsx
@@ -7,6 +7,7 @@ import manifest from '../../../build/manifest';
 import config from 'config';
 import { themeClass } from './themeClass';
 import createCanonicalLinkFromState from 'lib/createCanonicalLinkFromState';
+import createAmpHtmlLinkFromState from 'lib/createAmpHtmlLinkFromState';
 import safeStringify from 'lib/safeStringify';
 
 const env = process.env.NODE_ENV || 'production';
@@ -20,6 +21,10 @@ export default function(data, store) {
 
   const canonicalLink = !state.platform.shell
     ? createCanonicalLinkFromState(state)
+    : null;
+
+  const ampLink = !state.platform.shell
+    ? createAmpHtmlLinkFromState(state)
     : null;
 
   return ReactServerDom.renderToStaticMarkup(
@@ -37,6 +42,7 @@ export default function(data, store) {
         <link href={ `${assetPath}/favicon/152x152.png` } rel="apple-touch-icon" sizes="152x152" />
         <link href={ `${assetPath}/favicon/180x180.png` } rel="apple-touch-icon" sizes="180x180" />
         { canonicalLink ? <link rel='canonical' href={ canonicalLink }/> : null }
+        { ampLink ? <link rel='amphtml' href={ ampLink }/> : null }
       </head>
       <body className={ themeClass(data.theme) }>
         <div


### PR DESCRIPTION
For self post comments pages, we add a link tag with `rel="amphtml"` to
indicate to crawlers where they can find the AMP version of the page.
Because this is a crawler-targeted feature, we only need to do this for
compelte server renders.