### PR TITLE
Add sticky comment mod tools

### DIFF
--- a/src/app/components/Comment/CommentDropdown/index.jsx
+++ b/src/app/components/Comment/CommentDropdown/index.jsx
@@ -24,6 +24,7 @@ export default function CommentDropdown(props) {
     isRemoved,
     isSpam,
     isApproved,
+    isSticky,
     approvedBy,
     removedBy,
     showModModal,
@@ -68,6 +69,7 @@ export default function CommentDropdown(props) {
         removedBy={ removedBy }
         distinguishType={ distinguishType }
         isMine={ isMine }
+        isSticky={ isSticky }
         targetType={ ModelTypes.COMMENT }
       >
       </ModeratorModal>

--- a/src/app/components/Comment/CommentTools/index.jsx
+++ b/src/app/components/Comment/CommentTools/index.jsx
@@ -33,6 +33,7 @@ export default function CommentTools(props) {
     removedBy,
     isMine,
     distinguishType,
+    isSticky,
   } = props;
 
   const modModalId = `mod-${id}`;
@@ -47,11 +48,11 @@ export default function CommentTools(props) {
       { renderDropdown(id, permalinkUrl, commentAuthor, username, saved,
                        onEdit, onDelete, onToggleSave, onReportComment, onToggleModal,
                        isSubredditModerator, isApproved, isSpam, isRemoved,
-                       approvedBy, removedBy, false, null) }
+                       approvedBy, removedBy, false, null, isSticky) }
       { isSubredditModerator ? renderDropdown(id, permalinkUrl, commentAuthor, username, saved,
                        onEdit, onDelete, onToggleSave, onReportComment, onToggleModal,
                        isSubredditModerator, isApproved, isSpam, isRemoved,
-                       approvedBy, removedBy, true, modModalId, isMine, distinguishType) : null }
+                       approvedBy, removedBy, true, modModalId, isMine, distinguishType, isSticky) : null }
     </div>
   );
 }
@@ -154,6 +155,7 @@ const renderDropdown = (
   modModalId,
   isMine,
   distinguishType,
+  isSticky,
 ) => (
   <CommentDropdown
     id={ id }
@@ -170,6 +172,7 @@ const renderDropdown = (
     isApproved={ isApproved }
     isSpam={ isSpam }
     isRemoved={ isRemoved }
+    isSticky={ isSticky }
     approvedBy={ approvedBy }
     removedBy={ removedBy }
     showModModal={ showModModal }

--- a/src/app/components/Comment/index.jsx
+++ b/src/app/components/Comment/index.jsx
@@ -178,6 +178,7 @@ function renderTools(props) {
           removedBy={ comment.bannedBy }
           isMine={ user && user.name === comment.author }
           distinguishType={ comment.distinguished }
+          isSticky={ comment.stickied }
         />
       </div>
     </div>

--- a/src/app/reducers/comments.js
+++ b/src/app/reducers/comments.js
@@ -132,6 +132,21 @@ export default function(state=DEFAULT, action={}) {
       return state;
     }
 
+    case modToolActions.MODTOOLS_SET_STICKY_COMMENT_SUCCESS: {
+      const { thing, isStickied } = action;
+
+      if (thing.type !== COMMENT) { return state; }
+      
+      return mergeUpdatedModel(
+        state,
+        {
+          model: thing.set({
+            stickied: isStickied,
+          }),
+        },
+      );
+    }
+
     case commentActions.UPDATED_BODY: {
       let { model } = action;
       const currentComment = state[model.uuid];

--- a/src/app/reducers/comments.test.js
+++ b/src/app/reducers/comments.test.js
@@ -510,5 +510,61 @@ createTest({ reducers: { comments } }, ({ getStore, expect }) => {
         });
       });
     });
+
+    describe('MODTOOLS_SET_STICKY_COMMENT_SUCCESS', () => {
+      it('should mark a comment as sticky', () => {
+        const COMMENT_UNSTICKIED = CommentModel.fromJSON({
+          link_id: '1',
+          name: 't1_1',
+          stickied: false,
+        });
+
+        const COMMENT_STICKIED = CommentModel.fromJSON({
+          link_id: '1',
+          name: 't1_1',
+          stickied: true,
+        });
+
+        const { store } = getStore({
+          comments: {
+            [COMMENT_UNSTICKIED.uuid]: COMMENT_UNSTICKIED,
+          },
+        });
+
+        store.dispatch(modToolActions.setStickyCommentSuccess(COMMENT_UNSTICKIED, true));
+
+        const { comments } = store.getState();
+        expect(comments).to.eql({
+          [COMMENT_UNSTICKIED.uuid]: COMMENT_STICKIED,
+        });
+      });
+
+      it('should unmark a comment as sticky', () => {
+        const COMMENT_UNSTICKIED = CommentModel.fromJSON({
+          link_id: '1',
+          name: 't1_1',
+          stickied: false,
+        });
+
+        const COMMENT_STICKIED = CommentModel.fromJSON({
+          link_id: '1',
+          name: 't1_1',
+          stickied: true,
+        });
+
+        const { store } = getStore({
+          comments: {
+            [COMMENT_STICKIED.uuid]: COMMENT_STICKIED,
+          },
+        });
+
+        store.dispatch(modToolActions.setStickyCommentSuccess(COMMENT_STICKIED, false));
+
+        const { comments } = store.getState();
+        expect(comments).to.eql({
+          [COMMENT_STICKIED.uuid]: COMMENT_UNSTICKIED,
+        });
+      });
+    });
   });
 });

--- a/src/app/reducers/helpers/stickyCommentsFromState.js
+++ b/src/app/reducers/helpers/stickyCommentsFromState.js
@@ -1,0 +1,20 @@
+import modelFromThingId from 'app/reducers/helpers/modelFromThingId';
+
+/**
+ * Returns a list of sticky comments in the current comments page.
+ * @function
+ * @param {Object} state
+ * @returns {Object[]}
+ */
+export default function(state) {
+  const { commentsPages } = state;
+  if (!commentsPages) { return []; }
+
+  const activePage = commentsPages[commentsPages.current];
+  if (!(activePage && activePage.results.length)) { return []; }
+  
+  const stickiedComments = activePage.results.map(r => modelFromThingId(r.uuid, state))
+                                             .filter(r => r.stickied);
+
+  return stickiedComments;
+}

--- a/src/app/reducers/toaster.js
+++ b/src/app/reducers/toaster.js
@@ -26,6 +26,7 @@ export default function(state=DEFAULT, action={}) {
     case mailActions.FAILED_MESSAGE:
     case modActions.MODTOOLS_DISTINGUISH_ERROR:
     case modActions.MODTOOLS_SET_STICKY_POST_ERROR:
+    case modActions.MODTOOLS_SET_STICKY_COMMENT_ERROR:
     case postActions.FAILED_UPDATE_SELF_TEXT:
     case postingActions.FAILURE:
     case postingActions.VALIDATION_FAILURE:


### PR DESCRIPTION
This PR is against a branch containing https://github.com/reddit/reddit-mobile/pull/969, which is not yet deployed.

for [CE-375](https://reddit.atlassian.net/browse/CE-375)

The primary action creator here, `actions/modTools#setStickyComment`, works similarly to the one for sticky posts (`actions/modTools#setStickyPost`), in that it additionally _unstickies_ any existing sticky comments in the thread.  A new helper is added to pull the existing sticky comment for the active thread out of state, `stickyCommentsFromState`, which works very similarly to the one added for sticky posts, `stickyPostsFromState`.

EDIT: requires reddit/node-api-client#194 to work

👓 @birakattack @scarow 