### PR TITLE
Support xpromo interstitials for in-app navigation

### DIFF
--- a/src/app/actions/smartBanner.js
+++ b/src/app/actions/smartBanner.js
@@ -7,6 +7,12 @@ export const show = () => ({ type: SHOW });
 export const HIDE = 'SMARTBANNER__HIDE';
 export const hide = () => ({ type: HIDE });
 
+export const RECORD_SHOWN = 'SMARTBANNER__RECORD_SHOWN';
+export const recordShown = url => ({
+  type: RECORD_SHOWN,
+  url,
+});
+
 const EXTERNAL_PREF_NAME = 'hide_mweb_xpromo_banner';
 
 // element is the interface element through which the user dismissed the

--- a/src/app/components/InterstitialListing/index.jsx
+++ b/src/app/components/InterstitialListing/index.jsx
@@ -7,6 +7,8 @@ import { redirect } from '@r/platform/actions';
 import { markBannerClosed } from 'lib/smartBannerState';
 import * as smartBannerActions from 'app/actions/smartBanner';
 
+import XPromoWrapper from 'app/components/XPromoWrapper';
+
 import {
   InterstitialListingCommon,
   selector,
@@ -14,11 +16,13 @@ import {
 
 export function InterstitialListing(props) {
   return (
-    <div className='InterstitialListing'>
-      <div className='InterstitialListing__content'>
-        <InterstitialListingCommon { ... props } />
+    <XPromoWrapper>
+      <div className='InterstitialListing'>
+        <div className='InterstitialListing__content'>
+          <InterstitialListingCommon { ... props } />
+        </div>
       </div>
-    </div>
+    </XPromoWrapper>
   );
 }
 

--- a/src/app/components/InterstitialListing/modal.jsx
+++ b/src/app/components/InterstitialListing/modal.jsx
@@ -7,6 +7,7 @@ import { redirect } from '@r/platform/actions';
 import { markBannerClosed } from 'lib/smartBannerState';
 import * as smartBannerActions from 'app/actions/smartBanner';
 import * as modalActions from 'app/actions/modal';
+import XPromoWrapper from 'app/components/XPromoWrapper';
 
 import {
   InterstitialListingCommon,
@@ -15,14 +16,16 @@ import {
 
 export function InterstitialModal(props) {
   return (
-    <div className='InterstitialListing'>
-      <div className='InterstitialListing__modalCover' />
-      <div className='InterstitialListing__modal'>
-        <div className='InterstitialListing__modalcontent'>
-          <InterstitialListingCommon { ... props } />
+    <XPromoWrapper>
+      <div className='InterstitialListing'>
+        <div className='InterstitialListing__modalCover' />
+        <div className='InterstitialListing__modal'>
+          <div className='InterstitialListing__modalcontent'>
+            <InterstitialListingCommon { ... props } />
+          </div>
         </div>
       </div>
-    </div>
+    </XPromoWrapper>
   );
 }
   

--- a/src/app/components/InterstitialPromo/index.jsx
+++ b/src/app/components/InterstitialPromo/index.jsx
@@ -18,6 +18,7 @@ import { featuresSelector} from 'app/selectors/features';
 import * as smartBannerActions from 'app/actions/smartBanner';
 import SnooIcon from '../SnooIcon';
 import Logo from '../Logo';
+import XPromoWrapper from '../XPromoWrapper';
 
 const T = React.PropTypes;
 
@@ -79,40 +80,42 @@ function InterstitialPromo(props) {
                        features.enabled(VARIANT_XPROMO_LISTING);
 
   return (
-    <div className='InterstitialPromo'>
-      <div
-        className='InterstitialPromo__close icon icon-x'
-        onClick={ onClose }
-      />
-      <div className='InterstitialPromo__icon'>
-        <SnooIcon />
-        <div className='InterstitialPromo__wordmark'>
-          <Logo />
-        </div>
-      </div>
-      <div className='InterstitialPromo__bottom'>
-        <div className='InterstitialPromo__header'>
-          <div className='InterstitialPromo__title'>{ TITLE }</div>
-          <div className='InterstitialPromo__subtitle'>
-            Reddit is better with the app.
-            We&nbsp;hate to intrude, but&nbsp;you&nbsp;deserve&nbsp;the&nbsp;best.
-          </div>
-          { listVariants ? <List /> : null }
-        </div>
+    <XPromoWrapper>
+      <div className='InterstitialPromo'>
         <div
-          className='InterstitialPromo__button'
-          onClick={ navigator(urls[0]) }
-        >
-          { CTA }
-          <span className="icon icon-play"></span>
+          className='InterstitialPromo__close icon icon-x'
+          onClick={ onClose }
+        />
+        <div className='InterstitialPromo__icon'>
+          <SnooIcon />
+          <div className='InterstitialPromo__wordmark'>
+            <Logo />
+          </div>
         </div>
-        { features.enabled(VARIANT_XPROMO_RATING) ?
-            <Rating device={ device} navigate={ navigator(urls[1]) }/> : null }
-        <div className='InterstitialPromo__dismissal'>
-          or go to the <a onClick={ onClose }>mobile site</a>
+        <div className='InterstitialPromo__bottom'>
+          <div className='InterstitialPromo__header'>
+            <div className='InterstitialPromo__title'>{ TITLE }</div>
+            <div className='InterstitialPromo__subtitle'>
+              Reddit is better with the app.
+              We&nbsp;hate to intrude, but&nbsp;you&nbsp;deserve&nbsp;the&nbsp;best.
+            </div>
+            { listVariants ? <List /> : null }
+          </div>
+          <div
+            className='InterstitialPromo__button'
+            onClick={ navigator(urls[0]) }
+          >
+            { CTA }
+            <span className="icon icon-play"></span>
+          </div>
+          { features.enabled(VARIANT_XPROMO_RATING) ?
+              <Rating device={ device} navigate={ navigator(urls[1]) }/> : null }
+          <div className='InterstitialPromo__dismissal'>
+            or go to the <a onClick={ onClose }>mobile site</a>
+          </div>
         </div>
       </div>
-    </div>
+    </XPromoWrapper>
   );
 }
 

--- a/src/app/components/XPromoWrapper/index.jsx
+++ b/src/app/components/XPromoWrapper/index.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { createStructuredSelector } from 'reselect';
+
+import * as smartBannerActions from 'app/actions/smartBanner';
+
+
+const T = React.PropTypes;
+
+class XPromoWrapper extends React.Component {
+  static propTypes = {
+    recordXPromoShown: T.func.isRequired,
+  };
+
+  componentDidMount() {
+    // Indicate that we've displayed a crosspromotional UI, so we don't keep
+    // showing them during this browsing session.
+    this.props.recordXPromoShown();
+  }
+
+  render() {
+    return this.props.children;
+  }
+}
+
+const selector = createStructuredSelector({
+  currentUrl: state => state.platform.currentPage.url,
+});
+
+const mergeProps = (stateProps, dispatchProps, ownProps) => ({
+  ...stateProps,
+  ...dispatchProps,
+  recordXPromoShown: () =>
+    dispatchProps.dispatch(smartBannerActions.recordShown(stateProps.currentUrl)),
+  ...ownProps,
+});
+
+export default connect(selector, undefined, mergeProps)(XPromoWrapper);

--- a/src/app/reducers/smartBanner.js
+++ b/src/app/reducers/smartBanner.js
@@ -5,6 +5,8 @@ import * as smartBannerActions from 'app/actions/smartBanner';
 
 export const DEFAULT = {
   showBanner: false,
+  haveShownXPromo: false,
+  xPromoShownUrl: null,
 };
 
 export default function(state=DEFAULT, action={}) {
@@ -20,8 +22,21 @@ export default function(state=DEFAULT, action={}) {
       return DEFAULT;
     }
 
+    case smartBannerActions.RECORD_SHOWN: {
+      return merge(state, {
+        haveShownXPromo: true,
+        xPromoShownUrl: action.url,
+      });
+    }
+
     case platformActions.NAVIGATE_TO_URL: {
-      return DEFAULT;
+      if (state.haveShownXPromo) {
+        return merge(state, {
+          showBanner: false,
+        });
+      }
+
+      return state;
     }
 
     default:

--- a/src/app/reducers/smartBanner.test.js
+++ b/src/app/reducers/smartBanner.test.js
@@ -1,16 +1,20 @@
 import createTest from '@r/platform/createTest';
+import { METHODS } from '@r/platform/router';
+import * as platformActions from '@r/platform/actions';
 
+import routes from 'app/router';
 import smartBanner, { DEFAULT } from './smartBanner';
 
 import * as smartBannerActions from 'app/actions/smartBanner';
 
 
-createTest({ reducers: { smartBanner } }, ({ getStore, expect }) => {
+createTest({ reducers: { smartBanner }, routes }, ({ getStore, expect }) => {
   describe('smartBanner', () => {
     describe('SHOW', () => {
       it('should show the smart banner', () => {
         const { store } = getStore({ smartBanner: DEFAULT });
         const expected = {
+          ...DEFAULT,
           showBanner: true,
         };
 
@@ -30,6 +34,48 @@ createTest({ reducers: { smartBanner } }, ({ getStore, expect }) => {
         store.dispatch(smartBannerActions.hide());
         const { smartBanner } = store.getState();
         expect(smartBanner).to.eql(DEFAULT);
+      });
+    });
+
+    describe('RECORD_SHOWN', () => {
+      it('should mark that we have shown an xpromo', () => {
+        const { store } = getStore({ smartBanner: DEFAULT });
+        const url = '/foo/bar';
+
+        // Indicate desire to show, and then record that we showed.
+        store.dispatch(smartBannerActions.show());
+        store.dispatch(smartBannerActions.recordShown(url));
+        const { smartBanner } = store.getState();
+        expect(smartBanner).to.eql({
+          showBanner: true,
+          haveShownXPromo: true,
+          xPromoShownUrl: url,
+        });
+      });
+    });
+
+    describe('PLATFORM__NAVIGATE_TO_URL', () => {
+      it('should remove desire to show xpromo if we have already shown it once', () => {
+        const { store } = getStore({ smartBanner: DEFAULT });
+
+        // Indicate desire to show, record that we showed, navigate.
+        store.dispatch(smartBannerActions.show());
+        store.dispatch(smartBannerActions.recordShown('/foo/bar'));
+        store.dispatch(platformActions.navigateToUrl(METHODS.GET, '/user/foobar'));
+        const { smartBanner } = store.getState();
+        const { showBanner } = smartBanner;
+        expect(showBanner).to.eql(false);
+      });
+
+      it('should not remove desire to show xpromo if we have not shown it yet', () => {
+        const { store } = getStore({ smartBanner: DEFAULT });
+
+        // Indicate desire to show, navigate.
+        store.dispatch(smartBannerActions.show());
+        store.dispatch(platformActions.navigateToUrl(METHODS.GET, '/user/foobar'));
+        const { smartBanner } = store.getState();
+        const { showBanner } = smartBanner;
+        expect(showBanner).to.eql(true);
       });
     });
   });


### PR DESCRIPTION
We need to support display of the cross-promo interstitials for the
appropriate pages for in-app navigation, but we also don't want to show
multiple interstitials per session (and in particular not for sequential
navigations). We track if we have already shown an xpromo experience,
and then we can avoid showing it for later pages.