### PR TITLE
Enable showing the link to message compose

### DIFF
--- a/src/app/components/Messages/Header.jsx
+++ b/src/app/components/Messages/Header.jsx
@@ -1,16 +1,15 @@
 import './Header.less';
 import React from 'react';
-// import { Anchor } from '@r/platform/components';
+import { Anchor } from '@r/platform/components';
 
 export default function MessagesHeader() {
   return (
     <div className='MessageHeader'>
       <div className='MessageHeader__title'>Inbox</div>
-      {/*Don't allow access to messager composition until that feature is ready
       <Anchor
         className='MessageHeader__compose icon icon-message'
         href='/message/compose'
-      />*/}
+      />
     </div>
   );
 }


### PR DESCRIPTION
This was previously working but hidden due to a
captcha-related issue. This should now be working,
so we can unhide the link.

👓  @phil303 @schwers 