### PR TITLE
Add back in RelevantContent

### DIFF
--- a/src/app/components/RelevantContent/index.jsx
+++ b/src/app/components/RelevantContent/index.jsx
@@ -177,6 +177,8 @@ function RelevantContent(props) {
       />
     );
   }
+
+  return null;
 }
 
 const makeSelector = createSelector(

--- a/src/app/pages/Comments.jsx
+++ b/src/app/pages/Comments.jsx
@@ -9,6 +9,7 @@ import { METHODS } from '@r/platform/router';
 import * as replyActions from 'app/actions/reply';
 import crawlerRequestSelector from 'app/selectors/crawlerRequestSelector';
 
+import RelevantContent from 'app/components/RelevantContent';
 import CommentsList from 'app/components/CommentsList';
 import CommentsPageTools from 'app/components/CommentsPage/CommentsPageTools';
 import GoogleCarouselMetadata from 'app/components/GoogleCarouselMetadata';
@@ -61,6 +62,8 @@ function CommentsPage(props) {
         onSortChange={ onSortChange }
         onToggleReply={ onToggleReply }
       />
+
+      <RelevantContent postId={ pageParams.id } />
 
       { !commentsPage || commentsPage.loading
         ? <Loading />


### PR DESCRIPTION
This is mostly just reverting an accidental deletion, but with a small
cleanup. It's possible to get a React exception if you don't return a
React element or null. This code has a code path that could possible
return undefined, which was sometimes causing an exception.

I've tested this and got it working under very select conditions, which
are:
1. User is logged out.
2. User has gotten to the comments page via a specific subreddit page
(not via the frontpage for example). The reason being that landing on
the subreddit page populates the necessary data for the relevant content
UX.
3. User has to have the "hot" sort set in the url (no other sorts work
by design looks like) when he hits the listing page. Hot just being on
by default doesn't seem to get this to show.

Talking with Andy, we're ok with this for now since this was the
previous status quo.

:eyeglasses: @schwers 