### PR TITLE
Change Post tool display

### DIFF
--- a/src/app/components/Comment/CommentDropdown/index.jsx
+++ b/src/app/components/Comment/CommentDropdown/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Dropdown, DropdownRow, DropdownLinkRow } from 'app/components/Dropdown';
+import { DropdownModal, DropdownRow, DropdownLinkRow } from 'app/components/Dropdown';
 
 const T = React.PropTypes;
 
@@ -15,12 +15,13 @@ export default function CommentDropdown(props) {
     onDelete,
     onToggleSave,
     onReportComment,
+    onToggleModal,
   } = props;
 
   const userIsAuthor = commentAuthor === username;
 
   return (
-    <Dropdown id={ id }>
+    <DropdownModal id={ id } onClick={ onToggleModal }>
       { userIsAuthor
         ? <DropdownRow icon='post_edit' text='Edit Comment' onClick={ onEdit }/>
         : null }
@@ -37,7 +38,7 @@ export default function CommentDropdown(props) {
       { username
         ? <DropdownRow onClick={ onReportComment } icon='flag' text='Report'/>
         : null }
-    </Dropdown>
+    </DropdownModal>
   );
 }
 
@@ -59,4 +60,5 @@ CommentDropdown.defaultProps = {
   onEdit: () => {},
   onDelete: () => {},
   onToggleSave: () => {},
+  onToggleModal: () => {},
 };

--- a/src/app/components/Comment/CommentTools/index.jsx
+++ b/src/app/components/Comment/CommentTools/index.jsx
@@ -1,6 +1,6 @@
 import './styles.less';
 import React from 'react';
-import { TooltipTarget } from '@r/widgets/tooltip';
+import { ModalTarget } from '@r/widgets/modal';
 
 import VotingBox from 'app/components/VotingBox';
 import CommentDropdown from '../CommentDropdown';
@@ -24,18 +24,19 @@ export default function CommentTools(props) {
     onDelete,
     onToggleSave,
     onReportComment,
+    onToggleModal,
   } = props;
 
-  const tooltipId = `comment-tooltip-${id}`;
+  const modalId = `comment-modal-${id}`;
 
   return (
     <div className='CommentTools'>
       { commentingDisabled ? null : renderReply(props) }
-      { renderSeashells(tooltipId) }
+      { renderSeashells(modalId) }
       { renderDivider(props) }
       { renderVote(id, score, scoreHidden, voteDirection, votingDisabled) }
-      { renderDropdown(tooltipId, permalinkUrl, commentAuthor, username, saved,
-                       onEdit, onDelete, onToggleSave, onReportComment) }
+      { renderDropdown(modalId, permalinkUrl, commentAuthor, username, saved,
+                       onEdit, onDelete, onToggleSave, onReportComment, onToggleModal) }
     </div>
   );
 }
