### PR TITLE
Send correct referrer with events

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@r/build": "~0.10.0",
     "@r/flags": "^1.5.0",
     "@r/middleware": "~0.8.1",
-    "@r/platform": "~0.17.0",
+    "@r/platform": "~0.17.1",
     "@r/private": "0.4.0",
     "@r/redux-state-archiver": "~0.0.5",
     "@r/widgets": "~0.2.2",

--- a/src/lib/eventUtils.js
+++ b/src/lib/eventUtils.js
@@ -57,21 +57,26 @@ export function getUserInfoOrLoid(state) {
   };
 }
 
+function getDomain(referrer, meta) {
+  const x = url.parse(referrer);
+  return x.host || meta.domain;
+}
 
 export function getBasePayload(state) {
   // NOTE: this is only for usage on the client since it has references to window
-  const referrer = state.platform.currentPage.referrer || '';
+  const { platform, meta, compact, preferences } = state;
+  const referrer = platform.currentPage.referrer;
 
   const payload = {
-    domain: state.meta.domain,
-    geoip_country: state.meta.country,
-    user_agent: state.meta.userAgent,
-    base_url: state.platform.currentPage.url,
-    referrer_domain: url.parse(referrer).host || state.meta.domain,
+    domain: meta.domain,
+    geoip_country: meta.country,
+    user_agent: meta.userAgent,
+    base_url: platform.currentPage.url,
+    referrer_domain: referrer ? getDomain(referrer, meta) : '',
     referrer_url: referrer,
-    language: state.preferences.lang,
+    language: preferences.lang,
     dnt: !!window.DO_NOT_TRACK,
-    compact_view: state.compact,
+    compact_view: compact,
     adblock: hasAdblock(),
     ...getUserInfoOrLoid(state),
   };


### PR DESCRIPTION
Platform will now send a value indicating when the
user navigated directly to the site. We also now handle
internal navigation by building the referrer from the
current url/domain

**Solution**
I modified the function that initializes the currentPage for the 'first' page (the second on the stack technically) which sends a string indicating there was no referrer, we can then look for that in eventUtils and distinguish between empty referrer on first load vs on single page app routing changes.

**issues**
I get errors but I think they are related to running off a local version of @r/platform. if you have a local copy of platform set up please test. Otherwise we need to get someone who has it working correctly to test.

for [CONT-5](https://reddit.atlassian.net/browse/CONT-5) together with https://github.com/reddit/node-platform/pull/30 
