### PR TITLE
Update post submit param name

### DIFF
--- a/src/app/actions/posting.js
+++ b/src/app/actions/posting.js
@@ -42,7 +42,7 @@ export const submitPost = data => async (dispatch, getState) => {
     kind: data.kind,
     [meta_param]: data.meta,
     title: data.title,
-    'g-recaptcha-response': data.gRecaptchaResponse,
+    gRecaptchaResponse: data.gRecaptchaResponse,
     iden: data.captchaIden,
     sendreplies: true,
     resubmit: false,


### PR DESCRIPTION
👓 @schwers 

Seems like the post param was not set correctly.

I tried with this param name, and could see the
header `g-recaptcha-response`:

<img width="460" alt="screen shot 2016-11-17 at 12 11 40 am" src="https://cloud.githubusercontent.com/assets/18406591/20381075/a40ef66c-ac5a-11e6-8294-9a6bd208d8a3.png">

Thanks