### PR TITLE
Correct types on the error toaster

### DIFF
--- a/src/app/actions/vote.js
+++ b/src/app/actions/vote.js
@@ -13,11 +13,11 @@ export const FAILURE = 'VOTE__FAILURE';
 
 export const pending = (id, model) => ({ type: PENDING, id, model });
 export const success = (id, model) => ({ type: SUCCESS, id, model });
-export const failure = direction => {
+export const failure = (direction, type) => {
   const voteWord = direction === 1 ? 'upvote' : 'downvote';
   return {
     type: FAILURE,
-    message: `Failed to ${voteWord} the comment.`,
+    message: `Failed to ${voteWord} the ${type}.`,
   };
 };
 
@@ -39,7 +39,7 @@ export const vote = (id, direction) => async (dispatch, getState) => {
     dispatch(success(id, model));
 
   } catch (e) {
-    dispatch(failure(direction));
+    dispatch(failure(direction, type));
     if (!(e instanceof ResponseError)) {
       throw e;
     }


### PR DESCRIPTION
Bug:
This copy was hardcoded to just 'comment' but the action applies to both
comments and posts. When something went wrong on a post upvote we'd show
"failed to upvote the comment", which makes no sense.

Fix:
Use the `type` (which is either 'post' or 'comment') in the copy.

:eyeglasses: @uzi 