### PR TITLE
Enable logged-out outbounds

### DIFF
--- a/src/app/components/OutboundLink/index.jsx
+++ b/src/app/components/OutboundLink/index.jsx
@@ -5,6 +5,7 @@ import { createSelector } from 'reselect';
 import omit from 'lodash/omit';
 
 import { convertId } from 'lib/eventUtils';
+import findNearestLinkElement from 'lib/findNearestLinkElement';
 
 const T = React.PropTypes;
 
@@ -29,22 +30,32 @@ const addUserIdParam = (url, userId) => {
   return `${baseUrl}${newQuery}`;
 };
 
-const setOutboundURL = ($link, outboundLink, userId) => {
+const setOutboundURL = ($target, outboundLink, userId) => {
+  const $link = findNearestLinkElement($target);
+  if (!$link) {
+    return;
+  }
+
   // if our link hasn't expired, set the href to the outbound link
   if (outboundLink.expiration > Date.now()) {
     $link.href = addUserIdParam(outboundLink.url, userId);
   }
 };
 
-const resetOriginalURL = ($link, href) => {
+const resetOriginalURL = ($target, href) => {
+  const $link = findNearestLinkElement($target);
+  if (!$link) {
+    return;
+  }
+
   $link.href = href;
 };
 
 function OutboundLink(props) {
   const { outboundLink, userId, href } = props;
   // get all of the props we want to pass to standard react components (styles, className, etc)
-  const linkProps = omit(props, 'outboundLink'); 
-  
+  const linkProps = omit(props, 'outboundLink');
+
   if (!outboundLink) {
     // we don't have outbound link data, pass through to a normal anchor with no special handlers
     return <a { ...linkProps } />;

--- a/src/lib/apiOptionsFromState.js
+++ b/src/lib/apiOptionsFromState.js
@@ -9,20 +9,14 @@ export const apiOptionsFromState = state => {
   let options = (session && session.accessToken)
     ? optionsWithAuth(session.accessToken)
     : { ...APIOptions };
-    
-  // TEST: We're testing outbound links for employees only. To do this,
-  // we only send the `X-Reddit-Web-Client` client if the logged in user
-  // is an employee.
-  const { user, accounts } = state;
-  const userAccount = user.loggedOut ? null : accounts[user.name];
-  if (userAccount && userAccount.isEmployee) {
-    options = {
-      ...options,
-      queryParams: {
-        redditWebClient: 'mweb2x',
-      },
-    };
-  }
+
+  // Identify ourselves as the mweb app for api purposes
+  options = {
+    ...options,
+    queryParams: {
+      redditWebClient: 'mweb2x',
+    },
+  };
 
   // grab loids if we have them, and set the cookie if on the server
   const {

--- a/src/lib/findNearestLinkElement.js
+++ b/src/lib/findNearestLinkElement.js
@@ -1,0 +1,11 @@
+export default function findNearestLinkElement(el) {
+  if (el.tagName === 'A') {
+    return el;
+  }
+
+  if (el.parentNode) {
+    return findNearestLinkElement(el.parentNode);
+  }
+
+  return null;
+}


### PR DESCRIPTION
This enables logged-out outbounds. The core feature work here is really simple, we now always send the `redditWebClient` queryParam.

This also fixes a critical bug in the OutboundLink component that prevented tracking clicks on links with nested dom elements. This slipped through QA as there's only one instance of this, but its an important one, the linkbar on comments pages.

👓  @curioussavage @nramadas 