### PR TITLE
RFC - Posts and comments - different date formats

### DIFF
--- a/src/app/components/Comment/CommentHeader/index.jsx
+++ b/src/app/components/Comment/CommentHeader/index.jsx
@@ -3,7 +3,7 @@ import './styles.less';
 import React from 'react';
 import fill from 'lodash/fill';
 
-import { short } from 'lib/formatDifference';
+import formatElapsedTime from 'lib/formatElapsedTime';
 
 const T = React.PropTypes;
 const separator = <div className='CommentHeader__separator'> • </div>;
@@ -79,7 +79,7 @@ function renderTimestamp(created, highlight) {
   let cls = 'CommentHeader__timestamp';
   if (highlight) { cls += ' m-highlight'; }
 
-  return <div className={ cls }>{ short(created) }</div>;
+  return <div className={ cls }>{ formatElapsedTime(created) }</div>;
 }
 
 function renderGold(gildCount) {

--- a/src/app/components/MessageThread/Message.jsx
+++ b/src/app/components/MessageThread/Message.jsx
@@ -2,7 +2,7 @@ import './Message.less';
 import React from 'react';
 import { Anchor } from '@r/platform/components';
 
-import { short } from 'lib/formatDifference';
+import formatElapsedTime from 'lib/formatElapsedTime';
 import RedditLinkHijacker from 'app/components/RedditLinkHijacker';
 
 const T = React.PropTypes;
@@ -22,7 +22,7 @@ export default function MessageThreadMessage(props) {
           { message.author }
         </Anchor>
         { SEPARATOR }
-        { short(message.createdUTC) }
+        { formatElapsedTime(message.createdUTC) }
       </div>
       <RedditLinkHijacker>
         <div

--- a/src/app/components/Messages/Comment.jsx
+++ b/src/app/components/Messages/Comment.jsx
@@ -2,7 +2,7 @@ import './Comment.less';
 import React from 'react';
 import { Anchor } from '@r/platform/components';
 
-import { short } from 'lib/formatDifference';
+import formatElapsedTime from 'lib/formatElapsedTime';
 import RedditLinkHijacker from 'app/components/RedditLinkHijacker';
 
 const T = React.PropTypes;
@@ -35,7 +35,7 @@ export default function MessagesComment(props) {
           { comment.subreddit }
         </Anchor>
         { SEPARATOR }
-        { short(comment.createdUTC) }
+        { formatElapsedTime(comment.createdUTC) }
       </div>
       <RedditLinkHijacker>
         <div

--- a/src/app/components/Messages/Message.jsx
+++ b/src/app/components/Messages/Message.jsx
@@ -2,7 +2,7 @@ import './Message.less';
 import React from 'react';
 import { Anchor } from '@r/platform/components';
 
-import { short } from 'lib/formatDifference';
+import formatElapsedTime from 'lib/formatElapsedTime';
 import RedditLinkHijacker from 'app/components/RedditLinkHijacker';
 
 const T = React.PropTypes;
@@ -31,7 +31,7 @@ export default function MessagesMessage(props) {
             { message.author }
           </Anchor>
           { SEPARATOR }
-          { short(message.createdUTC) }
+          { formatElapsedTime(message.createdUTC) }
         </div>
         <Anchor
           className='MessagesMessage__link icon icon-nav-arrowforward'

--- a/src/app/components/Post/PostHeader/index.jsx
+++ b/src/app/components/Post/PostHeader/index.jsx
@@ -2,7 +2,7 @@ import './styles.less';
 import React from 'react';
 import { Anchor } from '@r/platform/components';
 
-import { short } from 'lib/formatDifference';
+import formatElapsedTime from 'lib/formatElapsedTime';
 import mobilify from 'lib/mobilify';
 
 import { models } from '@r/api-client';
@@ -131,16 +131,14 @@ function renderAuthorAndTimeStamp(post, single, hideWhen) {
       <span>
         { authorLink }
         { SEPERATOR }
-        { short(createdUTC) }
+        { formatElapsedTime(createdUTC) }
       </span>
    );
   }
 
   return (
     <span>
-      { short(createdUTC) }
-      { SEPERATOR }
-      { authorLink }
+      { formatElapsedTime(createdUTC) }
     </span>
  );
 }

--- a/src/app/components/UserProfileSummary/index.jsx
+++ b/src/app/components/UserProfileSummary/index.jsx
@@ -5,7 +5,8 @@ import { models } from '@r/api-client';
 import { Anchor } from '@r/platform/components';
 
 import { formatNumber } from 'lib/formatNumber';
-import { short, long } from 'lib/formatDifference';
+import { long } from 'lib/formatDifference';
+import formatElapsedTime from 'lib/formatElapsedTime';
 
 const T = React.PropTypes;
 
@@ -23,7 +24,7 @@ export const UserProfileSummary = props => {
           <UserProfileBadgeIcon iconName='karma' color='orangered' />
         </UserProfileBadge>
         <UserProfileBadge
-          text={ short(user.createdUTC) }
+          text={ formatElapsedTime(user.createdUTC) }
           subtext='REDDIT AGE'
           half={ true }
         >

--- a/src/lib/formatDifference.js
+++ b/src/lib/formatDifference.js
@@ -57,20 +57,6 @@ export const formatPartsFromNow = (unixTime, format) => {
   return parts;
 };
 
-// return a shorthand string describing the differnece between now and then given unix timesamp
-// shorthand means that instead of "year", we'd return "y", and instead of 'day', we'd return 'd'.
-// we also want it to be concise so we'll only use the first unit of time (see above) that describes
-// the difference. (.e.g. 2months, 3weeks, and 1day ago will be formatted as '2m')
-export const short = unixTime => {
-  // use short names for the parts, and only use the first part
-  return formatPartsFromNow(unixTime, {
-    years: 'y',
-    days: 'd',
-    hours: 'h',
-    minutes: 'm',
-  }).slice(0, 1).join(', ');
-};
-
 // return a string describing the difference between now and the given unix timestamp.
 // `long` is in contrast to `short` that's above, it will return the full name for units of time.
 // however it only cares about 'years', 'months', and 'days'. So a date thats:

--- a/src/lib/formatElapsedTime.js
+++ b/src/lib/formatElapsedTime.js
@@ -1,0 +1,49 @@
+const MONTHS = [
+  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+];
+
+const START_YEAR = 1900;
+const MIN_IN_MS = 60 * 1000;
+const HOUR_IN_MS = MIN_IN_MS * 60;
+const DAY_IN_MS = HOUR_IN_MS * 24;
+const WEEK_IN_MS = DAY_IN_MS * 7;
+
+function pluralizeUnit(time, unit) {
+  return `${time} ${unit}${ time > 1 ? 's' : ''}`;
+}
+
+/**
+ * Show the "time ago" format for 7 days with increasing increments, minutes
+ * to hours to days, then after that show the actual date. If it's a different
+ * calendar year than the current, append the year as well.
+ *
+ * @param {Number} unixSeconds
+ *        Seconds since epoch
+ * @returns {String}
+ *        Formatted representation of time elapsed since the passed-in time
+*/
+export default function formatElapsedTime(unixSeconds) {
+  const now = new Date();
+  const date = new Date(unixSeconds * 1000);
+  const elapsedMs = now - date;
+
+  if (elapsedMs > WEEK_IN_MS) {
+    return date.getYear() === now.getYear()
+      ? `${MONTHS[date.getMonth()]} ${date.getDate()}`
+      : `${MONTHS[date.getMonth()]} ${date.getDate()}, ${START_YEAR + date.getYear()}`;
+  }
+
+  const days = Math.floor(elapsedMs / DAY_IN_MS);
+  if (days >= 1) {
+    return pluralizeUnit(days, 'day');
+  }
+
+  const hours = Math.floor(elapsedMs / HOUR_IN_MS);
+  if (hours >= 1) {
+    return pluralizeUnit(hours, 'hr');
+  }
+
+  const mins = Math.floor(elapsedMs / MIN_IN_MS);
+  return pluralizeUnit(mins, 'min');
+}


### PR DESCRIPTION
For 7 days we show the "time ago" format with increasing increments,
minutes to hours to days, then after that we show the actual date.

How this looks:
- `r/foobarsub ● 5 mins ● u/thephilthe`
- `r/foobarsub ● 8 hrs ● u/thephilthe`
- `r/foobarsub ● 1 day ● u/thephilthe`
- `r/foobarsub ● 7 days ● u/thephilthe`
- `r/foobarsub ● Aug 18 ● u/thephilthe`
- `r/foobarsub ● Dec 20, 2015 ● u/thephilthe`

On posts on listings, this can get a little cramped (it's already pretty
cramped), so I took a page from the iOS app and removed the user. The
user will show up on the comments page version of the Post.

Various examples of what this looks like:

**Posts hours old (notice no user name)**
<img width="392" alt="screen shot 2016-11-03 at 7 55 32 am" src="https://cloud.githubusercontent.com/assets/787203/19972678/1602f36a-a1a0-11e6-9403-7973cc0d070b.png">

**Comments hours old**
<img width="408" alt="screen shot 2016-11-03 at 7 56 39 am" src="https://cloud.githubusercontent.com/assets/787203/19972705/30157cd2-a1a0-11e6-882c-38ae1cfb1ebf.png">

**Comments days old**
<img width="397" alt="screen shot 2016-11-03 at 8 16 13 am" src="https://cloud.githubusercontent.com/assets/787203/19972723/39f72908-a1a0-11e6-867b-8f5eff1c45ad.png">

**Mixed format (comments less than and greater than a week old)**
<img width="432" alt="screen shot 2016-11-03 at 8 31 07 am" src="https://cloud.githubusercontent.com/assets/787203/19972761/52e82ac0-a1a0-11e6-82d4-2c40b202efed.png">

**Deeply nested comments (previous calendar year - notice the wrapped header)**
<img width="396" alt="screen shot 2016-11-03 at 8 38 21 am" src="https://cloud.githubusercontent.com/assets/787203/19973054/4d6d1208-a1a1-11e6-882e-aa7580fb8e44.png">