### PR TITLE
Chan 304 instrument interstitials

### DIFF
--- a/src/app/actions/smartBanner.js
+++ b/src/app/actions/smartBanner.js
@@ -1,4 +1,4 @@
-import { markBannerClosed, shouldShowBanner } from 'lib/smartBannerState';
+import { markXPromoClosed, shouldShowXPromo } from 'lib/smartBannerState';
 import { trackPreferenceEvent } from 'lib/eventUtils';
 
 export const SHOW = 'SMARTBANNER__SHOW';
@@ -18,7 +18,7 @@ const EXTERNAL_PREF_NAME = 'hide_mweb_xpromo_banner';
 // element is the interface element through which the user dismissed the
 // crosspromo experience.
 export const close = () => async (dispatch, getState) => {
-  markBannerClosed();
+  markXPromoClosed();
   dispatch(hide());
 
   // We use a separate externally-visible name/value for the preference for
@@ -33,7 +33,7 @@ export const close = () => async (dispatch, getState) => {
 };
 
 export const checkAndSet = () => async (dispatch) => {
-  if (shouldShowBanner()) {
+  if (shouldShowXPromo()) {
     dispatch(show());
   }
 };

--- a/src/app/components/DualPartInterstitial/index.jsx
+++ b/src/app/components/DualPartInterstitial/index.jsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { redirect } from '@r/platform/actions';
 
-import { markBannerClosed } from 'lib/smartBannerState';
+import { markXPromoClosed } from 'lib/smartBannerState';
 import * as smartBannerActions from 'app/actions/smartBanner';
 
 import XPromoWrapper from 'app/components/XPromoWrapper';
@@ -29,7 +29,7 @@ export function DualPartInterstitial(props) {
 const mapDispatchToProps = dispatch => ({
   onClose: () => dispatch(smartBannerActions.close()),
   navigator: (url) => (() => {
-    markBannerClosed();
+    markXPromoClosed();
     dispatch(redirect(url));
   }),
 });

--- a/src/app/components/DualPartInterstitial/modal.jsx
+++ b/src/app/components/DualPartInterstitial/modal.jsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { redirect } from '@r/platform/actions';
 
-import { markBannerClosed } from 'lib/smartBannerState';
+import { markXPromoClosed } from 'lib/smartBannerState';
 import * as smartBannerActions from 'app/actions/smartBanner';
 import * as modalActions from 'app/actions/modal';
 import XPromoWrapper from 'app/components/XPromoWrapper';
@@ -35,7 +35,7 @@ const mapDispatchToProps = dispatch => ({
     dispatch(smartBannerActions.close());
   },
   navigator: (url) => (() => {
-    markBannerClosed();
+    markXPromoClosed();
     dispatch(redirect(url));
   }),
 });

--- a/src/app/components/InterstitialPromo/index.jsx
+++ b/src/app/components/InterstitialPromo/index.jsx
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import { redirect } from '@r/platform/actions';
 
-import { markBannerClosed } from 'lib/smartBannerState';
+import { markXPromoClosed } from 'lib/smartBannerState';
 
 import { flags } from 'app/constants';
 import featureFlags from 'app/featureFlags';
@@ -157,7 +157,7 @@ const selector = createStructuredSelector({
 const mapDispatchToProps = dispatch => ({
   onClose: () => dispatch(smartBannerActions.close()),
   navigator: (url) => (() => {
-    markBannerClosed();
+    markXPromoClosed();
     dispatch(redirect(url));
   }),
 });

--- a/src/app/components/XPromoWrapper/index.jsx
+++ b/src/app/components/XPromoWrapper/index.jsx
@@ -17,11 +17,11 @@ class XPromoWrapper extends React.Component {
     // Indicate that we've displayed a crosspromotional UI, so we don't keep
     // showing them during this browsing session.
     this.props.recordXPromoShown();
-    window.addEventListener('scroll', this.onScroll);
+    window.addEventListener('scroll', this.onScroll.bind(this));
   }
 
   componentWillUnmount() {
-    window.removeEventListener('scroll', this.onScroll);
+    window.removeEventListener('scroll', this.onScroll.bind(this));
   }
 
   onScroll() {
@@ -30,7 +30,7 @@ class XPromoWrapper extends React.Component {
     // note the referencing of window
     if (window.pageYOffset > window.innerHeight / 2) {
       markXPromoScrolledPassed();
-      window.removeEventListener('scroll', this.onScroll);
+      window.removeEventListener('scroll', this.onScroll.bind(this));
     }
   }
 

--- a/src/app/components/XPromoWrapper/index.jsx
+++ b/src/app/components/XPromoWrapper/index.jsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 
 import * as smartBannerActions from 'app/actions/smartBanner';
-import { markXPromoScrolledPassed } from 'lib/smartBannerState';
+import { markXPromoScrolledPast } from 'lib/smartBannerState';
 
 
 const T = React.PropTypes;
@@ -26,10 +26,10 @@ class XPromoWrapper extends React.Component {
 
   onScroll() {
     // For now we will consider scrolling half the viewport
-    // "scrolling passed" the interstitial.
+    // "scrolling past" the interstitial.
     // note the referencing of window
     if (window.pageYOffset > window.innerHeight / 2) {
-      markXPromoScrolledPassed();
+      markXPromoScrolledPast();
       window.removeEventListener('scroll', this.onScroll.bind(this));
     }
   }

--- a/src/app/components/XPromoWrapper/index.jsx
+++ b/src/app/components/XPromoWrapper/index.jsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 
 import * as smartBannerActions from 'app/actions/smartBanner';
+import { markBannerScrolledPassed } from 'lib/smartBannerState';
 
 
 const T = React.PropTypes;
@@ -16,6 +17,20 @@ class XPromoWrapper extends React.Component {
     // Indicate that we've displayed a crosspromotional UI, so we don't keep
     // showing them during this browsing session.
     this.props.recordXPromoShown();
+    window.addEventListener('scroll', this.onScroll);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('scroll', this.onScroll);
+  }
+
+  onScroll() {
+    // For now we will consider scrolling half the viewport
+    // "scrolling passed" the interstitial.
+    // note the referencing of window
+    if (window.pageYOffset > window.innerHeight / 2) {
+      markBannerScrolledPassed();
+    }
   }
 
   render() {

--- a/src/app/components/XPromoWrapper/index.jsx
+++ b/src/app/components/XPromoWrapper/index.jsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 
 import * as smartBannerActions from 'app/actions/smartBanner';
-import { markBannerScrolledPassed } from 'lib/smartBannerState';
+import { markXPromoScrolledPassed } from 'lib/smartBannerState';
 
 
 const T = React.PropTypes;
@@ -29,7 +29,8 @@ class XPromoWrapper extends React.Component {
     // "scrolling passed" the interstitial.
     // note the referencing of window
     if (window.pageYOffset > window.innerHeight / 2) {
-      markBannerScrolledPassed();
+      markXPromoScrolledPassed();
+      window.removeEventListener('scroll', this.onScroll);
     }
   }
 

--- a/src/lib/eventUtils.js
+++ b/src/lib/eventUtils.js
@@ -9,7 +9,7 @@ import isFakeSubreddit from 'lib/isFakeSubreddit';
 import { getEventTracker } from 'lib/eventTracker';
 import localStorageAvailable from 'lib/localStorageAvailable';
 import * as gtm from 'lib/gtm';
-import { XPROMO_LAST_CLOSED, XPROMO_SCROLLED_PASSED } from 'lib/smartBannerState';
+import { XPROMO_LAST_CLOSED, XPROMO_SCROLLED_PAST } from 'lib/smartBannerState';
 
 const ID_REGEX = /(?:t\d+_)?(.*)/;
 
@@ -71,8 +71,8 @@ export function getBannerInfo() {
   if (localStorage.getItem(XPROMO_LAST_CLOSED)) {
     info.banner_closed = true;
   }
-  if (localStorage.getItem(XPROMO_SCROLLED_PASSED)) {
-    info.banner_scrolled_passed = true;
+  if (localStorage.getItem(XPROMO_SCROLLED_PAST)) {
+    info.banner_scrolled_past = true;
   }
   return info;
 }

--- a/src/lib/eventUtils.js
+++ b/src/lib/eventUtils.js
@@ -7,8 +7,9 @@ import { ADBLOCK_TEST_ID } from 'app/constants';
 import { isHidden } from 'lib/dom';
 import isFakeSubreddit from 'lib/isFakeSubreddit';
 import { getEventTracker } from 'lib/eventTracker';
+import localStorageAvailable from 'lib/localStorageAvailable';
 import * as gtm from 'lib/gtm';
-import { BANNER_LAST_CLOSED, BANNER_SCROLLED_PASSED } from 'lib/smartBannerState';
+import { XPROMO_LAST_CLOSED, XPROMO_SCROLLED_PASSED } from 'lib/smartBannerState';
 
 const ID_REGEX = /(?:t\d+_)?(.*)/;
 
@@ -64,13 +65,14 @@ function getDomain(referrer, meta) {
 }
 
 export function getBannerInfo() {
+  if (!localStorageAvailable()) { return; }
+
   const info = {};
-  console.log('scrolled passed', BANNER_SCROLLED_PASSED);
-  if (localStorage.getItem(BANNER_LAST_CLOSED)) {
-    info.banner_closed = 'true';
+  if (localStorage.getItem(XPROMO_LAST_CLOSED)) {
+    info.banner_closed = true;
   }
-  if (localStorage.getItem(BANNER_SCROLLED_PASSED)) {
-    info.banner_scrolled_passed = 'true';
+  if (localStorage.getItem(XPROMO_SCROLLED_PASSED)) {
+    info.banner_scrolled_passed = true;
   }
   return info;
 }
@@ -127,7 +129,7 @@ function trackCrawlEvent(state, additionalEventData) {
   const payload = {
     params_app: 'mweb',
     http_response_code: state.platform.currentPage.status,
-7    // (skrisman | 10.17.2016) consider how we can get a response_time here
+    // (skrisman | 10.17.2016) consider how we can get a response_time here
     // (skrisman | 10.17.2016) is there a concept like "server" that we have?
     crawler_name: crawler,
     method,

--- a/src/lib/eventUtils.js
+++ b/src/lib/eventUtils.js
@@ -8,6 +8,7 @@ import { isHidden } from 'lib/dom';
 import isFakeSubreddit from 'lib/isFakeSubreddit';
 import { getEventTracker } from 'lib/eventTracker';
 import * as gtm from 'lib/gtm';
+import { BANNER_LAST_CLOSED, BANNER_SCROLLED_PASSED } from 'lib/smartBannerState';
 
 const ID_REGEX = /(?:t\d+_)?(.*)/;
 
@@ -50,7 +51,7 @@ export function getUserInfoOrLoid(state) {
     };
   }
 
-  const loid = state.loid; 
+  const loid = state.loid;
   return {
     'loid': loid.loid,
     'loid_created': loid.loidCreated,
@@ -60,6 +61,18 @@ export function getUserInfoOrLoid(state) {
 function getDomain(referrer, meta) {
   const x = url.parse(referrer);
   return x.host || meta.domain;
+}
+
+export function getBannerInfo() {
+  const info = {};
+  console.log('scrolled passed', BANNER_SCROLLED_PASSED);
+  if (localStorage.getItem(BANNER_LAST_CLOSED)) {
+    info.banner_closed = 'true';
+  }
+  if (localStorage.getItem(BANNER_SCROLLED_PASSED)) {
+    info.banner_scrolled_passed = 'true';
+  }
+  return info;
 }
 
 export function getBasePayload(state) {
@@ -78,6 +91,7 @@ export function getBasePayload(state) {
     dnt: !!window.DO_NOT_TRACK,
     compact_view: compact,
     adblock: hasAdblock(),
+    ...getBannerInfo(),
     ...getUserInfoOrLoid(state),
   };
 
@@ -113,7 +127,7 @@ function trackCrawlEvent(state, additionalEventData) {
   const payload = {
     params_app: 'mweb',
     http_response_code: state.platform.currentPage.status,
-    // (skrisman | 10.17.2016) consider how we can get a response_time here
+7    // (skrisman | 10.17.2016) consider how we can get a response_time here
     // (skrisman | 10.17.2016) is there a concept like "server" that we have?
     crawler_name: crawler,
     method,

--- a/src/lib/smartBannerState.js
+++ b/src/lib/smartBannerState.js
@@ -6,8 +6,9 @@ import { getDevice, IOS_DEVICES, ANDROID } from 'lib/getDeviceFromState';
 import * as constants from 'app/constants';
 import features from 'app/featureFlags';
 
-export const BANNER_LAST_CLOSED = 'bannerLastClosed';
-export const BANNER_SCROLLED_PASSED = 'bannerScrollPassed';
+// this is set to bannerLastClosed for legacy reasons.
+export const XPROMO_LAST_CLOSED = 'bannerLastClosed';
+export const XPROMO_SCROLLED_PASSED = 'xPromoScrollPassed';
 
 const TWO_WEEKS = 2 * 7 * 24 * 60 * 60 * 1000;
 
@@ -94,7 +95,7 @@ export function getDeepLink(state) {
   }
 }
 
-export function shouldShowBanner() {
+export function shouldShowXPromo() {
   // Most of the decision for showing a cross-promo component will happen in
   // the featureFlags component, but we have a couple of things to consider
   // here.
@@ -113,15 +114,15 @@ export function shouldShowBanner() {
   return true;
 }
 
-export function markBannerClosed() {
-  if (!localStorageAvailable()) { return false; }
+export function markXPromoClosed() {
+  if (!localStorageAvailable()) { return; }
 
   // note that we dismissed the banner
-  localStorage.setItem(BANNER_LAST_CLOSED, new Date());
+  localStorage.setItem(XPROMO_LAST_CLOSED, new Date());
 }
 
-export function markBannerScrolledPassed() {
-  if (!localStorageAvailable()) { return false; }
+export function markXPromoScrolledPassed() {
+  if (!localStorageAvailable()) { return; }
 
-  localStorage.setItem(BANNER_SCROLLED_PASSED, true);
+  localStorage.setItem(XPROMO_SCROLLED_PASSED, true);
 }

--- a/src/lib/smartBannerState.js
+++ b/src/lib/smartBannerState.js
@@ -8,7 +8,7 @@ import features from 'app/featureFlags';
 
 // this is set to bannerLastClosed for legacy reasons.
 export const XPROMO_LAST_CLOSED = 'bannerLastClosed';
-export const XPROMO_SCROLLED_PAST = 'xPromoScrollPassed';
+export const XPROMO_SCROLLED_PAST = 'xPromoScrollPast';
 
 const TWO_WEEKS = 2 * 7 * 24 * 60 * 60 * 1000;
 
@@ -121,7 +121,7 @@ export function markXPromoClosed() {
   localStorage.setItem(XPROMO_LAST_CLOSED, new Date());
 }
 
-export function markXPromoScrolledPassed() {
+export function markXPromoScrolledPast() {
   if (!localStorageAvailable()) { return; }
 
   localStorage.setItem(XPROMO_SCROLLED_PAST, true);

--- a/src/lib/smartBannerState.js
+++ b/src/lib/smartBannerState.js
@@ -8,7 +8,7 @@ import features from 'app/featureFlags';
 
 // this is set to bannerLastClosed for legacy reasons.
 export const XPROMO_LAST_CLOSED = 'bannerLastClosed';
-export const XPROMO_SCROLLED_PASSED = 'xPromoScrollPassed';
+export const XPROMO_SCROLLED_PAST = 'xPromoScrollPassed';
 
 const TWO_WEEKS = 2 * 7 * 24 * 60 * 60 * 1000;
 
@@ -124,5 +124,5 @@ export function markXPromoClosed() {
 export function markXPromoScrolledPassed() {
   if (!localStorageAvailable()) { return; }
 
-  localStorage.setItem(XPROMO_SCROLLED_PASSED, true);
+  localStorage.setItem(XPROMO_SCROLLED_PAST, true);
 }

--- a/src/lib/smartBannerState.js
+++ b/src/lib/smartBannerState.js
@@ -6,6 +6,9 @@ import { getDevice, IOS_DEVICES, ANDROID } from 'lib/getDeviceFromState';
 import * as constants from 'app/constants';
 import features from 'app/featureFlags';
 
+export const BANNER_LAST_CLOSED = 'bannerLastClosed';
+export const BANNER_SCROLLED_PASSED = 'bannerScrollPassed';
+
 const TWO_WEEKS = 2 * 7 * 24 * 60 * 60 * 1000;
 
 const { USE_BRANCH } = constants.flags;
@@ -114,5 +117,11 @@ export function markBannerClosed() {
   if (!localStorageAvailable()) { return false; }
 
   // note that we dismissed the banner
-  localStorage.setItem('bannerLastClosed', new Date());
+  localStorage.setItem(BANNER_LAST_CLOSED, new Date());
+}
+
+export function markBannerScrolledPassed() {
+  if (!localStorageAvailable()) { return false; }
+
+  localStorage.setItem(BANNER_SCROLLED_PASSED, true);
 }


### PR DESCRIPTION
The goal of this PR to include two new fields for the screenview payload. One about if an interstitial has been closed and one about if an interstitial was scrolled passed. I chose 50% of the viewport to be considered a 'scroll passed event'. Not sure if this the best idea but it seems like at 50% they really meant to just get out of that interstitial. 

Justin requested simply adding the value of true to these properties. Given that, my implementation of the scroll passed storage is simply idempotently setting true whenever the event happens. On desktop these events happen very very very often. On mobile though, they happen only when a user's finger releases from the screen. 