### PR TITLE
Add more padding to xpromo dismissal link

### DIFF
--- a/src/app/components/InterstitialListing/common.jsx
+++ b/src/app/components/InterstitialListing/common.jsx
@@ -76,7 +76,12 @@ export function InterstitialListingCommon(props) {
             { buttonText }
           </div>
           <div className='InterstitialListing__dismissal'>
-            or go to the <a onClick={ onClose }>mobile site</a>
+            <span className='InterstitialListing__dismissalText'>
+              { 'or go to the '}
+            </span>
+            <a className='InterstitialListing__dismissalLink' onClick={ onClose }>
+              mobile site
+            </a>
           </div>
         </div>
       </div>

--- a/src/app/components/InterstitialListing/styles.less
+++ b/src/app/components/InterstitialListing/styles.less
@@ -285,7 +285,7 @@
     height: 48px;
     line-height: 48px;
     text-align: center;
-    margin: @grid-size @grid-size*3;
+    margin: @grid-size @grid-size*3 @half-grid-size;
     width: calc(100% ~ '-' @grid-size*6);
     max-width: 320px;
     border-radius: 5px;
@@ -299,14 +299,32 @@
     }
   }
 
-  &__dismissal {
-    color: @grey-text;
-    a, a:visited, a:hover {
+  @closeLinkHPadding: 2 * @grid-size;
+
+  &__dismissalLink {
+    // give the link a bigger hit are all around, but make sure any clicks
+    // below it register as this is very close to the bottom of the screen
+    padding: @grid-size @closeLinkHPadding 3 * @grid-size;
+
+    &, &:visited, &:hover {
       text-decoration: underline;
+
       .themeify({
         color: @grey-text;
       });
     }
+  }
+
+  &__dismissalText {
+    // padding on the link moves this text to left, we want to
+    // pull it to the link so we maintain visual text-centering
+    position: relative;
+    right: -@closeLinkHPadding;
+  }
+
+  &__dismissal {
+    margin-top: @grid-size;
+    color: @grey-text;
   }
 }
 


### PR DESCRIPTION
👓  @uzi or @prashtx 

There's been some feedback that the dismiss button on xpromo modals is hard to click on. This patch adds more padding to the link. It adds more padding to the bottom as the link is rendered near the bottom edge of the screen, and adding too much to the top could accidentally eat clicks intended for the app link button. 