### PR TITLE
Force the captcha to reload on registration errors

### DIFF
--- a/src/app/components/ReCaptcha/index.jsx
+++ b/src/app/components/ReCaptcha/index.jsx
@@ -15,6 +15,7 @@ class ReCaptcha extends React.Component {
   static propTypes = {
     elementId: T.string,
     sitekey: T.string.isRequired,
+    reloadComparisonKey: T.string.isRequired,
     theme: T.oneOf(['light', 'dark']),
     type: T.oneOf(['image', 'audio']),
     size: T.oneOf(['normal', 'compact']),
@@ -67,6 +68,14 @@ class ReCaptcha extends React.Component {
 
   shouldComponentUpdate() {
     return false;
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.reloadComparisonKey !== this.props.reloadComparisonKey) {
+      if (window.grecaptcha) {
+        window.grecaptcha.reset();
+      }
+    }
   }
 
   render() {

--- a/src/app/components/Register/index.jsx
+++ b/src/app/components/Register/index.jsx
@@ -235,6 +235,7 @@ class Register extends React.Component {
             sitekey={ recaptchaSitekey }
             onSuccess={ this.setRecaptchaResponse }
             theme={ captchaTheme }
+            reloadComparisonKey={ JSON.stringify(error) }
           />
           <input
             name='gRecaptchaResponse'


### PR DESCRIPTION
When a user gets form errors when trying to register an account, the captcha that they created is no longer valid. However, we don't prompt them to re-do the captcha and get re-issued a valid `gRecaptchaResponse` to pass to the api.

This patch will cause the recaptcha to reset if the user had errors while trying to create an account.

NOTE: This isn't a _fantastic_ product solution since this potentially forces the user to have to do the captcha verification more than once. In an ideal world, we would validate the form first, and if everything looks ok, ask the user to verify through recaptcha. However, what's in this patch is a quick fix that will restore the ability for users to register.