### PR TITLE
Replace user activity routes with r2 equivalents.

### DIFF
--- a/src/app/components/UserProfileHeader/index.jsx
+++ b/src/app/components/UserProfileHeader/index.jsx
@@ -35,19 +35,19 @@ const UserProfileTabs = props => {
   return (
     <nav className='UserProfileHeader__tabs'>
       <UserProfileTab
-        href={ `/user/${userName}` }
+        href={ UserActivityHandler.activityUrl(userName, null) }
         icon='icon-user-account'
         text='ABOUT'
         selected={ currentActivity === undefined }
       />
       <UserProfileTab
-        href={ UserActivityHandler.activityURL(userName, POSTS_ACTIVITY) }
+        href={ UserActivityHandler.activityUrl(userName, POSTS_ACTIVITY) }
         icon='icon-posts'
         text='POSTS'
         selected={ currentActivity === POSTS_ACTIVITY }
       />
       <UserProfileTab
-        href={ UserActivityHandler.activityURL(userName, COMMENTS_ACTIVITY) }
+        href={ UserActivityHandler.activityUrl(userName, COMMENTS_ACTIVITY) }
         icon='icon-comment'
         text='COMMENTS'
         selected={ currentActivity === COMMENTS_ACTIVITY }

--- a/src/app/pages/AppMain.jsx
+++ b/src/app/pages/AppMain.jsx
@@ -143,6 +143,8 @@ const AppMain = props => {
                     component={ CommentsPage }
                   />
                   <Page url='/user/:userName/activity' component={ UserActivityPage } />
+                  <Page url='/user/:userName/comments' component={ UserActivityPage } />
+                  <Page url='/user/:userName/submitted' component={ UserActivityPage } />
                   <Page url='/user/:userName/gild' component={ UserProfilePage } />
                   <Page
                     url='/user/:userName/:savedOrHidden(saved|hidden)'

--- a/src/app/router/handlers/UserActivityReroute.js
+++ b/src/app/router/handlers/UserActivityReroute.js
@@ -1,0 +1,15 @@
+import { BaseHandler, METHODS } from '@r/platform/router';
+import * as platformActions from '@r/platform/actions';
+
+import UserActivityHandler from 'app/router/handlers/UserActivity';
+
+export default class UserActivityRerouteHandler extends BaseHandler {
+  async [METHODS.GET](dispatch, getState) {
+    const { platform: { currentPage }} = getState();
+    const { urlParams, queryParams } = currentPage;
+    const { userName } = urlParams;
+    const url = UserActivityHandler.activityUrl(userName, queryParams.activity);
+
+    dispatch(platformActions.redirect(url));
+  }
+}

--- a/src/app/router/index.js
+++ b/src/app/router/index.js
@@ -13,6 +13,7 @@ import SetOver18Handler from './handlers/SetOver18';
 import SubredditAboutPageHandler from './handlers/SubredditAboutPage';
 import ToggleSubredditSubscriptionHandler from './handlers/ToggleSubredditSubscription';
 import UserActivityHandler from './handlers/UserActivity';
+import UserActivityRerouteHandler from './handlers/UserActivityReroute';
 import UserProfilerHandler from './handlers/UserProfile';
 import DirectMessage from './handlers/DirectMessage';
 import Messages from './handlers/Messages';
@@ -41,9 +42,10 @@ export default [
   ['/comments/:postId/:postTitle/:commentId', CommentsPageHandler, { name: 'comments' }],
   ['/comments/:postId/:postTitle?', CommentsPageHandler, { name: 'comments' }],
   ['/comments', CommentsPageHandler],
-  ['/user/:userName/activity', UserActivityHandler],
+  ['/user/:userName/activity', UserActivityRerouteHandler],
   ['/user/:userName/gild', UserProfilerHandler],
   ['/user/:userName/:savedOrHidden(saved|hidden)', SavedAndHiddenHandler],
+  ['/user/:userName/:commentsOrSubmitted(comments|submitted)', UserActivityHandler],
   ['/user/:userName', UserProfilerHandler, { name: 'user' }],
   ['/live/*', LiveRedirectHandler ],
   ['/login', Login],


### PR DESCRIPTION
This changes the user comment and submission paths from `/user/wting/activity?activity=comments` to `/users/wting/comments`. Visitors hitting the old activity URLs will be forwarded to the replacements, and defaulting to the user's profile page if the activity is not understood.