### PR TITLE
Modtool fixup 1

### DIFF
--- a/src/Server.js
+++ b/src/Server.js
@@ -124,6 +124,7 @@ export function startServer() {
       async (ctx, next) => {
         await next();
         ctx.set('X-Frame-Options', 'SAMEORIGIN');
+        ctx.set('Cache-control', 'private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate');
       },
       async (ctx, next) => {
         await next();

--- a/src/app/actions/modTools.js
+++ b/src/app/actions/modTools.js
@@ -267,6 +267,12 @@ export const toggleSpoiler = id => async(dispatch, getState) => {
 
 export const fetchModeratingSubreddits = () => async (dispatch, getState) => {
   const state = getState();
+
+  if (state.user.loggedOut) { return; }
+  if (state.accounts[state.user.name] && !state.accounts[state.user.name].isMod) {
+    return;
+  }
+
   const apiOptions = apiOptionsFromState(state);
 
   const subredditsAlreadyFetched = (

--- a/src/app/actions/user.js
+++ b/src/app/actions/user.js
@@ -1,4 +1,5 @@
 import * as accountActions from 'app/actions/accounts';
+import * as modToolActions from 'app/actions/modTools';
 
 export const fetchMyUser = () => async (dispatch, getState) => {
   const state = getState();
@@ -7,4 +8,5 @@ export const fetchMyUser = () => async (dispatch, getState) => {
   // we prevent the promise that `fetchMyUser` returns from resolving until
   // the dispatch is complete.
   await dispatch(accountActions.fetch({ name: 'me', loggedOut: !state.session.accessToken }));
+  await dispatch(modToolActions.fetchModeratingSubreddits());
 };

--- a/src/app/router/handlers/handlerCommon.js
+++ b/src/app/router/handlers/handlerCommon.js
@@ -1,11 +1,9 @@
 import * as preferenceActions from 'app/actions/preferences';
 import * as userActions from 'app/actions/user';
-import * as modActions from 'app/actions/modTools';
 
 export const fetchUserBasedData = (dispatch) => {
   return Promise.all([
     dispatch(userActions.fetchMyUser()),
     dispatch(preferenceActions.fetch()),
-    dispatch(modActions.fetchModeratingSubreddits()),
   ]);
 };


### PR DESCRIPTION
👓 @schwers @birakattack 

You can test on https://modtool-fixup-1.mobile.staging.snooguts.net (note that production cache behavior is different on staging so you can't actually repro the problem -- I am basically making sure that the cache headers don't crash anything or log people out unexpectedly).

Note that on staging, when you navigate to `r/pics` (for example) via the url (not inside the app), you get logged out. This is old behavior, not introduced by this change.

I also added some checks to `fetchModeratingSubreddits` to avoid API calls.