### PR TITLE
Check redirect cookie's value.

### DIFF
--- a/src/Server.js
+++ b/src/Server.js
@@ -117,8 +117,8 @@ export function startServer() {
       },
       async (ctx, next) => {
         await next();
-        const redirectToDesktop = !!ctx.cookies.get('mweb-no-redirect');
-        if (redirectToDesktop) {
+        const desktopPreferredCookie = ctx.cookies.get('mweb-no-redirect');
+        if (parseInt(desktopPreferredCookie, 10) === 1) {
           const path = urlParser.parse(ctx.url).path;
           ctx.redirect(config.reddit + path);
         }


### PR DESCRIPTION
In the past we only checked the presence of the cookie rather than the value. As a result, when we zero out the cookie it still redirects users.

:eyeglasses: @andytuba @schwers @telaviv 