### PR TITLE
Log smartbanner preference change more carefully

### DIFF
--- a/src/app/actions/smartBanner.js
+++ b/src/app/actions/smartBanner.js
@@ -1,4 +1,5 @@
 import { markBannerClosed, shouldShowBanner } from 'lib/smartBannerState';
+import { trackPreferenceEvent } from 'lib/eventUtils';
 
 export const SHOW = 'SMARTBANNER__SHOW';
 export const show = () => ({ type: SHOW });
@@ -6,11 +7,23 @@ export const show = () => ({ type: SHOW });
 export const HIDE = 'SMARTBANNER__HIDE';
 export const hide = () => ({ type: HIDE });
 
+const EXTERNAL_PREF_NAME = 'hide_mweb_xpromo_banner';
+
 // element is the interface element through which the user dismissed the
 // crosspromo experience.
 export const close = () => async (dispatch, getState) => {
-  markBannerClosed(getState());
+  markBannerClosed();
   dispatch(hide());
+
+  // We use a separate externally-visible name/value for the preference for
+  // clarity when analyzing these events in our data pipeline.
+  trackPreferenceEvent(getState(), {
+    modified_preferences: [EXTERNAL_PREF_NAME],
+    user_preferences: {
+      [EXTERNAL_PREF_NAME]: true,
+    },
+  });
+
 };
 
 export const checkAndSet = () => async (dispatch) => {

--- a/src/lib/smartBannerState.js
+++ b/src/lib/smartBannerState.js
@@ -2,15 +2,12 @@ import url from 'url';
 
 import localStorageAvailable from './localStorageAvailable';
 import { getDevice, IOS_DEVICES, ANDROID } from 'lib/getDeviceFromState';
-import { trackPreferenceEvent } from 'lib/eventUtils';
 import * as constants from 'app/constants';
 import features from 'app/featureFlags';
 
 const TWO_WEEKS = 2 * 7 * 24 * 60 * 60 * 1000;
 
 const { USE_BRANCH } = constants.flags;
-
-const EXTERNAL_PREF_NAME = 'hide_mweb_xpromo_banner';
 
 export function getBranchLink(state, payload={}) {
   const { me={} } = state.accounts;
@@ -87,17 +84,8 @@ export function shouldShowBanner() {
   return true;
 }
 
-export function markBannerClosed(state) {
+export function markBannerClosed() {
   if (!localStorageAvailable()) { return false; }
-
-  // We use a separate externally-visible name/value for the preference for
-  // clarity when analyzing these events in our data pipeline.
-  trackPreferenceEvent(state, {
-    modified_preferences: [EXTERNAL_PREF_NAME],
-    user_preferences: {
-      [EXTERNAL_PREF_NAME]: true,
-    },
-  });
 
   // note that we dismissed the banner
   localStorage.setItem('bannerLastClosed', new Date());


### PR DESCRIPTION
Don't try to log a preference change event when the user follows the
link in the banner's call to action. We really just want to track when
users bail out of the crosspromo experience.