### PR TITLE
Fix message thread replying

### DIFF
--- a/src/app/actions/mail.js
+++ b/src/app/actions/mail.js
@@ -53,17 +53,17 @@ export const postMessage = data => async (dispatch, getState) => {
     return;
   }
 
-  if (message && message.parentId) {
-    // This is the case of replying to a message thread -- we get the
-    // model back from the new message.
+  if (message && message.firstMessageName) {
+    // This is the case of replying to a message thread -- we get the model
+    // back from the new message, and we add it to the head (firstMessageName).
     // Note: if it's null, then it was a new message thread
     const { messages } = getState();
-    const parent = messages[message.parentId];
+    const parent = messages[message.firstMessageName];
     const newParent = parent.set('replies', [...parent.replies, message.name]);
     const data = {
       messages: {
         [message.name]: message,
-        [message.parentId]: newParent,
+        [message.firstMessageName]: newParent,
       },
     };
     dispatch(addReply(data));


### PR DESCRIPTION
It turns out that we can only reply to a message
thread if the other side has sent us a message.
For example, if there's one message in the thread
and the current user sent it, they can't send
further messages until the other side sends a reply.

Take a look at all of the messages in a thread, find
the latest response from the other side and use that
as the message id we respond to. Unfortunately the
API appears to succeed if we reply to our own message,
so this circumvents the issue.

We no longer show the replyToggle if the user can't
yet reply to a thread.

👓 @phil303 @schwers @andytuba 

And thanks @andytuba for helping diagnose this.