### PR TITLE
Unified urls - Match subreddit sorts to desktop

### DIFF
--- a/src/app/components/SortAndTimeSelector/index.jsx
+++ b/src/app/components/SortAndTimeSelector/index.jsx
@@ -87,37 +87,23 @@ const mapDispatchToProps = dispatch => ({
 });
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => {
-  const { currentPage } = stateProps;
-  const { queryParams } = currentPage;
-  const { sort = SORTS.HOT } = queryParams;
+  const { currentPage: { url, urlParams, queryParams } } = stateProps;
+
+  const sort = urlParams.sort || queryParams.sort || SORTS.HOT;
   const time = ownProps.time || listingTime(queryParams, sort);
   const { navigateToUrl } = dispatchProps;
 
-  const onSortChange = sort => {
-    navigateToUrl(currentPage.url, {
-      queryParams: {
-        ...queryParams,
-        sort,
-      },
-    });
-  };
-
-  const onTimeChange = time => {
-    navigateToUrl(currentPage.url, {
-      queryParams: {
-        ...queryParams,
-        t: time,
-      },
-    });
-  };
-
   return {
-    ...stateProps,
-    ...ownProps,
-    onSortChange,
-    onTimeChange,
-    sort,
     time,
+    sort,
+    ...ownProps,
+    ...stateProps,
+    onTimeChange: time => navigateToUrl(url, { queryParams: { ...queryParams, t: time } }),
+    onSortChange: sort => {
+      // add the sort to the url by taking just the '/r/:subredditName' part
+      const newUrl = [ ...url.split('/').slice(0, 3), sort ].join('/');
+      navigateToUrl(newUrl);
+    },
   };
 };
 

--- a/src/app/pages/AppMain.jsx
+++ b/src/app/pages/AppMain.jsx
@@ -5,6 +5,7 @@ import { createSelector } from 'reselect';
 import { UrlSwitch, Page, Case } from '@r/platform/url';
 
 import CommentsPage from './Comments';
+import { SUPPORTED_SORTS } from 'app/sortValues';
 import { PostsFromSubredditPage } from './PostsFromSubreddit';
 import { SavedAndHiddenPage } from './SavedAndHidden';
 import { SearchPage } from './SearchPage';
@@ -85,6 +86,10 @@ const AppMain = props => {
                   />
                   <Page
                     url='/r/:subredditName'
+                    component={ PostsFromSubredditPage }
+                  />
+                  <Page
+                    url={ `/r/:subredditName/:sort(${SUPPORTED_SORTS.join('|')})` }
                     component={ PostsFromSubredditPage }
                   />
                   <Page

--- a/src/app/router/handlers/PostsFromSubreddit.js
+++ b/src/app/router/handlers/PostsFromSubreddit.js
@@ -13,11 +13,15 @@ import { convertId, trackPageEvents } from 'lib/eventUtils';
 
 import { setTitle } from 'app/actions/pageMetadata';
 
+// NOTE: we're deprecating the query param `sort` in favor of its url param.
+// You'll find a couple places in this file that fallback to the query param
+// since those are still in the wild.
+
 export default class PostsFromSubreddit extends BaseHandler {
 
   static pageParamsToSubredditPostsParams({ urlParams, queryParams}) {
-    const { multi, multiUser } = urlParams;
-    const { sort, after, before } = queryParams;
+    const { multi, multiUser, sort } = urlParams;
+    const { after, before, sort: queryParamSort } = queryParams;
     let { subredditName } = urlParams;
     subredditName = subredditName ? subredditName.toLowerCase() : null;
 
@@ -25,7 +29,7 @@ export default class PostsFromSubreddit extends BaseHandler {
       subredditName,
       multi,
       multiUser,
-      sort,
+      sort: sort || queryParamSort,
       t: listingTime(queryParams, sort),
       after,
       before,
@@ -73,10 +77,12 @@ export default class PostsFromSubreddit extends BaseHandler {
 const LINK_LIMIT = 25;
 
 function buildSortOrderData(state) {
-  const { currentPage: { queryParams: { sort, time, before, after } } } = state.platform;
+  const { currentPage: { queryParams, urlParams } } = state.platform;
+  const { time, before, after } = queryParams;
+  const sort = urlParams.sort || queryParams.sort || 'hot';
 
   return {
-    target_sort: sort || 'hot',
+    target_sort: sort,
     target_count: LINK_LIMIT,
     target_filter_time: sort === 'top' ? (time || 'all') : null,
     target_before: before ? before : null,

--- a/src/app/router/index.js
+++ b/src/app/router/index.js
@@ -1,3 +1,4 @@
+import { SUPPORTED_SORTS } from 'app/sortValues';
 import CommentsPageHandler from './handlers/CommentsPage';
 import CommunityGotoActionHandler from './handlers/CommunityGotoAction';
 import PostsFromSubredditHandler from './handlers/PostsFromSubreddit';
@@ -20,6 +21,8 @@ import { PostSubmitHandler, PostSubmitCommunityHandler } from './handlers/PostSu
 import UserRerouteHandler from './handlers/UserReroute';
 import Status404PageHandler from './handlers/Status404Page';
 
+const SORTS = SUPPORTED_SORTS.join('|');
+
 /* eslint-disable max-len */
 export default [
   ['/', PostsFromSubredditHandler, { name: 'index' }],
@@ -31,6 +34,7 @@ export default [
   ['/search', SearchPageHandler],
   ['/r/:subredditName/search', SearchPageHandler],
   ['/r/:subredditName/about', SubredditAboutPageHandler],
+  [`/r/:subredditName/:sort(${SORTS})`, PostsFromSubredditHandler, { name: 'listing' }],
   ['/r/:subredditName/(w|wiki)/:path(.*)?', WikiPageHandler],
   ['/(help|w|wiki)/:path(.*)?', WikiPageHandler],
   ['/comments/:postId/:postTitle/:commentId', CommentsPageHandler, { name: 'comments' }],

--- a/src/app/sortValues.js
+++ b/src/app/sortValues.js
@@ -18,6 +18,13 @@ export const SORTS = {
   PAST_HOUR: 'hour',
 };
 
+export const SUPPORTED_SORTS = [
+  SORTS.HOT,
+  SORTS.TOP,
+  SORTS.NEW,
+  SORTS.CONTROVERSIAL,
+];
+
 export const SORT_VALUES_MAP = {
   [SORTS.CONFIDENCE]: {
     text: 'Best',


### PR DESCRIPTION
Bug:
Currently 2X doesn't support urls that have the format of `/r/nba/top`,
where the subreddit sort is part of the path. As part of the unified url
push, we need to support this.

Fix:
Currently we support the sort as a query parameter but we'd like to
deprecate this over time. So we're going to first look for the sort in
the url then fallback to the query param then fallback to 'hot'.

There's a few other sorts that 2X doesn't support yet at all, such as
"gilded" or "ads". Per discussion with William, we're going to 404 these
(this is the status quo).

Demo:
![subreddit sorts](https://cloud.githubusercontent.com/assets/787203/19989476/0b6cb910-a1e4-11e6-9961-c1146071696c.gif)


:eyeglasses: @nramadas @wting @schwers 