### PR TITLE
Clear 'token' cookie on logout

### DIFF
--- a/src/server/session/logoutproxy.js
+++ b/src/server/session/logoutproxy.js
@@ -10,6 +10,7 @@ export default (router) => {
     // (and amp, modmail, etc) is now available on the root reddit domain, so
     // we can unify these sessions and only have one cookie to clear.
     ctx.cookies.set('reddit_session', undefined, { domain: config.rootReddit });
+    ctx.cookies.set('token', undefined, { domain: config.rootReddit });
     ctx.cookies.set('reddit_session');
 
     clearSessionCookies(ctx);


### PR DESCRIPTION
We are having a cookie persistence error on mweb. Essentially, when a user logs out, then navigates to a subreddit, the `token` cookie becomes populated with that user's old cookie, which logs them back in.

This is especially problematic when a user (`user1`) logs out, then logs in on an alt (`user2`), then navigates to a subreddit and is unknowingly logged in as `user1` again.