### PR TITLE
Switch from Tune to Branch for the Mobile Native banner

### DIFF
--- a/blueprints.config.js
+++ b/blueprints.config.js
@@ -21,6 +21,7 @@ module.exports = function(isProduction) {
     {
       generator: 'set-node-env',
       'process.env': {
+        BRANCH_KEY: JSON.stringify(process.env.BRANCH_KEY),
         GOOGLE_TAG_MANAGER_ID: JSON.stringify(process.env.GOOGLE_TAG_MANAGER_ID),
         MEDIA_DOMAIN: JSON.stringify(process.env.MEDIA_DOMAIN),
         REDDIT: JSON.stringify(process.env.REDDIT),

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@r/widgets": "~0.2.2",
     "autoprefixer": "6.3.6",
     "babel-polyfill": "^6.7.4",
+    "branch-sdk": "^2.11.0",
     "Base64": "1.0.0",
     "cluster": "^0.7.7",
     "event-tracker": "git://github.com/reddit/event-tracker.git#28bc2dd9ce3b80540fdf189e1b003f8264cd0d08",

--- a/src/Client.js
+++ b/src/Client.js
@@ -18,7 +18,7 @@ import reducers from 'app/reducers';
 import reduxMiddleware from 'app/reduxMiddleware';
 import { sendTimings, onHandlerCompleteTimings } from 'lib/timing';
 import Session from 'app/models/Session';
-import * as smartBannerActions from 'app/actions/smartBanner';
+import * as smartBannerActions from 'app/actions/smartBannerClientOnly';
 
 // Bits to help in the gathering of client side timings to relay back
 // to the server

--- a/src/app/actions/smartBanner.js
+++ b/src/app/actions/smartBanner.js
@@ -1,12 +1,12 @@
+import branch from 'branch-sdk';
+
 import getRouteMetaFromState from 'lib/getRouteMetaFromState';
 import { shouldShowBanner, markBannerClosed } from 'lib/smartBannerState';
-import TrackingPixel from 'lib/TrackingPixel';
 
 export const SHOW = 'SMARTBANNER__SHOW';
-export const show = (impressionUrl, clickUrl) => ({
+export const show = clickUrl => ({
   type: SHOW,
   data: {
-    impressionUrl,
     clickUrl,
   },
 });
@@ -24,7 +24,6 @@ export const checkAndSet = () => async (dispatch, getState) => {
   const routeMeta = getRouteMetaFromState(state);
   const {
     showBanner,
-    impressionUrl,
     clickUrl,
   } = shouldShowBanner({
     actionName: routeMeta && routeMeta.name,
@@ -32,9 +31,33 @@ export const checkAndSet = () => async (dispatch, getState) => {
     user: state.accounts[state.user.name],
   });
   if (showBanner) {
-    dispatch(show(impressionUrl, clickUrl));
+    if (clickUrl) {
+      dispatch(show(clickUrl));
+    } else {
+      branch.init('key_live_hoc05HaCXaME10UMwyj3filpqzfu2Ue6', (err, data) => {
+        // callback to handle err or data
+        window.referring_link = data.referring_link;
+        window.referring_data = data.data_parsed;
+      });
 
-    // create a pixel to track the impressions
-    (new TrackingPixel({ url: impressionUrl })).fire();
+      branch.link(
+        {
+          channel: 'Web',
+          feature: 'Banner',
+          // We can use this space to fill "tags" which will populate on the
+          // branch dashboard and allow you sort/parse data. Optional/not required.
+          // tags: [ 'tag1', 'tag2' ],
+          data: {
+            // Pass in data you want to appear and pipe in the app,
+            // including user token or anything else!
+            '$og_redirect': window.location.href,
+            '$deeplink_path': window.location.href.split(window.location.host)[1],
+          },
+        },
+        (err, link) => {
+          dispatch(show(link));
+        }
+      );  
+    }
   }
 };

--- a/src/app/actions/smartBanner.js
+++ b/src/app/actions/smartBanner.js
@@ -1,7 +1,4 @@
-import branch from 'branch-sdk';
-
-import getRouteMetaFromState from 'lib/getRouteMetaFromState';
-import { shouldShowBanner, markBannerClosed } from 'lib/smartBannerState';
+import { markBannerClosed } from 'lib/smartBannerState';
 
 export const SHOW = 'SMARTBANNER__SHOW';
 export const show = clickUrl => ({
@@ -17,47 +14,4 @@ export const hide = () => ({ type: HIDE });
 export const close = () => async (dispatch) => {
   markBannerClosed();
   dispatch(hide());
-};
-
-export const checkAndSet = () => async (dispatch, getState) => {
-  const state = getState();
-  const routeMeta = getRouteMetaFromState(state);
-  const {
-    showBanner,
-    clickUrl,
-  } = shouldShowBanner({
-    actionName: routeMeta && routeMeta.name,
-    userAgent: state.meta.userAgent || '',
-    user: state.accounts[state.user.name],
-  });
-  if (showBanner) {
-    if (clickUrl) {
-      dispatch(show(clickUrl));
-    } else {
-      branch.init('key_live_hoc05HaCXaME10UMwyj3filpqzfu2Ue6', (err, data) => {
-        // callback to handle err or data
-        window.referring_link = data.referring_link;
-        window.referring_data = data.data_parsed;
-      });
-
-      branch.link(
-        {
-          channel: 'Web',
-          feature: 'Banner',
-          // We can use this space to fill "tags" which will populate on the
-          // branch dashboard and allow you sort/parse data. Optional/not required.
-          // tags: [ 'tag1', 'tag2' ],
-          data: {
-            // Pass in data you want to appear and pipe in the app,
-            // including user token or anything else!
-            '$og_redirect': window.location.href,
-            '$deeplink_path': window.location.href.split(window.location.host)[1],
-          },
-        },
-        (err, link) => {
-          dispatch(show(link));
-        }
-      );  
-    }
-  }
 };

--- a/src/app/actions/smartBannerClientOnly.js
+++ b/src/app/actions/smartBannerClientOnly.js
@@ -1,0 +1,56 @@
+import branch from 'branch-sdk';
+
+import config from 'config';
+
+import getRouteMetaFromState from 'lib/getRouteMetaFromState';
+import { shouldShowBanner } from 'lib/smartBannerState';
+import { show } from 'app/actions/smartBanner';
+
+// The branch-sdk module makes an assumption that it runs in a browser
+// environment, even just on load, so we cannot import it on the server. Right
+// now we import all of the reducers on the server, though, and they in turn
+// need access to the smartBanner actions. So we separate the checkAndSet bound
+// action creator (which has a branch dependency) from the other smartBanner
+// action code, so we can confine branch-sdk to the client.
+export const checkAndSet = () => async (dispatch, getState) => {
+  const state = getState();
+  const routeMeta = getRouteMetaFromState(state);
+  const {
+    showBanner,
+    clickUrl,
+  } = shouldShowBanner({
+    actionName: routeMeta && routeMeta.name,
+    userAgent: state.meta.userAgent || '',
+    user: state.accounts[state.user.name],
+  });
+  if (showBanner) {
+    if (clickUrl) {
+      dispatch(show(clickUrl));
+    } else {
+      branch.init(config.branchKey, (err, data) => {
+        // callback to handle err or data
+        window.referring_link = data.referring_link;
+        window.referring_data = data.data_parsed;
+      });
+
+      branch.link(
+        {
+          channel: 'Web',
+          feature: 'Banner',
+          // We can use this space to fill "tags" which will populate on the
+          // branch dashboard and allow you sort/parse data. Optional/not required.
+          // tags: [ 'tag1', 'tag2' ],
+          data: {
+            // Pass in data you want to appear and pipe in the app,
+            // including user token or anything else!
+            '$og_redirect': window.location.href,
+            '$deeplink_path': window.location.href.split(window.location.host)[1],
+          },
+        },
+        (err, link) => {
+          dispatch(show(link));
+        }
+      );  
+    }
+  }
+};

--- a/src/app/constants.js
+++ b/src/app/constants.js
@@ -70,12 +70,6 @@ export const POST_COMPACT_THUMBNAIL_WIDTH = 70;
 
 export const POST_DEFAULT_WIDTH = 320;
 
-/* eslint-disable max-len */
-export const BANNER_URLS_TUNE = {
-  IMPRESSION: 'https://249639.measurementapi.com/serve?action=impression&publisher_id=249639&site_id=122129&site_id_ios=121809',
-  CLICK: 'https://249639.measurementapi.com/serve?action=click&publisher_id=249639&site_id=122129&site_id_ios=121809',
-};
-
 export const BANNER_URLS_DIRECT = {
   IOS: 'https://itunes.apple.com/us/app/reddit-the-official-app/id1064216828',
   ANDROID: 'https://play.google.com/store/apps/details?id=com.reddit.frontpage',

--- a/src/app/reducers/smartBanner.js
+++ b/src/app/reducers/smartBanner.js
@@ -5,7 +5,6 @@ import * as smartBannerActions from 'app/actions/smartBanner';
 export const DEFAULT = {
   showBanner: false,
   clickUrl: null,
-  impressionUrl: null,
 };
 
 export default function(state=DEFAULT, action={}) {

--- a/src/app/reducers/smartBanner.test.js
+++ b/src/app/reducers/smartBanner.test.js
@@ -12,11 +12,10 @@ createTest({ reducers: { smartBanner } }, ({ getStore, expect }) => {
         const { store } = getStore({ smartBanner: DEFAULT });
         const expected = {
           showBanner: true,
-          impressionUrl: 'foo',
-          clickUrl: 'bar',
+          clickUrl: 'foo',
         };
 
-        store.dispatch(smartBannerActions.show('foo', 'bar'));
+        store.dispatch(smartBannerActions.show('foo'));
         const { smartBanner } = store.getState();
         expect(smartBanner).to.eql(expected);
       });

--- a/src/config.js
+++ b/src/config.js
@@ -95,6 +95,8 @@ const config = () => ({
 
   // Note that this is a public key, so this can be shared.
   recaptchaSitekey: process.env.RECAPTCHA_SITEKEY || '6LeTnxkTAAAAAN9QEuDZRpn90WwKk_R1TRW_g-JC',
+
+  branchKey: process.env.BRANCH_KEY,
 });
 
 export default config();

--- a/src/lib/smartBannerState.js
+++ b/src/lib/smartBannerState.js
@@ -3,7 +3,6 @@ import * as constants from 'app/constants';
 
 const BASE_VAL = {
   showBanner: false,
-  impressionUrl: '',
   clickUrl: '',
 };
 
@@ -30,7 +29,7 @@ const PAGE_PERCENTAGES = {
   'comments': 5,
 };
 
-const USE_TUNE = 100;
+const USE_BRANCH = 100;
 
 const checkDeviceType = (allowedAgents, userAgentString) => {
   return allowedAgents.some(a => userAgentString.indexOf(a) > -1);
@@ -70,14 +69,12 @@ export function shouldShowBanner({ actionName, user, userAgent }={}) {
 
   // Ok, now we know we're actually going to show the banner. Next, we need to
   // determine what urls we're going to use
-  // A) Use Tune links
-  if (bucket < USE_TUNE) {
-    // just use the universal Tune links
+  // A) Use Branch link
+  if (bucket < USE_BRANCH) {
+    // just use the universal Branch link
     return {
       ...BASE_VAL,
       showBanner: true,
-      clickUrl: constants.BANNER_URLS_TUNE.CLICK,
-      impressionUrl: constants.BANNER_URLS_TUNE.IMPRESSION,
     };
   }
 


### PR DESCRIPTION
We've switched our deep linking provider from Tune to Branch.

The first commit is @uzi's work to swap in the Branch SDK to "code complete" level. Their SDK assumes it will run in a browser, so the followup commit lets us avoid importing the SDK for code run on the server.