### PR TITLE
Playing state gif 

### DIFF
--- a/src/app/actions/posts.js
+++ b/src/app/actions/posts.js
@@ -103,6 +103,18 @@ export const toggleEdit = postId => ({
   thingId: postId,
 });
 
+export const START_PLAYING = 'POSTS__START_PLAYING';
+export const startPlaying = postId => ({
+  type: START_PLAYING,
+  thingId: postId,
+});
+
+export const STOP_PLAYING = 'POSTS__STOP_PLAYING';
+export const stopPlaying = postId => ({
+  type: STOP_PLAYING,
+  thingId: postId,
+});
+
 export const UPDATING_SELF_TEXT = 'POSTS__UPDATING_SELF_TEXT';
 export const updatingSelfText = postId => ({
   type: UPDATING_SELF_TEXT,

--- a/src/app/components/Post/PostContent/index.jsx
+++ b/src/app/components/Post/PostContent/index.jsx
@@ -29,6 +29,482 @@ import {
 
 const T = React.PropTypes;
 
+class LinkDescriptor {
+  constructor(url, outbound) {
+    this.url = url;
+    this.outbound = outbound;
+  }
+}
+
+// PostContent is used to render:
+//  * Post thumbnail, if there is one
+//  * Post Preview/Link Bar (includes playable gif / video / gallery etc)
+
+PostContent.propTypes = {
+  post: T.instanceOf(PostModel),
+  compact: T.bool.isRequired,
+  single: T.bool.isRequired,
+  onTapExpand: T.func.isRequired,
+  expandedCompact: T.bool.isRequired,
+  width: T.number.isRequired,
+  toggleShowNSFW: T.func.isRequired,
+  togglePlaying: T.func.isRequired,
+  showNSFW: T.bool.isRequired,
+  editing: T.bool,
+  editPending: T.bool,
+  onToggleEdit: T.func.isRequired,
+  onUpdateSelftext: T.func.isRequired,
+  forceHTTPS: T.bool.isRequired,
+  isDomainExternal: T.bool.isRequired,
+  renderMediaFullbleed: T.bool.isRequired,
+  isThumbnail: T.bool.isRequired,
+  isPlaying: T.bool,
+};
+
+PostContent.defaultProps = {
+  editing: false,
+  editPending: false,
+  isPlaying: false,
+};
+
+export default function PostContent(props) {
+  const { post, isDomainExternal, compact, isThumbnail,
+          renderMediaFullbleed, showLinksInNewTab } = props;
+
+  const linkUrl = cleanPostHREF(mobilify(post.cleanUrl));
+  const linkDescriptor = new LinkDescriptor(linkUrl, true);
+  const mediaContentNode = buildMediaContent(post, linkDescriptor, props);
+  const selftextNode = buildSelfTextContent(props);
+
+  if (!mediaContentNode && !selftextNode) {
+    if (!isDomainExternal || compact) {
+      // When in compact mode, the PostHeader Component is responsible for rendering
+      // outbound links. But when in list mode, we are, so make sure we render
+      // the linkbar to outbound links if needed.
+      return null;
+    }
+  }
+
+  return (
+    <div className={ `PostContent ${isThumbnail ? 'size-compact' : 'size-default'}` }>
+      { renderMediaContent(mediaContentNode, isThumbnail, isDomainExternal,
+                           cleanPostDomain(post.domain), linkUrl,
+                           renderMediaFullbleed, showLinksInNewTab,
+                           post.outboundLink) }
+      { selftextNode }
+    </div>
+  );
+}
+
+function renderMediaContent(mediaContentNode, isThumbnail, isDomainExternal,
+                            linkDisplayText, linkUrl, renderMediaFullbleed,
+                            showLinksInNewTab, outboundLink) {
+  if (isThumbnail || !isDomainExternal || renderMediaFullbleed) {
+    return mediaContentNode;
+  }
+
+  return (
+    <div className='PostContent__media-wrapper'>
+      { mediaContentNode }
+      { renderLinkBar(linkDisplayText, linkUrl,
+                      showLinksInNewTab, outboundLink) }
+    </div>
+  );
+}
+
+function buildSelfTextContent(props) {
+  const { single, editing, post } = props;
+  if (!single) { return; }
+
+  if (editing) {
+    return renderTextEditor(post.selfTextMD, props);
+  }
+
+  if (!post.selfTextHTML) { return; }
+
+  const mobileSelfText = mobilify(post.expandedContent);
+  return (
+    <RedditLinkHijacker>
+      <div
+        className='PostContent__selftext'
+        dangerouslySetInnerHTML={ { __html: mobileSelfText } }
+      />
+    </RedditLinkHijacker>
+  );
+}
+
+function renderTextEditor(rawMarkdown, props) {
+  const { editPending, onToggleEdit, onUpdateSelftext } = props;
+
+  return (
+    <EditForm
+      startingText={ rawMarkdown }
+      editPending={ editPending }
+      onCancelEdit={ onToggleEdit }
+      onSaveEdit={ onUpdateSelftext }
+    />
+  );
+}
+
+
+function buildMediaContent(post, linkDescriptor, props) {
+  const { isPlaying, isThumbnail, single, width, showNSFW, onTapExpand,
+          togglePlaying } = props;
+  const oembed = post.media ? post.media.oembed : null;
+
+  if (isThumbnail && !(post.preview || oembed)) {
+    return null; // Compact mode only renders thumbnails _if_ there's a preview
+  }
+
+  const isNSFW = isPostNSFW(post);
+  const needsNSFWBlur = showNSFWBlur(isNSFW, showNSFW);
+  const playableType = postToPlayableType(post);
+  const sourceURL = optimizeContent(post);
+
+  let previewImage;
+  if (post.preview || oembed) {
+    previewImage = findPreviewImage(
+      isThumbnail, post.preview, post.thumbnail, oembed, width, needsNSFWBlur);
+  }
+
+  // if we got a preview image that's a gif, convert it to a still image if possible
+  if (previewImage && previewImage.url) {
+    const html5VideoSources = gifToHTML5Sources(previewImage.url);
+    if (html5VideoSources && html5VideoSources.poster) {
+      previewImage.url = html5VideoSources.poster;
+    }
+  }
+
+  let callOnTapExpand;
+  if (post.promoted && !post.isSelf) {
+    // ads without self text should go to the url instead of expando
+    callOnTapExpand = null;
+  } else {
+    callOnTapExpand = e => {
+      e.preventDefault();
+      const clickTarget = 'thumbnail';
+      onTapExpand(clickTarget);
+      togglePlaying();
+    };
+  }
+
+  if (isThumbnail && previewImage && previewImage.url) {
+    return renderImage(previewImage, sourceURL, linkDescriptor, callOnTapExpand,
+                       needsNSFWBlur, playableType, props);
+  }
+
+  // handles:
+  //  * image preview of playabe image / video
+  //  * a gif that we're playing ourselves with html5 video or inline
+  if (playableType !== PLAYABLE_TYPE.NOT_PLAYABLE && previewImage &&
+      useOurOwnPlayingOrPreviewing(oembed, sourceURL, isPlaying)) {
+    const togglePlay = e => {
+      e.preventDefault();
+      togglePlaying();
+    };
+    return buildImagePreview(previewImage, sourceURL, linkDescriptor,
+                             togglePlay, needsNSFWBlur, playableType, props);
+  }
+
+  if (oembed) {
+    return buildMediaPreview(post, sourceURL, oembed, single);
+  }
+
+  if (previewImage) {
+    const callback = isNSFW ? e => {
+      e.preventDefault();
+      props.toggleShowNSFW();
+    } : null;
+    return buildImagePreview(previewImage, sourceURL, linkDescriptor, callback,
+                             needsNSFWBlur, playableType, props);
+  }
+}
+
+
+function buildImagePreview(previewImage, imageURL, linkDescriptor, callback,
+                           needsNSFWBlur, playableType, props) {
+  const html5sources = gifToHTML5Sources(imageURL, previewImage.url);
+  const { single, isPlaying } = props;
+
+  if (isPlaying && html5sources) {
+    const { width, height } = previewImage;
+    const aspectRatio = getAspectRatio(single, width, height);
+
+    if (html5sources.iframe) {
+      return renderIframe(html5sources.iframe, aspectRatio);
+    }
+
+    const generatedSrc = {
+      webm: html5sources.webm,
+      mp4: html5sources.mp4,
+      width: previewImage.width,
+      height: previewImage.height,
+    };
+
+    return renderVideo(generatedSrc, html5sources.poster, aspectRatio);
+  }
+
+  return renderImage(previewImage, imageURL, linkDescriptor, callback,
+    needsNSFWBlur, playableType, props);
+}
+
+function buildMediaPreview(post, sourceURL, oembed, single) {
+  const aspectRatio = getAspectRatio(single, oembed.width, oembed.height);
+
+  switch (oembed.type) {
+    case 'image':
+      return renderIframe(sourceURL, aspectRatio);
+    case 'video':
+      return renderRawHTML(post.expandedContent, aspectRatio);
+    case 'rich':
+      return renderRichOembed(oembed.html, aspectRatio);
+  }
+}
+
+function renderRichOembed(oembedHtml, aspectRatio) {
+  const findSrc = oembedHtml.match(/src="([^"]*)/);
+
+  if (findSrc && findSrc[1]) {
+    const frameUrl = findSrc[1].replace('&amp;', '&');
+    return renderIframe(frameUrl, aspectRatio);
+  }
+}
+
+function renderImage(previewImage, imageURL, linkDescriptor, onClick,
+                     needsNSFWBlur, playableType, props) {
+  const { isThumbnail, single, showLinksInNewTab,
+          post, forceHTTPS, isPlaying } = props;
+  let playbackControlNode;
+  if (playableType && !needsNSFWBlur) {
+    playbackControlNode = renderPlaybackIcon(playableType, isThumbnail);
+  }
+
+  let nsfwNode;
+  if (needsNSFWBlur) {
+    nsfwNode = renderNSFWWarning(isThumbnail);
+  }
+
+  const aspectRatio = getAspectRatio(single, previewImage.width,
+                                     previewImage.height);
+  const linkTarget = showLinksInNewTab ? '_blank' : null;
+
+  if (previewImage && previewImage.url && !aspectRatio) {
+    return renderImageOfUnknownSize(
+      previewImage.url, linkDescriptor, onClick, playbackControlNode,
+      nsfwNode, linkTarget, post.outboundLink);
+  }
+
+  return renderImageWithAspectRatio(previewImage, imageURL, linkDescriptor,
+                                    aspectRatio, onClick, isThumbnail,
+                                    playbackControlNode, nsfwNode, linkTarget,
+                                    post.outboundLink, forceHTTPS, isPlaying);
+}
+
+function baseImageLinkClass(imageUrl, hasNSFWBlur) {
+  return `PostContent__image-link ${hasNSFWBlur && !imageUrl ? 'placeholder' :''}`;
+}
+
+function renderImageOfUnknownSize(imageURL, linkDescriptor, onClick,
+                                  playbackControlNode, nsfwNode, linkTarget,
+                                  outboundLink) {
+  const linkClass = baseImageLinkClass(imageURL, !!nsfwNode);
+  return (
+    <OutboundLink
+      className={ linkClass }
+      href={ linkDescriptor.url }
+      target={ linkTarget }
+      onClick={ onClick }
+      outboundLink={ outboundLink }
+    >
+      <img className='PostContent__image-img' src={ imageURL } />
+      { playbackControlNode }
+      { nsfwNode }
+    </OutboundLink>
+  );
+}
+
+
+function renderImageWithAspectRatio(previewImage, imageURL, linkDescriptor,
+                                    aspectRatio, onClick, isThumbnail,
+                                    playbackControlNode, nsfwNode, linkTarget,
+                                    outboundLink, forceHTTPS, isPlaying) {
+
+  const style = {};
+
+  if (previewImage.url) {
+    const giphyPosterHref = posterForHrefIfGiphyCat(imageURL);
+    const backgroundImage = giphyPosterHref && !nsfwNode ?
+      giphyPosterHref : previewImage.url;
+    style.backgroundImage = `url("${forceProtocol(backgroundImage, forceHTTPS)}")`;
+  }
+
+  let linkClass = baseImageLinkClass(previewImage.url, !!nsfwNode);
+  if (!isThumbnail) {
+    linkClass += ` ${aspectRatioClass(aspectRatio)}`;
+  }
+
+  return (
+    <OutboundLink
+      className={ linkClass }
+      href={ linkDescriptor.url }
+      target={ linkTarget }
+      onClick={ onClick }
+      style={ style }
+      outboundLink={ outboundLink }
+    >
+      { isPlaying
+        ? <img className='PostContent__inline-gif' src={ imageURL } />
+        : playbackControlNode }
+      { nsfwNode }
+    </OutboundLink>
+  );
+}
+
+function renderIframe(src, aspectRatio) {
+  return (
+    <div className={ `PostContent__iframe-wrapper ${aspectRatioClass(aspectRatio)}` } >
+      <iframe
+        className='PostContent__iframe'
+        src={ src }
+        frameBorder='0'
+        allowFullScreen=''
+        sandbox='allow-scripts allow-forms allow-same-origin'
+      />
+    </div>
+  );
+}
+
+function renderVideo(videoSpec, posterImage, aspectRatio) {
+  return (
+    <div className={ `PostContent__video-wrapper ${aspectRatioClass(aspectRatio)}` } >
+      <video
+        className='PostContent__video'
+        poster={ posterImage }
+        loop='true'
+        muted='true'
+        controls='true'
+        autoPlay='true'
+        ref={ autoPlayGif }
+      >
+        { buildVideoSources(videoSpec) }
+      </video>
+    </div>
+  );
+}
+
+
+function buildVideoSources(videoSpec) {
+  const sources = [];
+  ['mp4', 'webm'].forEach(function(videoType) {
+    const source = videoSpec[videoType];
+    if (source) {
+      sources.push(
+        <source
+          key={ `video-src-${videoType}` }
+          type={ `video/${videoType}` }
+          src={ source }
+        />
+      );
+    }
+  });
+
+  return sources;
+}
+
+function renderRawHTML(htmlContent, aspectRatio) {
+  return (
+    <RedditLinkHijacker>
+      <div
+        className={ `PostContent__html ${aspectRatioClass(aspectRatio)}` }
+        dangerouslySetInnerHTML={ { __html: htmlContent } }
+      />
+    </RedditLinkHijacker>
+  );
+}
+
+function renderPlaybackIcon(playableType, isThumbnail) {
+  if (playableType === PLAYABLE_TYPE.NOT_PLAYABLE) {
+    return;
+  }
+
+  let iconCls = 'PostContent__playback-action-icon darkgrey';
+
+  if (playableType === PLAYABLE_TYPE.GALLERY) {
+    iconCls += ' icon icon-gallery_squares';
+  } else if (playableType === PLAYABLE_TYPE.INLINE) {
+    iconCls += ' icon icon-play_triangle';
+  }
+
+  const modifierClass = isThumbnail ? 'compact' : 'regular';
+  const buttonCls = `PostContent__playback-action-circle  ${modifierClass}`;
+
+  return (
+    <div className={ buttonCls }>
+      <span className={ iconCls } />
+    </div>
+  );
+}
+
+
+function renderLinkBar(displayText, href, showLinksInNewTab, outboundLink) {
+  const target = showLinksInNewTab ? '_blank' : null;
+
+  return (
+    <OutboundLink
+      className='PostContent__link-bar'
+      href={ href }
+      target={ target }
+      outboundLink={ outboundLink }
+    >
+      <span className='PostContent__link-bar-text'>{ displayText }</span>
+      <span className='PostContent__link-bar-icon icon icon-linkout blue' />
+    </OutboundLink>
+  );
+}
+
+function renderNSFWWarning(isThumbnail) {
+  if (isThumbnail) {
+    return (
+      <div className='PostContent__nsfw-warning'>
+        <p className='PostContent__nsfw-warning-text'>NSFW</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className='PostContent__nsfw-warning'>
+      <p className='PostContent__nsfw-warning-text'>This post is marked as NSFW</p>
+      <p className='PostContent__nsfw-warning-button'>Show Post?</p>
+    </div>
+  );
+}
+
+function useOurOwnPlayingOrPreviewing(oembed, url, isPlaying) {
+  if (!isPlaying || !oembed) {
+    return true;
+  }
+
+  // we want to use our own previewing for gifs which will be
+  // type 'video', so make sure we don't accidently catch
+  // anything else like an imgur gallery (type 'rich')
+  if (oembed.type !== 'video') { return false; }
+
+  const provider = oembed.provider_name.toLowerCase();
+  return (provider === 'gfycat' || provider === 'imgur' || /\.gif$/.test(url));
+}
+
+function showNSFWBlur(isNSFW, showNSFW) {
+  return isNSFW && !showNSFW;
+}
+
+function getAspectRatio(single, width, height) {
+  if (width && height) {
+    return single ? width / height : limitAspectRatio(width / height);
+  }
+
+  return DEFAULT_ASPECT_RATIO;
+}
+
 function autoPlayGif(gif) {
   if (!gif) {
     return;
@@ -101,476 +577,4 @@ function gifToMp4Content(post) {
 function optimizeContent(post) {
   const { url } = gifToMp4Content(post) || {};
   return url || post.cleanUrl;
-}
-
-class LinkDescriptor {
-  constructor(url, outbound) {
-    this.url = url;
-    this.outbound = outbound;
-  }
-}
-
-// PostContent is used to render:
-//  * Post thumbnail, if there is one
-//  * Post Preview/Link Bar (includes playable gif / video / gallery etc)
-
-export default class PostContent extends React.Component {
-  static propTypes = {
-    post: T.instanceOf(PostModel),
-    compact: T.bool.isRequired,
-    single: T.bool.isRequired,
-    onTapExpand: T.func.isRequired,
-    expandedCompact: T.bool.isRequired,
-    width: T.number.isRequired,
-    toggleShowNSFW: T.func.isRequired,
-    showNSFW: T.bool.isRequired,
-    editing: T.bool,
-    editPending: T.bool,
-    onToggleEdit: T.func.isRequired,
-    onUpdateSelftext: T.func.isRequired,
-    forceHTTPS: T.bool.isRequired,
-    isDomainExternal: T.bool.isRequired,
-    renderMediaFullbleed: T.bool.isRequired,
-  };
-
-  static defaultProps = {
-    editing: false,
-    editPending: false,
-  };
-
-  constructor(props) {
-    super(props);
-
-
-    this.state = {
-      playing: props.expandedCompact, // we want things to autoplay in expanded compact mode
-    };
-
-    this.togglePlaying = this.togglePlaying.bind(this);
-  }
-
-  togglePlaying = e => {
-    e.preventDefault();
-    this.setState({ playing: !this.state.playing });
-  }
-
-  useOurOwnPlayingOrPreviewing(oembed, url) {
-    if (!this.state.playing || !oembed) {
-      return true;
-    }
-
-    // we want to use our own previewing for gifs which will be
-    // type 'video', so make sure we don't accidently catch
-    // anything else like an imgur gallery (type 'rich')
-    if (oembed.type !== 'video') { return false; }
-
-    const provider = oembed.provider_name.toLowerCase();
-    return (provider === 'gfycat' || provider === 'imgur' || /\.gif$/.test(url));
-  }
-
-  isCompact() {
-    const props = this.props;
-    return props.compact && !props.expandedCompact;
-  }
-
-  needsNSFWBlur(isNSFW, showNSFW) {
-    return isNSFW && !showNSFW;
-  }
-
-  getAspectRatio(single, width, height) {
-    if (width && height) {
-      return single ? width / height : limitAspectRatio(width / height);
-    }
-
-    return DEFAULT_ASPECT_RATIO;
-  }
-
-  render() {
-    const isCompact = this.isCompact();
-    const { single, post, isDomainExternal } = this.props;
-
-    const linkUrl = cleanPostHREF(mobilify(post.cleanUrl));
-    const linkDescriptor = new LinkDescriptor(linkUrl, true);
-    const mediaContentNode = this.buildMediaContent(post, isCompact, linkDescriptor);
-    const selftextNode = this.buildSelfTextContent(post, isCompact, single);
-
-    if (!mediaContentNode && !selftextNode) {
-      if (!isDomainExternal || isCompact) {
-        // When in compact mode, the PostHeader Component is responsible for rendering
-        // outbound links. But when in list mode, we are, so make sure we render
-        // the linkbar to outbound links if needed.
-        return null;
-      }
-    }
-
-    return (
-      <div className={ `PostContent ${isCompact ? 'size-compact' : 'size-default'}` }>
-        { this.renderMediaContent(
-          mediaContentNode, isCompact, isDomainExternal, cleanPostDomain(post.domain),
-          linkUrl) }
-        { selftextNode }
-      </div>
-    );
-  }
-
-  renderMediaContent(mediaContentNode, isCompact, isDomainExternal, linkDisplayText, linkUrl) {
-    if (isCompact || !isDomainExternal || this.props.renderMediaFullbleed) {
-      return mediaContentNode;
-    }
-
-    return (
-      <div className='PostContent__media-wrapper'>
-        { mediaContentNode }
-        { this.renderLinkBar(linkDisplayText, linkUrl) }
-      </div>
-    );
-  }
-
-  buildSelfTextContent(post, isCompact, single) {
-    if (isCompact || !single) { return; }
-
-    if (this.props.editing) {
-      return this.renderTextEditor(post.selfTextMD);
-    }
-
-    if (!post.selfTextHTML) { return; }
-
-    const mobileSelfText = mobilify(post.expandedContent);
-    return (
-      <RedditLinkHijacker>
-        <div
-          className='PostContent__selftext'
-          dangerouslySetInnerHTML={ { __html: mobileSelfText } }
-        />
-      </RedditLinkHijacker>
-    );
-  }
-
-  renderTextEditor(rawMarkdown) {
-    const { editPending, onToggleEdit, onUpdateSelftext } = this.props;
-
-    return (
-      <EditForm
-        startingText={ rawMarkdown }
-        editPending={ editPending }
-        onCancelEdit={ onToggleEdit }
-        onSaveEdit={ onUpdateSelftext }
-      />
-    );
-  }
-
-  buildMediaContent(post, isCompact, linkDescriptor) {
-    const oembed = post.media ? post.media.oembed : null;
-
-    if (isCompact && !(post.preview || oembed)) {
-      return null; // Compact mode only renders thumbnails _if_ there's a preview
-    }
-
-    const { width, showNSFW } = this.props;
-    const isNSFW = isPostNSFW(post);
-    const needsNSFWBlur = this.needsNSFWBlur(isNSFW, showNSFW);
-    const playableType = postToPlayableType(post);
-    const sourceURL = optimizeContent(post);
-
-    let previewImage;
-    if (post.preview || oembed) {
-      previewImage = findPreviewImage(
-        isCompact, post.preview, post.thumbnail, oembed, width, needsNSFWBlur);
-    }
-
-    // if we got a preview image that's a gif, convert it to a still image if possible
-    if (previewImage && previewImage.url) {
-      const html5VideoSources = gifToHTML5Sources(previewImage.url);
-      if (html5VideoSources && html5VideoSources.poster) {
-        previewImage.url = html5VideoSources.poster;
-      }
-    }
-
-    const { onTapExpand } = this.props;
-    let callOnTapExpand;
-    if (post.promoted && !post.isSelf) {
-      // ads without self text should go to the url instead of expando
-      callOnTapExpand = null;
-    } else {
-      callOnTapExpand = e => {
-        e.preventDefault();
-        const clickTarget = 'thumbnail';
-        onTapExpand(clickTarget);
-      };
-    }
-
-    if (isCompact && previewImage && previewImage.url) {
-      // the thumbnail
-      return this.renderImage(previewImage, sourceURL, linkDescriptor, callOnTapExpand,
-        needsNSFWBlur, true, playableType);
-    }
-
-    // handles:
-    //  * image preview of playabe image / video
-    //  * a gif that we're playing ourselves with html5 video or inline
-    if (playableType !== PLAYABLE_TYPE.NOT_PLAYABLE
-          && previewImage && this.useOurOwnPlayingOrPreviewing(oembed, sourceURL)) {
-      // if compact, preview should expand to full content
-      // if card mode, content should start playing
-      const callback = isCompact ? callOnTapExpand : this.togglePlaying;
-      return this.buildImagePreview(previewImage, sourceURL, linkDescriptor,
-        callback, needsNSFWBlur, isCompact, playableType);
-    }
-
-    if (oembed) {
-      return this.buildMediaPreview(post, sourceURL, oembed);
-    }
-
-    if (previewImage) {
-      const callback = isNSFW ? e => { e.preventDefault(); this.props.toggleShowNSFW(); } : null;
-      return this.buildImagePreview(
-        previewImage, sourceURL, linkDescriptor, callback, needsNSFWBlur, isCompact, playableType);
-    }
-  }
-
-  buildImagePreview(previewImage, imageURL, linkDescriptor, callback, needsNSFWBlur,
-      isCompact, playableType) {
-    const html5sources = gifToHTML5Sources(imageURL, previewImage.url);
-    const { single } = this.props;
-
-    if (this.state.playing && html5sources) {
-      const aspectRatio = this.getAspectRatio(single, previewImage.width, previewImage.height);
-
-      if (html5sources.iframe) {
-        return this.renderIframe(html5sources.iframe, aspectRatio);
-      }
-
-      const generatedSrc = {
-        webm: html5sources.webm,
-        mp4: html5sources.mp4,
-        width: previewImage.width,
-        height: previewImage.height,
-      };
-
-      return this.renderVideo(generatedSrc, html5sources.poster, aspectRatio);
-    }
-
-    return this.renderImage(previewImage, imageURL, linkDescriptor, callback,
-      needsNSFWBlur, isCompact, playableType);
-  }
-
-  buildMediaPreview(post, sourceURL, oembed) {
-    const { single } = this.props.single;
-    const aspectRatio = this.getAspectRatio(single, oembed.width, oembed.height);
-
-    switch (oembed.type) {
-      case 'image':
-        return this.renderIframe(sourceURL, aspectRatio);
-      case 'video':
-        return this.renderRawHTML(post.expandedContent, aspectRatio);
-      case 'rich':
-        return this.renderRichOembed(oembed.html, aspectRatio);
-    }
-  }
-
-  renderRichOembed(oembedHtml, aspectRatio) {
-    const findSrc = oembedHtml.match(/src="([^"]*)/);
-
-    if (findSrc && findSrc[1]) {
-      const frameUrl = findSrc[1].replace('&amp;', '&');
-      return this.renderIframe(frameUrl, aspectRatio);
-    }
-  }
-
-  renderImage(previewImage, imageURL, linkDescriptor, onClick, needsNSFWBlur,
-      isCompact, playableType) {
-    let playbackControlNode;
-    if (playableType && !needsNSFWBlur) {
-      playbackControlNode = this.renderPlaybackIcon(playableType, isCompact);
-    }
-
-    let nsfwNode;
-    if (needsNSFWBlur) {
-      nsfwNode = this.renderNSFWWarning(isCompact);
-    }
-
-    const { single } = this.props;
-    const aspectRatio = this.getAspectRatio(single, previewImage.width, previewImage.height);
-
-    if (previewImage && previewImage.url && !aspectRatio) {
-      return this.renderImageOfUnknownSize(
-        previewImage.url, linkDescriptor, onClick, playbackControlNode, nsfwNode);
-    }
-
-    return this.renderImageWithAspectRatio(previewImage, imageURL, linkDescriptor,
-      aspectRatio, onClick, isCompact, playbackControlNode, nsfwNode);
-  }
-
-  baseImageLinkClass(imageUrl, hasNSFWBlur) {
-    return `PostContent__image-link ${hasNSFWBlur && !imageUrl ? 'placeholder' :''}`;
-  }
-
-  renderImageOfUnknownSize(imageURL, linkDescriptor, onClick, playbackControlNode, nsfwNode) {
-    const linkClass = this.baseImageLinkClass(imageURL, !!nsfwNode);
-    return (
-      <OutboundLink
-        className={ linkClass }
-        href={ linkDescriptor.url }
-        target={ this.props.showLinksInNewTab ? '_blank' : null }
-        onClick={ onClick }
-        outboundLink={ this.props.post.outboundLink }
-      >
-        <img className='PostContent__image-img' src={ imageURL } />
-        { playbackControlNode }
-        { nsfwNode }
-      </OutboundLink>
-    );
-  }
-
-  renderImageWithAspectRatio(previewImage, imageURL, linkDescriptor, aspectRatio,
-      onClick, isCompact, playbackControlNode, nsfwNode) {
-    const { forceHTTPS } = this.props;
-
-    const style = {};
-
-    if (previewImage.url) {
-      const giphyPosterHref = posterForHrefIfGiphyCat(imageURL);
-      const backgroundImage = giphyPosterHref && !nsfwNode ? giphyPosterHref : previewImage.url;
-      style.backgroundImage = `url("${forceProtocol(backgroundImage, forceHTTPS)}")`;
-    }
-
-    let linkClass = this.baseImageLinkClass(previewImage.url, !!nsfwNode);
-    if (!isCompact) {
-      linkClass += ` ${aspectRatioClass(aspectRatio)}`;
-    }
-
-    const isPlaying = this.state.playing && playbackControlNode; // make sure we're
-    // really playing as opposed to showing the expanded compact version of the image
-    return (
-      <OutboundLink
-        className={ linkClass }
-        href={ linkDescriptor.url }
-        target={ this.props.showLinksInNewTab ? '_blank' : null }
-        onClick={ onClick }
-        style={ style }
-        outboundLink={ this.props.post.outboundLink }
-      >
-        { isPlaying
-          ? <img className='PostContent__inline-gif' src={ imageURL } />
-          : playbackControlNode }
-        { nsfwNode }
-      </OutboundLink>
-    );
-  }
-
-  renderIframe(src, aspectRatio) {
-    return (
-      <div className={ `PostContent__iframe-wrapper ${aspectRatioClass(aspectRatio)}` } >
-        <iframe
-          className='PostContent__iframe'
-          src={ src }
-          frameBorder='0'
-          allowFullScreen=''
-          sandbox='allow-scripts allow-forms allow-same-origin'
-        />
-      </div>
-    );
-  }
-
-  renderVideo(videoSpec, posterImage, aspectRatio) {
-    return (
-      <div className={ `PostContent__video-wrapper ${aspectRatioClass(aspectRatio)}` } >
-        <video
-          className='PostContent__video'
-          poster={ posterImage }
-          loop='true'
-          muted='true'
-          controls='true'
-          autoPlay='true'
-          ref={ autoPlayGif }
-        >
-          { this.buildVideoSources(videoSpec) }
-        </video>
-      </div>
-    );
-  }
-
-  buildVideoSources(videoSpec) {
-    const sources = [];
-    ['mp4', 'webm'].forEach(function(videoType) {
-      const source = videoSpec[videoType];
-      if (source) {
-        sources.push(
-          <source
-            key={ `video-src-${videoType}` }
-            type={ `video/${videoType}` }
-            src={ source }
-          />
-        );
-      }
-    });
-
-    return sources;
-  }
-
-  renderRawHTML(htmlContent, aspectRatio) {
-    return (
-      <RedditLinkHijacker>
-        <div
-          className={ `PostContent__html ${aspectRatioClass(aspectRatio)}` }
-          dangerouslySetInnerHTML={ { __html: htmlContent } }
-        />
-      </RedditLinkHijacker>
-    );
-  }
-
-  renderPlaybackIcon(playableType, isCompact) {
-    if (playableType === PLAYABLE_TYPE.NOT_PLAYABLE) {
-      return;
-    }
-
-    let iconCls = 'PostContent__playback-action-icon darkgrey';
-
-    if (playableType === PLAYABLE_TYPE.GALLERY) {
-      iconCls += ' icon icon-gallery_squares';
-    } else if (playableType === PLAYABLE_TYPE.INLINE) {
-      iconCls += ' icon icon-play_triangle';
-    }
-
-    const buttonCls = `PostContent__playback-action-circle  ${isCompact ? 'compact' : 'regular'}`;
-
-    return (
-      <div className={ buttonCls }>
-        <span className={ iconCls } />
-      </div>
-    );
-  }
-
-  renderLinkBar(displayText, href) {
-    const target = this.props.showLinksInNewTab ? '_blank' : null;
-
-    return (
-      <OutboundLink
-        className='PostContent__link-bar'
-        href={ href }
-        target={ target }
-        outboundLink={ this.props.post.outboundLink }
-      >
-        <span className='PostContent__link-bar-text'>{ displayText }</span>
-        <span className='PostContent__link-bar-icon icon icon-linkout blue' />
-      </OutboundLink>
-    );
-  }
-
-  renderNSFWWarning(isCompact) {
-    if (isCompact) {
-      return (
-        <div className='PostContent__nsfw-warning'>
-          <p className='PostContent__nsfw-warning-text'>NSFW</p>
-        </div>
-      );
-    }
-
-    return (
-      <div className='PostContent__nsfw-warning'>
-        <p className='PostContent__nsfw-warning-text'>This post is marked as NSFW</p>
-        <p className='PostContent__nsfw-warning-button'>Show Post?</p>
-      </div>
-    );
-  }
 }

--- a/src/app/components/Post/mediaUtils.js
+++ b/src/app/components/Post/mediaUtils.js
@@ -100,7 +100,7 @@ export function findPreviewVideo(preview) {
   return largestFirst[0];
 }
 
-function findBestFitPreviewImage(isCompact, previewImage, imageWidth, needsNSFWBlur) {
+function findBestFitPreviewImage(isThumbnail, previewImage, imageWidth, needsNSFWBlur) {
   if (needsNSFWBlur) {
     // for logged out users and users who have the 'make safer for work'
     // option enabled there will be no nsfw variants returned.
@@ -118,7 +118,7 @@ function findBestFitPreviewImage(isCompact, previewImage, imageWidth, needsNSFWB
         return a.width - b.width;
       })
       .find((r) => {
-        if (isCompact) {
+        if (isThumbnail) {
           return r.width >= imageWidth && r.height >= imageWidth;
         }
 

--- a/src/app/reducers/index.js
+++ b/src/app/reducers/index.js
@@ -23,6 +23,7 @@ import moreCommentsRequests from './moreCommentsRequests';
 import optOuts from './optOuts';
 import overlay from './overlay';
 import pageMetadata from './pageMetadata';
+import playingPosts from './playingPosts';
 import posting from './posting';
 import posts from './posts';
 import postsLists from './postsLists';
@@ -75,6 +76,7 @@ export default {
   optOuts,
   overlay,
   pageMetadata,
+  playingPosts,
   posting,
   posts,
   postsLists,

--- a/src/app/reducers/playingPosts.js
+++ b/src/app/reducers/playingPosts.js
@@ -1,0 +1,54 @@
+import * as postActions from 'app/actions/posts';
+import { SET_PAGE, GOTO_PAGE_INDEX } from '@r/platform/actions';
+import { removePrefix } from 'lib/eventUtils';
+
+export const DEFAULT = {};
+
+export default function(state=DEFAULT, action={}) {
+  switch (action.type) {
+    case GOTO_PAGE_INDEX: {
+      return DEFAULT;
+    }
+
+    case SET_PAGE: {
+      const postId = action.payload.urlParams.postId;
+      // Adam 12/2016: only do this if not on ios since it will autoexpand.
+      // We can remove this for ios10 and up when we are on react >= v15.3.2
+      // the navigator check is done here to avoid changing the SET_PAGE action
+      if (postId && typeof window === 'object' && window.navigator) {
+        const iOS = /iPad|iPhone|iPod/i.test(navigator.userAgent) && !window.MSStream;
+        if (state[postId] && !iOS) {
+          return { [postId]: true };
+        }
+      }
+      return DEFAULT;
+    }
+
+    case postActions.START_PLAYING: {
+      const postId = removePrefix(action.thingId);
+      const currentlyPlaying = state[postId];
+
+      if (currentlyPlaying) {
+        return state;
+      }
+
+      return {
+        ...state,
+        [postId]: true,
+      };
+    }
+
+    case postActions.STOP_PLAYING: {
+      const postId = removePrefix(action.thingId);
+      if (state[postId]) {
+        const nextState = { ...state };
+        delete nextState[postId];
+        return nextState;
+      }
+
+      return state;
+    }
+
+    default: return state;
+  }
+}

--- a/src/app/reducers/playingPosts.test.js
+++ b/src/app/reducers/playingPosts.test.js
@@ -1,0 +1,64 @@
+import createTest from '@r/platform/createTest';
+import * as platformActions from '@r/platform/actions';
+import * as postActions from 'app/actions/posts';
+
+import routes from 'app/router';
+
+import playingPosts, { DEFAULT } from './playingPosts';
+
+createTest({ reducers: { playingPosts }, routes }, ({ getStore, expect }) => {
+  describe('playingPosts', () => {
+    describe('GOTO_PAGE_INDEX', () => {
+      it('should reset PlayingPosts to default', () => {
+        const { store } = getStore({ playingPosts: { 'id23e': true }});
+
+        store.dispatch(platformActions.gotoPageIndex());
+        const { playingPosts } = store.getState();
+        expect(playingPosts).to.eql(DEFAULT);
+      });
+    });
+
+    describe('SET_PAGE', () => {
+      it('should reset state to a blank object', () => {
+        const { store } = getStore({ playingPosts: { 'id23e': true }});
+        
+        store.dispatch(platformActions.setPage('/', {}));
+        const { playingPosts } = store.getState();
+        expect(playingPosts).to.eql(DEFAULT);
+      });
+
+      it('should leave post playing state if user is going to comment page', () => {
+        const postId = 'id23e';
+        const playingState = { [postId]: true };
+        const { store } = getStore({ playingPosts: playingState });
+
+        store.dispatch(platformActions.setPage(`/comments/${postId}`, { urlParams: { postId: postId }}));
+        const { playingPosts } = store.getState();
+        expect(playingPosts).to.eql(playingState);
+      });
+    });
+
+    describe('START_PLAYING', () => {
+      it('should add post id to playingPosts if not present', () => {
+        const postId = 'id23e';
+        const { store } = getStore({ playingPosts: {}});
+
+        store.dispatch(postActions.startPlaying(postId));
+        const { playingPosts } = store.getState();
+        expect(playingPosts[postId]);
+      });
+    });
+
+    describe('STOP_PLAYING', () => {
+      it('should remove id from playingPosts if it is present', () => {
+        const postId = 'id23e';
+        const { store } = getStore({ playingPosts: { [postId]: true }});
+
+        store.dispatch(postActions.stopPlaying(postId));
+        const { playingPosts } = store.getState();
+        expect(playingPosts).to.eql(DEFAULT);
+      });
+    });
+  });
+});
+

--- a/src/lib/eventUtils.js
+++ b/src/lib/eventUtils.js
@@ -11,9 +11,12 @@ import * as gtm from 'lib/gtm';
 
 const ID_REGEX = /(?:t\d+_)?(.*)/;
 
+export function removePrefix(prefixedId) {
+  return ID_REGEX.exec(prefixedId)[1];
+}
+
 export function convertId(id) {
-  const unprefixedId = ID_REGEX.exec(id)[1];
-  return parseInt(unprefixedId, 36);
+  return parseInt(removePrefix(id), 36);
 }
 
 


### PR DESCRIPTION
[CONT-4](https://reddit.atlassian.net/browse/CONT-4)


**issue:**
This pull request resolves the issue caused by gifs playing when users go back to the previous page. example: from a comment page back to a listing page where they had previously expanded several posts. The problem is all the gifs playing at once use up a lot of data and slow things down.

**solution:**
playing state was moved out of the postContent component into redux and also decoupled from expanded state.

**bonus:**
 this lets us keep playing the gifs seamlessly when a user taps on the comments page link after playing the gif (only relevant platforms like android that play video/gifs inline).


**concerns:**
1. since moved out the only state in postContent it was expedient to convert it to a pure functional component. This was a major refactor of the component. Several pre-existing bugs were discovered while refactoring. There is the possibility of new bugs being introduced so please test the various behaviors required by the postContent component other than playing. This component may be a good place to add some ui testing in the future too.
2. the logic to decide when to play or not turned out to be a teeny bit convoluted, there could be states where we get undesired behavior still. The reducer was tested and does handle the back button and links going back to the listing correctly ( removes the playing state on all posts )