### PR TITLE
Handle new login error types from the API

### DIFF
--- a/src/app/components/Login/index.jsx
+++ b/src/app/components/Login/index.jsx
@@ -6,7 +6,7 @@ import { createSelector } from 'reselect';
 import { METHODS } from '@r/platform/router';
 import { Form, Anchor, BackAnchor } from '@r/platform/components';
 
-import { loginErrors } from 'app/constants';
+import { loginErrors, genericErrors } from 'app/constants';
 
 import * as sessionActions from 'app/actions/session';
 
@@ -86,17 +86,27 @@ class Login extends React.Component {
 
     const error = { username: '', password: '' };
 
-    if (errorType === loginErrors.WRONG_PASSWORD) {
-      error.password = 'Sorry, that’s not the right password';
-    } else if (errorType === loginErrors.BAD_USERNAME) {
-      error.username = 'Sorry, that’s not a valid username';
-    } else if (errorType === loginErrors.INCORRECT_USERNAME_PASSWORD) {
-      // Use a zero-width space, so we have something truthy to trigger the
-      // clear-username button without having to show two messages.
-      error.username = '\u200B';
-      error.password = 'Sorry, that’s an incorrect username or password';
-    } else if (errorType) {
-      error.password = 'Sorry, we were unable to log you in';
+    switch (errorType) {
+      case loginErrors.WRONG_PASSWORD: {
+        error.password = 'Sorry, that’s not the right password';
+        break;
+      }
+
+      case loginErrors.BAD_USERNAME: {
+        error.username = 'Sorry, that’s not a valid username';
+        break;
+      }
+
+      case loginErrors.INCORRECT_USERNAME_PASSWORD: {
+        error.username = true;
+        error.password = 'Sorry, that’s an incorrect username or password';
+        break;
+      }
+
+      case genericErrors.UNKNOWN_ERROR: {
+        error.password = 'Sorry, we were unable to log you in';
+        break;
+      }
     }
 
     return (

--- a/src/app/components/Login/index.jsx
+++ b/src/app/components/Login/index.jsx
@@ -6,6 +6,8 @@ import { createSelector } from 'reselect';
 import { METHODS } from '@r/platform/router';
 import { Form, Anchor, BackAnchor } from '@r/platform/components';
 
+import { loginErrors } from 'app/constants';
+
 import * as sessionActions from 'app/actions/session';
 
 import goBackDest from 'lib/goBackDest';
@@ -83,8 +85,18 @@ class Login extends React.Component {
     const errorType = session ? session.error : null;
 
     const error = { username: '', password: '' };
-    if (errorType) {
+
+    if (errorType === loginErrors.WRONG_PASSWORD) {
       error.password = 'Sorry, that’s not the right password';
+    } else if (errorType === loginErrors.BAD_USERNAME) {
+      error.username = 'Sorry, that’s not a valid username';
+    } else if (errorType === loginErrors.INCORRECT_USERNAME_PASSWORD) {
+      // Use a zero-width space, so we have something truthy to trigger the
+      // clear-username button without having to show two messages.
+      error.username = '\u200B';
+      error.password = 'Sorry, that’s an incorrect username or password';
+    } else if (errorType) {
+      error.password = 'Sorry, we were unable to log you in';
     }
 
     return (

--- a/src/app/components/LoginRegistrationForm/Input.jsx
+++ b/src/app/components/LoginRegistrationForm/Input.jsx
@@ -1,5 +1,6 @@
 import './Input.less';
 import React from 'react';
+import isString from 'lodash/isString';
 
 import cx from 'lib/classNames';
 
@@ -22,7 +23,7 @@ function LoginInput(props) {
     'error': !!error,
     'show-top': showTopBorder,
   });
-  const errorMessage = error ? <p className='LoginInput__error-text'>{ error }</p> : null;
+  const errorMessage = isString(error) ? <p className='LoginInput__error-text'>{ error }</p> : null;
 
   return (
     <div>

--- a/src/app/constants.js
+++ b/src/app/constants.js
@@ -111,3 +111,9 @@ export const themes = {
 };
 
 export const LOGGEDOUT_REDIRECT = '/register';
+
+export const loginErrors = {
+  WRONG_PASSWORD: 'WRONG_PASSWORD',
+  BAD_USERNAME: 'BAD_USERNAME',
+  INCORRECT_USERNAME_PASSWORD: 'INCORRECT_USERNAME_PASSWORD',
+};

--- a/src/app/constants.js
+++ b/src/app/constants.js
@@ -117,3 +117,7 @@ export const loginErrors = {
   BAD_USERNAME: 'BAD_USERNAME',
   INCORRECT_USERNAME_PASSWORD: 'INCORRECT_USERNAME_PASSWORD',
 };
+
+export const genericErrors = {
+  UNKNOWN_ERROR: 'UNKNOWN_ERROR',
+};

--- a/src/server/session/loginproxy.js
+++ b/src/server/session/loginproxy.js
@@ -4,7 +4,7 @@ import { PrivateAPI } from '@r/private';
 import { logServerError } from 'lib/errorLog';
 import proxiedApiOptions from 'lib/proxiedApiOptions';
 
-import { loginErrors } from 'app/constants';
+import { loginErrors, genericErrors } from 'app/constants';
 
 
 export default (router, apiOptions) => {
@@ -29,7 +29,7 @@ export default (router, apiOptions) => {
       } else {
         // If we don't know the error type, we still want to convey to the
         // client that an error occurred.
-        ctx.body = { error: 'UNKNOWN_ERROR' };
+        ctx.body = { error: genericErrors.UNKNOWN_ERROR };
         logServerError(error, ctx);
       }
     }

--- a/src/server/session/loginproxy.js
+++ b/src/server/session/loginproxy.js
@@ -4,6 +4,8 @@ import { PrivateAPI } from '@r/private';
 import { logServerError } from 'lib/errorLog';
 import proxiedApiOptions from 'lib/proxiedApiOptions';
 
+import { loginErrors } from 'app/constants';
+
 
 export default (router, apiOptions) => {
   router.post('/loginproxy', async (ctx) => {
@@ -19,12 +21,15 @@ export default (router, apiOptions) => {
       // writeSessionToResponse will set the cookies
       writeSessionToResponse(ctx, data);
     } catch (error) {
-      // TODO: the errors we get back aren't helpful, in most cases we
-      // only get back 'WRONG_PASSWORD' even if the user field is blank
       ctx.status = 401;
-      if (error === 'WRONG_PASSWORD') {
+      if (error === loginErrors.WRONG_PASSWORD ||
+          error === loginErrors.BAD_USERNAME ||
+          error === loginErrors.INCORRECT_USERNAME_PASSWORD) {
         ctx.body = { error };
-      } else { // we're not sure what this error is, log it for now
+      } else {
+        // If we don't know the error type, we still want to convey to the
+        // client that an error occurred.
+        ctx.body = { error: 'UNKNOWN_ERROR' };
         logServerError(error, ctx);
       }
     }


### PR DESCRIPTION
We're adding new login error types to the API, so we need to recognize
them and issue appropriate user messages. We should also make sure the
client can indicate unknown error types.