### PR TITLE
Fix modTool apiResponse status bug

### DIFF
--- a/src/app/actions/modTools.js
+++ b/src/app/actions/modTools.js
@@ -107,13 +107,12 @@ export const fetchModeratingSubreddits = () => async (dispatch, getState) => {
 
   const subredditsAlreadyFetched = (
     state.moderatingSubreddits.loading === true ||
-    state.moderatingSubreddits.responseCode === 200);
+    !!state.moderatingSubreddits.names);
 
   // don't make API call again
   if (subredditsAlreadyFetched) { return; }
 
   dispatch(fetchingSubs());
-
   try {
     const moderatingSubs = await ModeratingSubreddits.fetch(apiOptions);
     dispatch(receivedSubs(moderatingSubs.apiResponse));

--- a/src/app/reducers/moderatingSubreddits.js
+++ b/src/app/reducers/moderatingSubreddits.js
@@ -4,8 +4,8 @@ import * as loginActions from 'app/actions/login';
 
 const DEFAULT = {
   loading: false,
-  responseCode: null,
-  names: [],
+  error: null,
+  names: null,
 };
 
 export default function(state=DEFAULT, action={}) {
@@ -13,8 +13,8 @@ export default function(state=DEFAULT, action={}) {
     case modToolActions.FETCHING_MODERATING_SUBREDDITS: {
       const moderatingSubreddits = {
         loading: true,
-        responseCode: null,
-        names: [],
+        names: null,
+        error: null,
       };
       return merge(state, moderatingSubreddits);
     }
@@ -24,8 +24,8 @@ export default function(state=DEFAULT, action={}) {
       const moderatingSubredditNames = action.apiResponse.results.map(sr => sr.uuid);
       const moderatingSubreddits = {
         loading: false,
-        responseCode: action.apiResponse.response.status,
         names: moderatingSubredditNames,
+        error: null,
       };
       return merge(state, moderatingSubreddits);
     }
@@ -33,7 +33,7 @@ export default function(state=DEFAULT, action={}) {
     case modToolActions.FETCH_FAILED_MODERATING_SUBREDDITS: {
       const moderatingSubreddits = {
         loading: false,
-        responseCode: action.error.status,
+        error: action.error,
         names: [],
       };
       return merge(state, moderatingSubreddits);

--- a/src/app/reducers/moderatingSubreddits.test.js
+++ b/src/app/reducers/moderatingSubreddits.test.js
@@ -12,7 +12,7 @@ createTest({ reducers: { moderatingSubreddits } }, ({ getStore, expect }) => {
         const { store } = getStore({
           moderatingSubreddits: {
             names: ['test'],
-            responseCode: 200,
+            error: null,
             loading: false,
           },
         });
@@ -21,8 +21,8 @@ createTest({ reducers: { moderatingSubreddits } }, ({ getStore, expect }) => {
         const { moderatingSubreddits } = store.getState();
         expect(moderatingSubreddits).to.eql({
           loading: false,
-          responseCode: null,
-          names: [],
+          error: null,
+          names: null,
         });
       });
 
@@ -30,7 +30,7 @@ createTest({ reducers: { moderatingSubreddits } }, ({ getStore, expect }) => {
         const { store } = getStore({
           moderatingSubreddits: {
             names: ['test'],
-            responseCode: 200,
+            error: null,
             loading: false,
           },
         });
@@ -39,8 +39,8 @@ createTest({ reducers: { moderatingSubreddits } }, ({ getStore, expect }) => {
         const { moderatingSubreddits } = store.getState();
         expect(moderatingSubreddits).to.eql({
           loading: false,
-          responseCode: null,
-          names: [],
+          error: null,
+          names: null,
         });
       });
     });
@@ -49,8 +49,25 @@ createTest({ reducers: { moderatingSubreddits } }, ({ getStore, expect }) => {
       it('should not make API call if moderatingSubreddits exists in state', () => {
         const MODERATING_SUBREDDITS = {
           loading: false,
-          responseCode: 200,
+          error: null,
           names: ['test', 'test1'],
+        };
+
+        const { store } = getStore({
+          moderatingSubreddits: MODERATING_SUBREDDITS,
+        });
+
+        store.dispatch(modToolActions.fetchModeratingSubreddits());
+
+        const { moderatingSubreddits } = store.getState();
+        expect(moderatingSubreddits).to.equal(MODERATING_SUBREDDITS);
+      });
+
+      it('should not make API call if moderatingSubreddits is []', () => {
+        const MODERATING_SUBREDDITS = {
+          loading: false,
+          error: null,
+          names: [],
         };
 
         const { store } = getStore({
@@ -66,8 +83,8 @@ createTest({ reducers: { moderatingSubreddits } }, ({ getStore, expect }) => {
       it('should fetch moderatingSubreddits for a user', () => {
         const MODERATING_SUBREDDITS = {
           loading: false,
-          responseCode: null,
-          names: [],
+          error: null,
+          names: null,
         };
 
         const { store } = getStore({
@@ -79,8 +96,8 @@ createTest({ reducers: { moderatingSubreddits } }, ({ getStore, expect }) => {
         const { moderatingSubreddits } = store.getState();
         expect(moderatingSubreddits).to.eql(merge(moderatingSubreddits, {
           loading: true,
-          responseCode: null,
-          names: [],
+          error: null,
+          names: null,
         }));
       });
     });
@@ -89,8 +106,8 @@ createTest({ reducers: { moderatingSubreddits } }, ({ getStore, expect }) => {
       it('should update the loading state and results of moderatingSubreddits', () => {
         const MODERATING_SUBREDDITS = {
           loading: true,
-          responseCode: null,
-          names: [],
+          error: null,
+          names: null,
         };
 
         const RESULTS = [
@@ -113,18 +130,18 @@ createTest({ reducers: { moderatingSubreddits } }, ({ getStore, expect }) => {
         expect(moderatingSubreddits).to.eql(merge(moderatingSubreddits, {
           loading: false,
           names: ['pics', 'test', 'askHistorians'],
-          responseCode: 200,
+          error: null,
         }));
       });
     });
 
     describe('FAILED', () => {
-      it('should update the loading state and set responseCode', () => {
+      it('should update the loading state and set error', () => {
         const { store } = getStore({
           moderatingSubreddits: {
             loading: true,
-            responseCode: null,
-            names: [],
+            error: null,
+            names: null,
           },
         });
 
@@ -135,7 +152,7 @@ createTest({ reducers: { moderatingSubreddits } }, ({ getStore, expect }) => {
         const { moderatingSubreddits } = store.getState();
         expect(moderatingSubreddits).to.eql(merge(moderatingSubreddits, {
           loading: false,
-          responseCode: 404,
+          error: { status: 404 },
           names: [],
         }));
       });


### PR DESCRIPTION
For users who are moderators on >100
subreddits, the fetch pagination returns
two apiResponses, which was causing a bug
when attempting to get apiRespose.status.
Instead, we will now only capture errors,
as we don't really need the apiResponse code