### PR TITLE
Handle when stack is undefined.

### DIFF
--- a/src/lib/errorLog.js
+++ b/src/lib/errorLog.js
@@ -179,7 +179,7 @@ const buildLogJSON = details => {
     // We have a max limit of 4096 bytes per log line. To prevent log lines
     // from overflowing and becoming invalid JSON, we're truncating the error
     // stack or rejection response to the most relevant parts.
-    stack: stack.substring(0, 2048),
+    stack: stack && stack.substring(0, 2048),
     possibleDuplicate,
   };
 };

--- a/src/lib/errorLog.js
+++ b/src/lib/errorLog.js
@@ -176,7 +176,10 @@ const buildLogJSON = details => {
     url,
     line,
     column,
-    stack,
+    // We have a max limit of 4096 bytes per log line. To prevent log lines
+    // from overflowing and becoming invalid JSON, we're truncating the error
+    // stack or rejection response to the most relevant parts.
+    stack: stack.substring(0, 2048),
     possibleDuplicate,
   };
 };


### PR DESCRIPTION
I reverted the previous push because sometimes `stack` was undefined and caused these sorts of errors:

```json
{
  "column": "12",
  "env": "SERVER",
  "isAPIFailure": false,
  "line": "182",
  "message": "Error: Cannot read property 'substring' of undefined",
  "requestUrl": "/loginproxy",
  "stack": "TypeError: Cannot read property 'substring' of undefined\n    at g (/opt/reddit-mobile/bin/webpack:/src/lib/errorLog.js:182:12)\n    at o (/opt/reddit-mobile/bin/webpack:/src/lib/errorLog.js:33:19)\n    at w (/opt/reddit-mobile/bin/webpack:/src/lib/errorLog.js:202:3)\n    at Object.<anonymous> (/opt/reddit-mobile/bin/webpack:/src/server/session/loginproxy.js:24:9)\n    at tryCatch (/opt/reddit-mobile-deps/regenerator-runtime/runtime.js:62:40)\n    at GeneratorFunctionPrototype.invoke [as _invoke] (/opt/reddit-mobile-deps/regenerator-runtime/runtime.js:336:22)\n    at GeneratorFunctionPrototype.prototype.(anonymous function) [as throw] (/opt/reddit-mobile-deps/regenerator-runtime/runtime.js:95:21)\n    at r (/opt/reddit-mobile/bin/webpack:/ProductionServer.js:28673:187)\n    at /opt/reddit-mobile/bin/webpack:/ProductionServer.js:28673:402\n    at run (/opt/reddit-mobile-deps/core-js/modules/es6.promise.js:87:22)",
  "url": "/opt/reddit-mobile/bin/webpack:/src/lib/errorLog.js",
  "userAgent": "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0; .NET CLR 1.1.4322; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729)"
}
```

:eyeglasses: @schwers @uzi 