### PR TITLE
Fix duplicate images being rendered behind gifs while playing

### DIFF
--- a/src/app/components/Post/PostContent/index.jsx
+++ b/src/app/components/Post/PostContent/index.jsx
@@ -184,7 +184,9 @@ function buildMediaContent(post, linkDescriptor, props) {
       e.preventDefault();
       const clickTarget = 'thumbnail';
       onTapExpand(clickTarget);
-      togglePlaying();
+      if (playableType !== PLAYABLE_TYPE.NOT_PLAYABLE) {
+        togglePlaying();
+      }
     };
   }
 
@@ -331,7 +333,7 @@ function renderImageWithAspectRatio(previewImage, imageURL, linkDescriptor,
 
   const style = {};
 
-  if (previewImage.url) {
+  if (previewImage.url && !isPlaying) {
     const giphyPosterHref = posterForHrefIfGiphyCat(imageURL);
     const backgroundImage = giphyPosterHref && !nsfwNode ?
       giphyPosterHref : previewImage.url;


### PR DESCRIPTION
problem: while in playing state gif posts had the image rendered behind the playing gif. Also images were being rendered with both the image tag and the css background image. 

solution: We now don't change playing state for things that are not playable. We also check to make sure we are not playing before rendering the preview image as a background image.

👓 @schwers 