### PR TITLE
Inbox - fix messed up css

### DIFF
--- a/src/app/components/Messages/styles.less
+++ b/src/app/components/Messages/styles.less
@@ -2,8 +2,6 @@
 @import (reference) '~app/less/themes/themeify';
 
 .Messages {
-  padding-top: 48px;
-
   &__header,
   &__nav,
   &__divider {


### PR DESCRIPTION
Current:
<img width="421" alt="screen shot 2016-11-02 at 10 30 16 pm" src="https://cloud.githubusercontent.com/assets/787203/19956620/fba6d72e-a14b-11e6-9d60-b7a6c679c172.png">

This was caused by [this patch](https://github.com/reddit/reddit-mobile/commit/da852fb052482eb6a9a3cd387d8b1b3a1b3b9de1#diff-ac84b049f751bf1bfcb2fe2e60c27edeR113). We forgot to remove the pre-existing padding on the message component.

With fix:
<img width="438" alt="screen shot 2016-11-02 at 10 33 01 pm" src="https://cloud.githubusercontent.com/assets/787203/19956663/66ac1af2-a14c-11e6-84fc-47d87f719351.png">


:eyeglasses: @schwers 