@@ -55,6 +56,7 @@ CommentTools.propTypes = {
   onToggleSave: T.func,
   onReportComment: T.func.isRequired,
   onReplyOpen: T.func,
+  onToggleModal: T.func.isRequired,
 };
 
 CommentTools.defaultProps = {
@@ -67,6 +69,7 @@ CommentTools.defaultProps = {
   onDelete: () => {},
   onToggleSave: () => {},
   onToggleReply: () => {},
+  onToggleModal: () => {},
 };
 
 const renderReply = ({ commentReplying, onToggleReply }) => {
@@ -80,13 +83,12 @@ const renderReply = ({ commentReplying, onToggleReply }) => {
   );
 };
 
-const renderSeashells = tooltipId => (
-  <TooltipTarget
-    id={ tooltipId }
-    type={ TooltipTarget.TYPE.CLICK }
+const renderSeashells = modalId => (
+  <ModalTarget
+    id={ modalId }
   >
     <div className='CommentTools__more icon icon-seashells'/>
-  </TooltipTarget>
+  </ModalTarget>
 );
 
 const renderVote = (id, score, scoreHidden, voteDirection, votingDisabled) => (
@@ -113,6 +115,7 @@ const renderDropdown = (
   onDelete,
   onToggleSave,
   onReportComment,
+  onToggleModal,
 ) => (
   <CommentDropdown
     id={ tooltipId }
@@ -124,5 +127,6 @@ const renderDropdown = (
     onDelete={ onDelete }
     onToggleSave={ onToggleSave }
     onReportComment={ onReportComment }
+    onToggleModal={ onToggleModal }
   />
 );

--- a/src/app/components/Comment/index.jsx
+++ b/src/app/components/Comment/index.jsx
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 import { models } from '@r/api-client';
 import { Anchor } from '@r/platform/components';
+import { toggleModal } from '@r/widgets/modal';
 
 import mobilify from 'lib/mobilify';
 import * as replyActions from 'app/actions/reply';
@@ -134,6 +135,7 @@ function renderTools(props) {
     onToggleReply,
     commentingDisabled,
     votingDisabled,
+    onToggleModal,
   } = props;
 
   const className = cx('Comment__toolsContainer', 'clearfix', {
@@ -160,6 +162,7 @@ function renderTools(props) {
           onToggleReply={ onToggleReply }
           commentingDisabled={ commentingDisabled }
           votingDisabled={ votingDisabled }
+          onToggleModal={ onToggleModal }
         />
       </div>
     </div>
@@ -326,6 +329,7 @@ const mapDispatchToProps = (dispatch, { commentId }) => ({
     e.preventDefault();
     dispatch(replyActions.toggle(commentId));
   },
+  onToggleModal: () => dispatch(toggleModal(null)),
 });
 
 

--- a/src/app/components/Dropdown/index.jsx
+++ b/src/app/components/Dropdown/index.jsx
@@ -2,6 +2,7 @@ import './styles.less';
 import React from 'react';
 import { Anchor } from '@r/platform/components';
 import { Tooltip } from '@r/widgets/tooltip';
+import { Modal } from '@r/widgets/modal';
 
 import cx from 'lib/classNames';
 
@@ -24,6 +25,26 @@ export function Dropdown(props) {
 
 Dropdown.propTypes = {
   id: T.string.isRequired,
+};
+
+export function DropdownModal(props) {
+  return (
+    <div className='DropdownModalWrapper'>
+      <Modal
+        id={ props.id }
+        className='DropdownModal'
+      >
+        <div onClick={ props.onClick }>
+          { props.children }
+        </div>
+      </Modal>
+    </div>
+  );
+}
+
+DropdownModal.propTypes = {
+  id: T.string.isRequired,
+  onClick: T.func,
 };
 
 export function DropdownRow(props) {

--- a/src/app/components/Dropdown/styles.less
+++ b/src/app/components/Dropdown/styles.less
@@ -20,6 +20,32 @@
   }
 }
 
+.DropdownModal {
+  .themeify({
+    border: @theme-border;
+  });
+
+  @max-width: 600px;
+  @buffer: 200px;
+  max-width: 95%;
+  margin: auto;
+  position: absolute;
+  top: 30%;
+  bottom: auto;
+  left: 0;
+  right: 0;
+  overflow: scroll;
+
+  // if the viewport is larger than the modal,
+  @media(min-width: @max-width) {
+    top: @buffer;
+    bottom: auto;
+    left: 50%;
+    margin-left: -(@max-width / 2);
+    max-width: @max-width;
+  }
+}
+
 .DropdownRow,
 .DropdownLinkRow {
   @row-height: 50px;

--- a/src/app/components/Dropdown/styles.less
+++ b/src/app/components/Dropdown/styles.less
@@ -55,12 +55,6 @@
     background-color: @theme-body-color;
   });
 
-  & ~ & {
-    .themeify({
-      border-top: @theme-border;
-    });
-  }
-
   &__icon,
   &__text {
     display: inline-block;

--- a/src/app/components/Post/PostDropdown/index.jsx
+++ b/src/app/components/Post/PostDropdown/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Dropdown, DropdownRow, DropdownLinkRow } from 'app/components/Dropdown';
+import { DropdownModal, DropdownRow, DropdownLinkRow } from 'app/components/Dropdown';
 
 const T = React.PropTypes;
 
@@ -25,10 +25,11 @@ export default function PostDropdown(props) {
     onToggleHide,
     onReportPost,
     onToggleSave,
+    onToggleModal,
   } = props;
 
   return (
-    <Dropdown id={ id }>
+    <DropdownModal id={ id } onClick={ onToggleModal }>
       { canModify && <DropdownRow icon='post_edit' text='Edit Post' onClick={ onToggleEdit } /> }
       <DropdownLinkRow href={ permalink } icon='link' text='Permalink'/>
       { subreddit && renderSubredditDropdownLinkRow(subreddit) }
@@ -36,7 +37,7 @@ export default function PostDropdown(props) {
       { isLoggedIn ? <DropdownRow icon='save' text={ isSaved ? 'Saved' : 'Save' } onClick={ onToggleSave } isSelected={ isSaved }/> : null }
       { isLoggedIn ? <DropdownRow icon='hide' text='Hide' onClick={ onToggleHide }/> : null }
       { isLoggedIn ? <DropdownRow onClick={ onReportPost } icon='flag' text='Report'/> : null }
-    </Dropdown>
+    </DropdownModal>
   );
 }
 
@@ -52,6 +53,7 @@ PostDropdown.propTypes = {
   onToggleHide: T.func,
   onReportPost: T.func.isRequired,
   onToggleEdit: T.func,
+  onToggleModal: T.func,
 };
 
 PostDropdown.defaultProps = {
@@ -61,4 +63,5 @@ PostDropdown.defaultProps = {
   onToggleSave: () => {},
   onToggleHide: () => {},
   onToggleEdit: () => {},
+  onToggleModal: () => {},
 };

--- a/src/app/components/Post/PostFooter/index.jsx
+++ b/src/app/components/Post/PostFooter/index.jsx
@@ -2,7 +2,7 @@ import './styles.less';
 import React from 'react';
 import { Anchor } from '@r/platform/components';
 import { models } from '@r/api-client';
-import { TooltipTarget } from '@r/widgets/tooltip';
+import { ModalTarget } from '@r/widgets/modal';
 
 import PostDropdown from '../PostDropdown';
 import VotingBox from 'app/components/VotingBox';
@@ -26,6 +26,7 @@ export default class PostFooter extends React.Component {
     onDelete: T.func.isRequired,
     onToggleSave: T.func.isRequired,
     onElementClick: T.func.isRequired,
+    onToggleModal: T.func.isRequired,
   };
 
   constructor(props) {
@@ -83,6 +84,7 @@ export default class PostFooter extends React.Component {
       onToggleHide,
       onReportPost,
       single,
+      onToggleModal,
     } = this.props;
 
     const isLoggedIn = user && !user.loggedOut;
@@ -93,12 +95,11 @@ export default class PostFooter extends React.Component {
       <footer className={ `PostFooter ${compact ? 'size-compact' : ''}` }>
         { this.renderCommentsLink(post) }
         <div className='PostFooter__vote-and-tools-wrapper'>
-          <TooltipTarget
+          <ModalTarget
             id={ post.name }
-            type={ TooltipTarget.TYPE.CLICK }
           >
             <div className='PostFooter__dropdown-button PostFooter__hit-area icon icon-seashells'/>
-          </TooltipTarget>
+          </ModalTarget>
           <span className='PostFooter__vertical-divider' />
           <VotingBox
             thingId = { post.name }
@@ -120,6 +121,7 @@ export default class PostFooter extends React.Component {
           onToggleSave={ onToggleSave }
           onToggleHide={ onToggleHide }
           onReportPost={ onReportPost }
+          onToggleModal={ onToggleModal }
         />
       </footer>
     );

--- a/src/app/components/Post/index.jsx
+++ b/src/app/components/Post/index.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 import { models } from '@r/api-client';
+import { toggleModal } from '@r/widgets/modal';
 const { PostModel } = models;
 
 import * as modalActions from 'app/actions/modal';
@@ -57,6 +58,7 @@ Post.propTypes = {
   onToggleSavePost: T.func,
   onToggleHidePost: T.func,
   onReportPost: T.func.isRequired,
+  onToggleModal: T.func.isRequired,
 };
 
 Post.defaultProps = {
@@ -69,6 +71,7 @@ Post.defaultProps = {
   winWidth: 360,
   onToggleSavePost: () => {},
   onToggleHidePost: () => {},
+  onToggleModal: () => {},
 };
 
 export function Post(props) {
@@ -106,6 +109,7 @@ export function Post(props) {
     toggleShowNSFW,
     winWidth,
     z,
+    onToggleModal,
   } = props;
 
   const canExpand = post.preview && post.preview.images.length > 0 || !!post.oembed;
@@ -200,6 +204,7 @@ export function Post(props) {
         onToggleHide={ onToggleHidePost }
         onReportPost={ onReportPost }
         onElementClick={ onElementClick }
+        onToggleModal={ onToggleModal }
       />
     </article>
   );
@@ -246,6 +251,7 @@ const mapDispatchToProps = (dispatch, { postId }) => ({
   onToggleHidePost: () => dispatch(postActions.toggleHidePost(postId)),
   onReportPost: () => dispatch(reportingActions.report(postId)),
   onElementClick: () => dispatch(modalActions.showXpromoModal()),
+  onToggleModal: () => dispatch(toggleModal(null)),
 });
 
 export default connect(selector, mapDispatchToProps)(Post);


### PR DESCRIPTION
Previously, we were using a tooltip to show
actions like save, report, etc. We are moving
towards a new design that utilizes modals
instead, to make it easier to implement mod
tools with updated design in the future.

![screen shot 2016-12-13 at 2 24 51 pm](https://cloud.githubusercontent.com/assets/3656897/21161994/f7922abc-c13f-11e6-812a-ef7aa8e3d18b.png)
![screen shot 2016-12-13 at 2 24 37 pm](https://cloud.githubusercontent.com/assets/3656897/21161995/f7986e68-c13f-11e6-888b-fc7bb2b9745f.png)


https://reddit.atlassian.net/browse/CE-353