### PR TITLE
Spoilers and NSFW Refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:watch": "npm run test -- -w"
   },
   "dependencies": {
-    "@r/api-client": "3.31.0",
+    "@r/api-client": "3.32.1",
     "@r/build": "~0.10.0",
     "@r/flags": "^1.5.0",
     "@r/middleware": "~0.8.1",

--- a/src/app/components/Post/PostContent/styles.less
+++ b/src/app/components/Post/PostContent/styles.less
@@ -135,7 +135,7 @@
     }
   }
 
-  &__nsfw-warning {
+  &__warning {
     .display-flex;
     .flex-direction(column);
     .justify-content(center);
@@ -147,8 +147,8 @@
     width: 100%;
   }
 
-  &__nsfw-warning-text,
-  &__nsfw-warning-button {
+  &__warning-text,
+  &__warning-button {
     color: @white;
     font-size: 18px;
     max-width: 300px;
@@ -156,7 +156,7 @@
     margin: 5px 0;
   }
 
-  &__nsfw-warning-button {
+  &__warning-button {
     line-height: 0;
     width: 100%;
     border-radius: 3px;

--- a/src/app/components/Post/PostHeader/index.jsx
+++ b/src/app/components/Post/PostHeader/index.jsx
@@ -29,6 +29,12 @@ const NSFW_FLAIR = (
   </span>
 );
 
+const SPOILER_FLAIR = (
+  <span className='PostHeader__spoiler-text'>
+    SPOILER
+  </span>
+);
+
 const STICKY_FLAIR = (
   <span className='icon icon-sticky green' />
 );
@@ -158,11 +164,12 @@ function renderPostFlair(post, single) {
     gilded,
     locked,
     promoted,
+    spoiler,
   } = post;
 
   const showingGilded = gilded && single;
 
-  if (!(stickied || showingGilded || locked || distinguished || isNSFW || promoted)) {
+  if (!(stickied || showingGilded || locked || distinguished || isNSFW || promoted || spoiler)) {
     return null;
   }
 
@@ -175,6 +182,7 @@ function renderPostFlair(post, single) {
       { distinguished === 'moderator' ? MOD_FLAIR : null }
       { distinguished === 'admin' ? ADMIN_FLAIR : null }
       { isNSFW ? NSFW_FLAIR : null }
+      { spoiler ? SPOILER_FLAIR : null }
       { promoted ? PROMOTED_FLAIR : null }
     </span>
   );

--- a/src/app/components/Post/PostHeader/styles.less
+++ b/src/app/components/Post/PostHeader/styles.less
@@ -175,7 +175,7 @@
       text-decoration: none;
     }
 
-    + .PostHeader__spoiler-text {
+    +.PostHeader__spoiler-text {
       margin-left: 5px;
     }
   }

--- a/src/app/components/Post/PostHeader/styles.less
+++ b/src/app/components/Post/PostHeader/styles.less
@@ -174,6 +174,23 @@
       color: @nsfw-salmon !important;
       text-decoration: none;
     }
+
+    + .PostHeader__spoiler-text {
+      margin-left: 5px;
+    }
+  }
+
+  &__spoiler-text {
+    background-color: @dark-grey;
+    padding: 2px 5px 2px 5px;
+    font-weight: bold;
+    color: @white;
+    border-radius: 3px 3px;
+
+    &, a, a:visited, a:hover {
+      font-size: 11px;
+      text-decoration: none;
+    }
   }
 
   &__post-title-line {

--- a/src/app/components/Post/index.jsx
+++ b/src/app/components/Post/index.jsx
@@ -53,6 +53,7 @@ Post.propTypes = {
   hideSubredditLabel: T.bool,
   hideWhen: T.bool,
   subredditIsNSFW: T.bool,
+  subredditShowSpoilers: T.bool,
   showOver18Interstitial: T.bool,
   single: T.bool,
   userActivityPage: T.bool,
@@ -70,6 +71,7 @@ Post.defaultProps = {
   hideSubredditLabel: false,
   single: false,
   subredditIsNSFW: false,
+  subredditShowSpoilers: false,
   showOver18Interstitial: false,
   winWidth: 360,
   onToggleSavePost: () => {},
@@ -90,6 +92,12 @@ export function Post(props) {
   const isAndroid = userAgent && /android/i.test(userAgent);
   const showLinksInNewTab = externalDomain && isAndroid;
   const showNSFW = props.subredditIsNSFW || props.unblurred;
+
+  // Spoilers differ from NSFW in that if a subreddit disables spoilers
+  // we should not render the spoiler treatment. If the preference is
+  // enabled we should show the spoiler treatment. We will also only show
+  // the unobfuscated image if the post has been unblurred.
+  const showSpoilers = props.subredditShowSpoilers && !props.unblurred;
 
   const {
     post,
@@ -150,6 +158,7 @@ export function Post(props) {
         width={ winWidth }
         toggleShowNSFW={ toggleShowNSFW }
         showNSFW={ showNSFW }
+        showSpoilers={ showSpoilers }
         editing={ false }
         forceHTTPS={ forceHTTPS }
         isDomainExternal={ externalDomain }
@@ -178,6 +187,7 @@ export function Post(props) {
         togglePlaying={ onTogglePlaying }
         width={ winWidth }
         showNSFW={ showNSFW }
+        showSpoilers={ showSpoilers }
         toggleShowNSFW={ toggleShowNSFW }
         forceHTTPS={ forceHTTPS }
         isDomainExternal={ externalDomain }

--- a/src/app/components/Post/mediaUtils.js
+++ b/src/app/components/Post/mediaUtils.js
@@ -41,10 +41,10 @@ export function aspectRatioClass(ratio) {
   return `aspect-ratio-${(w / lcd)}x${(_HEIGHT / lcd)}`;
 }
 
-export function findPreviewImage(isCompact, preview, thumbnail, oembed, width, needsNSFWBlur) {
+export function findPreviewImage(isCompact, preview, thumbnail, oembed, width, needsObfuscating) {
   const imageWidth = isCompact ? POST_COMPACT_THUMBNAIL_WIDTH : width;
 
-  if (isCompact && thumbnail && !needsNSFWBlur) {
+  if (isCompact && thumbnail && !needsObfuscating) {
     return {
       url: thumbnail,
       width: POST_COMPACT_THUMBNAIL_WIDTH,
@@ -55,7 +55,7 @@ export function findPreviewImage(isCompact, preview, thumbnail, oembed, width, n
   if (preview) {
     if (preview.images.length) {
       const bestFitPreviewImage = findBestFitPreviewImage(
-        isCompact, preview.images[0], imageWidth, needsNSFWBlur);
+        isCompact, preview.images[0], imageWidth, needsObfuscating);
 
       if (bestFitPreviewImage) {
         return bestFitPreviewImage;
@@ -64,7 +64,7 @@ export function findPreviewImage(isCompact, preview, thumbnail, oembed, width, n
   }
 
   if (oembed) {
-    return oembedPreviewImage(oembed, needsNSFWBlur);
+    return oembedPreviewImage(oembed, needsObfuscating);
   }
 }
 
@@ -100,12 +100,12 @@ export function findPreviewVideo(preview) {
   return largestFirst[0];
 }
 
-function findBestFitPreviewImage(isThumbnail, previewImage, imageWidth, needsNSFWBlur) {
-  if (needsNSFWBlur) {
+function findBestFitPreviewImage(isThumbnail, previewImage, imageWidth, needsObfuscating) {
+  if (needsObfuscating) {
     // for logged out users and users who have the 'make safer for work'
     // option enabled there will be no nsfw variants returned.
-    if (has(previewImage, 'variants.nsfw.resolutions')) {
-      previewImage = previewImage.variants.nsfw;
+    if (has(previewImage, 'variants.obfuscated.resolutions')) {
+      previewImage = previewImage.variants.obfuscated;
     } else {
       return {};
     }
@@ -135,8 +135,8 @@ function findBestFitPreviewImage(isThumbnail, previewImage, imageWidth, needsNSF
   }
 }
 
-function oembedPreviewImage(oembed, needsNSFWBlur) {
-  if (!needsNSFWBlur) {
+function oembedPreviewImage(oembed, needsObfuscating) {
+  if (!needsObfuscating) {
     return {
       url: oembed.thumbnail_url,
       width: oembed.thumbnail_width,

--- a/src/app/components/PostsList/index.jsx
+++ b/src/app/components/PostsList/index.jsx
@@ -35,6 +35,7 @@ PostsList.propTypes = {
   shouldPage: T.bool,
   forceCompact: T.bool,
   subredditIsNSFW: T.bool,
+  subredditSpoilersEnabled: T.bool,
   onPostClick: T.func,
 };
 
@@ -43,11 +44,12 @@ PostsList.defaultProps = {
   prevUrl: '',
   forceCompact: false,
   subredditIsNSFW: false,
+  subredditSpoilersEnabled: false,
   shouldPage: true,
 };
 
 const renderPostsList = props => {
-  const { postRecords, ad, adId, forceCompact, subredditIsNSFW, onPostClick } = props;
+  const { postRecords, ad, adId, forceCompact, subredditIsNSFW, subredditShowSpoilers, onPostClick } = props;
   const records = ad ? recordsWithAd(postRecords, ad) : postRecords;
 
   return records.map((postRecord, index) => {
@@ -57,6 +59,7 @@ const renderPostsList = props => {
       postId,
       forceCompact,
       subredditIsNSFW,
+      subredditShowSpoilers,
       key: `post-id-${postId}`,
       onPostClick,
     };

--- a/src/app/pages/Comments.jsx
+++ b/src/app/pages/Comments.jsx
@@ -18,6 +18,7 @@ import Loading from 'app/components/Loading';
 import RecommendedPosts from 'app/components/RecommendedPosts';
 import RecommendedSubreddits from 'app/components/RecommendedSubreddits';
 import SubNav from 'app/components/SubNav';
+import getSubreddit from 'lib/getSubredditFromState';
 
 import CommentsPageHandler from 'app/router/handlers/CommentsPage';
 import { paramsToCommentsPageId } from 'app/models/CommentsPage';
@@ -39,6 +40,7 @@ function CommentsPage(props) {
     postLoaded,
     onSortChange,
     onToggleReply,
+    spoilersEnabled,
   } = props;
 
   if (!postLoaded) {
@@ -52,7 +54,7 @@ function CommentsPage(props) {
   return (
     <div className='CommentsPage'>
       <SubNav />
-      <Post postId={ pageParams.id } single={ true } key='post' />
+      <Post postId={ pageParams.id } single={ true } subredditShowSpoilers={ spoilersEnabled } key='post' />
       <RecommendedPosts
         postId={ pageParams.id }
         postLoaded={ postLoaded }
@@ -129,10 +131,15 @@ const stateProps = createSelector(
     const pageParams = CommentsPageHandler.pageParamsToCommentsPageParams(props);
     return !!state.replying[pageParams.id];
   },
+  state => {
+    const subredditName = getSubreddit(state);
+    const subreddit = state.subreddits[subredditName];
+    return subreddit ? subreddit.spoilersEnabled : false;
+  },
   state => state.platform.currentPage,
   state => state.preferences,
   crawlerRequestSelector,
-  (commentsPage, post, isReplying, currentPage, preferences, isCrawlerRequest) => {
+  (commentsPage, post, isReplying, spoilersEnabled, currentPage, preferences, isCrawlerRequest) => {
     const postLoaded = !!post;
 
     return {
@@ -145,6 +152,7 @@ const stateProps = createSelector(
       isCrawlerRequest,
       postLoaded,
       op: postLoaded ? post.author : '',
+      spoilersEnabled,
     };
   },
 );

--- a/src/app/pages/PostsFromSubreddit.jsx
+++ b/src/app/pages/PostsFromSubreddit.jsx
@@ -88,6 +88,7 @@ export const PostsFromSubredditPage = connect(mapStateToProps)(props => {
       <PostsList
         postsListId={ postsListId }
         subredditIsNSFW={ !!subreddit && subreddit.over18 }
+        subredditShowSpoilers={ !!subreddit && subreddit.spoilersEnabled }
       />
     </div>
   );


### PR DESCRIPTION
JIRA Ticket: https://reddit.atlassian.net/browse/CE-152

As part of integrating spoilers into mweb we decided to refactor the NSFW flow to leverage the new obfuscated image previews returned by the r2 api (especially since we are looking to deprecate the `nsfw` key from the api response). Spoilers will follow the exact same pattern as NSFW images and posts on mweb.

**Screenshots**

*Listing View*
![screen shot 2017-01-11 at 11 48 33 am](https://cloud.githubusercontent.com/assets/7967787/21863852/eefe3b3c-d7f3-11e6-869e-55d1b0e2892c.png)

*Listing Expanded View*
![screen shot 2017-01-11 at 11 49 21 am](https://cloud.githubusercontent.com/assets/7967787/21863876/0ab8ed36-d7f4-11e6-8005-4a365f53335a.png)

*Comments Page*
![screen shot 2017-01-10 at 5 58 41 pm](https://cloud.githubusercontent.com/assets/7967787/21832234/7348c344-d75e-11e6-86e2-f3a356ac04e3.png)

*NSFW and Spoiler*
![screen shot 2017-01-10 at 7 06 39 pm](https://cloud.githubusercontent.com/assets/7967787/21833785/fcccee0c-d767-11e6-859b-56fe74783003.png)


