### PR TITLE
Remove params_app from the crawl event payload

### DIFF
--- a/src/lib/eventUtils.js
+++ b/src/lib/eventUtils.js
@@ -75,7 +75,6 @@ function trackCrawlEvent(state, additionalEventData) {
   const { protocol, method, crawler, userAgent, domain } = state.meta;
 
   const payload = {
-    params_app: 'mweb',
     http_response_code: state.platform.currentPage.status,
     // (skrisman | 10.17.2016) consider how we can get a response_time here
     // (skrisman | 10.17.2016) is there a concept like "server" that we have?


### PR DESCRIPTION
Requests from apps like mweb to the r2 API include an `app` parameter.
We pass that along in r2 crawl events as `params_app`, so that we can
distinguish those API requests (caused by crawls of apps) from real,
direct crawls of the desktop site. We shouldn't include that in the mweb
crawl events, since these are direct page crawls and not API requests.
The `app_name` field will still be passed along by the event tracker
module, and we should use that to distinguish between desktop and mweb
crawls.