### PR TITLE
Reduce number of actions logged.

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -70,7 +70,7 @@ const config = () => ({
   localStorageAvailable: localStorageAvailable(),
 
   statsURL: process.env.STATS_URL || 'https://stats.redditmedia.com/',
-  reduxActionLogSize: process.env.REDUX_ACTION_LOG_SIZE || 50,
+  reduxActionLogSize: process.env.REDUX_ACTION_LOG_SIZE || 10,
   mediaDomain: process.env.MEDIA_DOMAIN || 'www.redditmedia.com',
   adsPath: process.env.ADS_PATH || '/api/request_promo.json',
   manifest: {},


### PR DESCRIPTION
We currently default to 50 action steps logged. Since this exceeds our limits
per log line (4096 bytes), it truncates the log lines resulting in unparseable
JSON. As a result we can't programmatically analyze our error logs.

:eyeglasses: @schwers @uzi 