### PR TITLE
Fix nsfw preview image obfuscation from gfycat

### DIFF
--- a/src/app/components/Post/PostContent/index.jsx
+++ b/src/app/components/Post/PostContent/index.jsx
@@ -468,7 +468,9 @@ function renderLinkBar(displayText, href, showLinksInNewTab, outboundLink) {
 
 function renderWarning(isThumbnail, post) {
   if (isThumbnail) {
-    return;
+    return (
+      <div className='PostContent__warning' />
+    );
   }
 
   let obfuscationText;


### PR DESCRIPTION
nsfw gifs and media from gfycat were not getting obfuscated correctly, this patch fixes the issue and presents the obfuscated media preview as the thumbnail. 

:eyeglasses: @schwers 

cc: @powerlanguage  