### PR TITLE
GIF/video previews expand on click in compact mode

### DIFF
--- a/src/app/components/Post/PostContent/index.jsx
+++ b/src/app/components/Post/PostContent/index.jsx
@@ -283,7 +283,7 @@ export default class PostContent extends React.Component {
           && previewImage && this.useOurOwnPlayingOrPreviewing(oembed, sourceURL)) {
       // if compact, preview should expand to full content
       // if card mode, content should start playing
-      const callback = isCompact ? callOnTapExpand : this.togglePlaying
+      const callback = isCompact ? callOnTapExpand : this.togglePlaying;
       return this.buildImagePreview(previewImage, sourceURL, linkDescriptor,
         callback, needsNSFWBlur, isCompact, playableType);
     }

--- a/src/app/components/Post/PostContent/index.jsx
+++ b/src/app/components/Post/PostContent/index.jsx
@@ -267,7 +267,7 @@ export default class PostContent extends React.Component {
         onTapExpand(clickTarget);
       };
     }
- 
+
     const sourceURL = post.cleanUrl;
 
     if (isCompact && previewImage && previewImage.url) {
@@ -281,8 +281,11 @@ export default class PostContent extends React.Component {
     //  * a gif that we're playing ourselves with html5 video or inline
     if (playableType !== PLAYABLE_TYPE.NOT_PLAYABLE
           && previewImage && this.useOurOwnPlayingOrPreviewing(oembed, sourceURL)) {
+      // if compact, preview should expand to full content
+      // if card mode, content should start playing
+      const callback = isCompact ? callOnTapExpand : this.togglePlaying
       return this.buildImagePreview(previewImage, sourceURL, linkDescriptor,
-        this.togglePlaying, needsNSFWBlur, isCompact, playableType);
+        callback, needsNSFWBlur, isCompact, playableType);
     }
 
     if (oembed) {


### PR DESCRIPTION
👓  @nramadas @schwers

Previously, playable content previews in compact mode would start playing on click where the preview is. For compact mode, this means that video would play in the teeny-tiny space allotted for preview. Now, a click will expand the playable content for playback, like we do with inline images.