### PR TITLE
Remove unused 'count' param from urls

### DIFF
--- a/src/app/components/PaginationButtons/index.jsx
+++ b/src/app/components/PaginationButtons/index.jsx
@@ -19,7 +19,6 @@ export const buildPrevUrl = (records, pagingPrefix='', currentQueryParams={}) =>
 
   if (page > 0) {
     const query = {
-      count: 25, // use the current params count if its defined
       ...currentQueryParams,
       page: page - 1,
       before: firstId,
@@ -35,7 +34,6 @@ export const buildNextUrl = (records, pagingPrefix='', currentQueryParams={}) =>
   const page = pageNumber(currentQueryParams);
 
   const query = {
-    count: 25,
     ...currentQueryParams,
     page: page + 1,
     after: lastId,


### PR DESCRIPTION
This makes it easier to glance up and see how much time you've
wasted browsing /r/all, as you can now see the page number in the
URL bar.

I had a grep for count and it doesn't look like anything actually
honours it.  On the desktop site, it is used to add numbers to the
left-hand-side, and is incremented whenever you page forwards or
back. On the mobile version, you have no number beside the posts,
and the 'count' param stays pointlessly set to whatever you type in
(including non-numeric values).