### PR TITLE
Restrict the amphtml link tag to 2% of content

### DIFF
--- a/src/app/constants.js
+++ b/src/app/constants.js
@@ -96,6 +96,7 @@ export const flags = {
   VARIANT_XPROMO_CLICK: 'experimentXPromoClick',
   VARIANT_TITLE_EXPANDO: 'experimentTitleExpando',
   VARIANT_MIXED_VIEW: 'experimentMixedView',
+  SHOW_AMP_LINK: 'showAmpLink',
 };
 
 export const themes = {

--- a/src/lib/createAmpHtmlLinkFromState.js
+++ b/src/lib/createAmpHtmlLinkFromState.js
@@ -2,7 +2,19 @@ import { matchRoute } from '@r/platform/navigationMiddleware';
 
 import config from 'config';
 
+import { flags } from 'app/constants';
+import features from 'app/featureFlags';
+
+const {
+  SHOW_AMP_LINK,
+} = flags;
+
 export const ampLink = (currentPage, state) => {
+  const feature = features.withContext({ state });
+  if (!feature.enabled(SHOW_AMP_LINK)) {
+    return null;
+  }
+
   const { postId } = currentPage.urlParams;
   const post = state.posts[`t3_${postId}`];
   if (!post || !post.cleanPermalink) {

--- a/src/lib/getContentIdFromState.js
+++ b/src/lib/getContentIdFromState.js
@@ -1,0 +1,22 @@
+import has from 'lodash/has';
+
+export default function getContentId(state) {
+  // Use post ID for comments pages and comment permalinks
+  if (has(state, ['platform', 'currentPage', 'urlParams', 'postId']) &&
+      has(state, ['commentsPages', 'current'])) {
+    // Vanilla comments page and comment permalink pages will have an entry in
+    // state.commentsPages
+    const commentsPage = state.commentsPages[state.commentsPages.current];
+    return commentsPage.postId;
+  }
+
+  // Use the subreddit fullname for subreddit listings
+  if (has(state, ['platform', 'currentPage', 'urlParams', 'subredditName'])) {
+    const subreddit = state.platform.currentPage.urlParams.subredditName;
+    if (subreddit) {
+      return state.subreddits[subreddit].name;
+    }
+  }
+
+  return null;
+}

--- a/test/lib/getContentIdFromState.test.js
+++ b/test/lib/getContentIdFromState.test.js
@@ -1,0 +1,45 @@
+import chai from 'chai';
+import sinonChai from 'sinon-chai';
+import getContentId from '../../src/lib/getContentIdFromState';
+import set from 'lodash/set';
+
+const expect = chai.expect;
+
+chai.use(sinonChai);
+
+describe('lib: getContentIdFromState', () => {
+  it('is a function', () => {
+    expect(getContentId).to.be.a('function');
+  });
+
+  it('null on empty object', () => {
+    const sampleState = {};
+    set(sampleState, 'platform.currentPage.urlParams.subredditName', null);
+    expect(getContentId(sampleState)).to.equal(null);
+  });
+
+  it('subreddit fullname on pics subreddit', () => {
+    const sampleState = {};
+    set(sampleState, 'platform.currentPage.urlParams.subredditName', 'pics');
+    set(sampleState, 'subreddits.pics.name', 't5_2qh0u');
+    expect(getContentId(sampleState)).to.equal('t5_2qh0u');
+  });
+
+  it('post ID on a comments page', () => {
+    const sampleState = {};
+    set(sampleState, 'platform.currentPage.urlParams.subredditName', 'pics');
+    set(sampleState, 'platform.currentPage.urlParams.postId', 'foo');
+    set(sampleState, 'subreddits.pics.name', 't5_2qh0u');
+    set(sampleState, 'commentsPages.current', 'deadbeef');
+    set(sampleState, 'commentsPages.deadbeef.postId', 't3_foo');
+    expect(getContentId(sampleState)).to.equal('t3_foo');
+  });
+
+  it('null when platform.currentPage.url equals /', () => {
+    const sampleState = {};
+    set(sampleState, 'commentsPages.current', 'deadbeef');
+    set(sampleState, 'commentsPages.current.deadbeef.postId', 't3_foo');
+    set(sampleState, 'platform.currentPage.url', '/');
+    expect(getContentId(sampleState)).to.equal(null);
+  });
+});


### PR DESCRIPTION
Create a basic page-bucketing mechanism, so we can restrict a feature to
a percentage of content. This is a temporary mechanism and not a
full-fledged page-based experimentation/flagging framework.

Restrict the amphtml link tag to just 2% of content, so that not all of
our self posts show up in search results as their AMP'd versions.