### PR TITLE
Issue an event when xpromos are dismissed

### DIFF
--- a/src/app/actions/smartBanner.js
+++ b/src/app/actions/smartBanner.js
@@ -6,8 +6,10 @@ export const show = () => ({ type: SHOW });
 export const HIDE = 'SMARTBANNER__HIDE';
 export const hide = () => ({ type: HIDE });
 
-export const close = () => async (dispatch) => {
-  markBannerClosed();
+// element is the interface element through which the user dismissed the
+// crosspromo experience.
+export const close = () => async (dispatch, getState) => {
+  markBannerClosed(getState());
   dispatch(hide());
 };
 

--- a/src/lib/eventUtils.js
+++ b/src/lib/eventUtils.js
@@ -126,6 +126,14 @@ export function trackPageEvents(state, additionalEventData={}) {
   }
 }
 
+export function trackPreferenceEvent(state, additionalEventData={}) {
+  const payload = {
+    ...getBasePayload(state),
+    ...additionalEventData,
+  };
+  getEventTracker().track('user_preference_events', 'cs.save_preference_cookie', payload);
+}
+
 const gtmPageView = state => {
   const { platform: { currentPage }} = state;
 


### PR DESCRIPTION
We need to log a user preference change event when users dismiss the cross-promotional experiences. The event originally covered cookie-based preferences, but we're overloading it to include localStorage and other non-account preferences. We also use a different name for the preference on advice of DA, so that the field is more descriptive in our data pipeline. Changing the name we use inside the app would introduce some risk when migrating the old setting to the new name, which is not ideal while we have ongoing experiments related to this.