### PR TITLE
Fix user race condition on logging in

### DIFF
--- a/src/app/actions/login.js
+++ b/src/app/actions/login.js
@@ -1,5 +1,16 @@
+import { fetchUserBasedData } from 'app/router/handlers/handlerCommon';
+
 export const LOGGED_IN = 'LOGGED_IN';
 export const loggedIn = () => ({ type: LOGGED_IN });
 
 export const LOGGED_OUT = 'LOGGED_OUT';
 export const loggedOut = () => ({ type: LOGGED_OUT });
+
+export const LOGGING_IN = 'LOGGING_IN';
+export const loggingIn = () => ({ type: LOGGING_IN });
+
+export const login = () => async (dispatch) => {
+  dispatch(loggingIn());
+  await fetchUserBasedData(dispatch);
+  dispatch(loggedIn());
+};

--- a/src/app/reducers/accountRequests.js
+++ b/src/app/reducers/accountRequests.js
@@ -8,7 +8,7 @@ const DEFAULT = {};
 
 export default function (state=DEFAULT, action={}) {
   switch (action.type) {
-    case loginActions.LOGGED_IN:
+    case loginActions.LOGGING_IN:
     case loginActions.LOGGED_OUT: {
       return DEFAULT;
     }

--- a/src/app/reducers/accountRequests.test.js
+++ b/src/app/reducers/accountRequests.test.js
@@ -9,13 +9,13 @@ const REQUIRED_KEYS = ['id', 'loading' ];
 createTest({ reducers: { accountRequests } }, ({ getStore, expect }) => {
   describe('accountRequests', () => {
 
-    describe('LOGGED_IN and LOGGED_OUT', () => {
-      it('should return default on log in', () => {
+    describe('LOGGING_IN and LOGGED_OUT', () => {
+      it('should return default on logging in', () => {
         const { store } = getStore({
           accountRequests: { 'me': {} },
         });
 
-        store.dispatch(loginActions.loggedIn());
+        store.dispatch(loginActions.loggingIn());
 
         const { accountRequests } = store.getState();
         expect(accountRequests).to.eql({});

--- a/src/app/reducers/accounts.js
+++ b/src/app/reducers/accounts.js
@@ -6,7 +6,7 @@ const DEFAULT = {};
 
 export default function(state=DEFAULT, action={}) {
   switch (action.type) {
-    case loginActions.LOGGED_IN:
+    case loginActions.LOGGING_IN:
     case loginActions.LOGGED_OUT: {
       return DEFAULT;
     }

--- a/src/app/reducers/accounts.test.js
+++ b/src/app/reducers/accounts.test.js
@@ -6,7 +6,7 @@ import * as loginActions from 'app/actions/login';
 
 createTest({ reducers: { accounts } }, ({ getStore, expect }) => {
   describe('accounts', () => {
-    describe('LOGGED_IN and LOGGED_OUT', () => {
+    describe('LOGGING_IN and LOGGED_OUT', () => {
       it('should return default on log out', () => {
         const { store } = getStore({
           accounts: {
@@ -19,14 +19,14 @@ createTest({ reducers: { accounts } }, ({ getStore, expect }) => {
         expect(accounts).to.eql({});
       });
 
-      it('should return the default on log in', () => {
+      it('should return the default on logging in', () => {
         const { store } = getStore({
           accounts: {
             't2_0001': { name: 'test account' },
           },
         });
 
-        store.dispatch(loginActions.loggedIn());
+        store.dispatch(loginActions.loggingIn());
         const { accounts } = store.getState();
         expect(accounts).to.eql({});
       });

--- a/src/app/reducers/activitiesRequests.js
+++ b/src/app/reducers/activitiesRequests.js
@@ -8,7 +8,7 @@ const DEFAULT = {};
 
 export default function (state=DEFAULT, action={}) {
   switch (action.type) {
-    case loginActions.LOGGED_IN:
+    case loginActions.LOGGING_IN:
     case loginActions.LOGGED_OUT: {
       return DEFAULT;
     }

--- a/src/app/reducers/activitiesRequests.test.js
+++ b/src/app/reducers/activitiesRequests.test.js
@@ -9,12 +9,12 @@ import * as loginActions from 'app/actions/login';
 
 createTest({ reducers: { activitiesRequests }}, ({ getStore, expect}) => {
   describe('activitiesRequests', () => {
-    describe('LOGGED_IN and LOGGED_OUT', () => {
+    describe('LOGGING_IN and LOGGED_OUT', () => {
       it('should return default on log in', () => {
         const { store } = getStore({
           activitiesRequests: { 'me': {} },
         });
-        store.dispatch(loginActions.loggedIn());
+        store.dispatch(loginActions.loggingIn());
 
         const { activitiesRequests } = store.getState();
         expect(activitiesRequests).to.eql({});

--- a/src/app/reducers/adRequests.js
+++ b/src/app/reducers/adRequests.js
@@ -7,7 +7,7 @@ export const DEFAULT = {};
 
 export default function(state=DEFAULT, action={}) {
   switch (action.type) {
-    case loginActions.LOGGED_IN:
+    case loginActions.LOGGING_IN:
     case loginActions.LOGGED_OUT: {
       return DEFAULT;
     }

--- a/src/app/reducers/adRequests.test.js
+++ b/src/app/reducers/adRequests.test.js
@@ -10,7 +10,7 @@ import adRequests, { DEFAULT } from './adRequests';
 
 createTest({ reducers: { adRequests }}, ({ getStore, expect }) => {
   describe('adRequests', () => {
-    describe('LOGGED_IN and LOGGED_OUT', () => {
+    describe('LOGGING_IN and LOGGED_OUT', () => {
       it('should return default on log out', () => {
         const { store } = getStore({
           adRequests: {
@@ -30,7 +30,7 @@ createTest({ reducers: { adRequests }}, ({ getStore, expect }) => {
           },
         });
 
-        store.dispatch(loginActions.loggedIn());
+        store.dispatch(loginActions.loggingIn());
         const { adRequests } = store.getState();
         expect(adRequests).to.eql(DEFAULT);
       });

--- a/src/app/reducers/collapsedComments.js
+++ b/src/app/reducers/collapsedComments.js
@@ -7,7 +7,7 @@ const DEFAULT = {};
 
 export default function (state=DEFAULT, action={}) {
   switch (action.type) {
-    case loginActions.LOGGED_IN:
+    case loginActions.LOGGING_IN:
     case loginActions.LOGGED_OUT: {
       return DEFAULT;
     }

--- a/src/app/reducers/collapsedComments.test.js
+++ b/src/app/reducers/collapsedComments.test.js
@@ -6,12 +6,12 @@ import * as loginActions from 'app/actions/login';
 
 createTest({ reducers: { collapsedComments } }, ({ getStore, expect }) => {
   describe('collapsedComments', () => {
-    describe('LOGGED_IN and LOGGED_OUT', () => {
+    describe('LOGGING_IN and LOGGED_OUT', () => {
       it('should return default on log in', () => {
         const { store } = getStore({
           collapsedComments: { t1_1: true },
         });
-        store.dispatch(loginActions.loggedIn());
+        store.dispatch(loginActions.loggingIn());
 
         const { collapsedComments } = store.getState();
         expect(collapsedComments).to.eql({});

--- a/src/app/reducers/comments.js
+++ b/src/app/reducers/comments.js
@@ -22,7 +22,7 @@ const DEFAULT = {};
 
 export default function(state=DEFAULT, action={}) {
   switch (action.type) {
-    case loginActions.LOGGED_IN:
+    case loginActions.LOGGING_IN:
     case loginActions.LOGGED_OUT: {
       return DEFAULT;
     }

--- a/src/app/reducers/comments.test.js
+++ b/src/app/reducers/comments.test.js
@@ -19,7 +19,7 @@ import * as modToolActions from 'app/actions/modTools';
 
 createTest({ reducers: { comments } }, ({ getStore, expect }) => {
   describe('comments', () => {
-    describe('LOGGED_IN and LOGGED_OUT', () => {
+    describe('LOGGING_IN and LOGGED_OUT', () => {
       it('should return default on log out', () => {
         const { store } = getStore({
           comments: { t1_1: {} },
@@ -35,7 +35,7 @@ createTest({ reducers: { comments } }, ({ getStore, expect }) => {
           comments: { t1_1: {} },
         });
 
-        store.dispatch(loginActions.loggedIn());
+        store.dispatch(loginActions.loggingIn());
         const { comments } = store.getState();
         expect(comments).to.eql({});
       });

--- a/src/app/reducers/commentsPages.js
+++ b/src/app/reducers/commentsPages.js
@@ -9,7 +9,7 @@ const DEFAULT = {};
 
 export default (state=DEFAULT, action={}) => {
   switch (action.type) {
-    case loginActions.LOGGED_IN:
+    case loginActions.LOGGING_IN:
     case loginActions.LOGGED_OUT: {
       return DEFAULT;
     }

--- a/src/app/reducers/commentsPages.test.js
+++ b/src/app/reducers/commentsPages.test.js
@@ -10,12 +10,12 @@ import * as replyActions from 'app/actions/reply';
 
 createTest({ reducers: { commentsPages } }, ({ getStore, expect }) => {
   describe('commentsPages', () => {
-    describe('LOGGED_IN and LOGGED_OUT', () => {
+    describe('LOGGING_IN and LOGGED_OUT', () => {
       it('should return default on log in', () => {
         const { store } = getStore({
           commentsPages: { 'page': {} },
         });
-        store.dispatch(loginActions.loggedIn());
+        store.dispatch(loginActions.loggingIn());
 
         const { commentsPages } = store.getState();
         expect(commentsPages).to.eql({});

--- a/src/app/reducers/compact.js
+++ b/src/app/reducers/compact.js
@@ -5,7 +5,7 @@ export const DEFAULT = true;
 
 export default (state=DEFAULT, action={}) => {
   switch (action.type) {
-    case loginActions.LOGGED_IN:
+    case loginActions.LOGGING_IN:
     case loginActions.LOGGED_OUT: {
       return DEFAULT;
     }

--- a/src/app/reducers/compact.test.js
+++ b/src/app/reducers/compact.test.js
@@ -6,10 +6,10 @@ import compact from './compact';
 
 createTest({ reducers: { compact } }, ({ getStore, expect }) => {
   describe('compact', () => {
-    describe('LOGGED_IN and LOGGED_OUT', () => {
+    describe('LOGGING_IN and LOGGED_OUT', () => {
       it('should return default on log in', () => {
         const { store } = getStore({ compact: false });
-        store.dispatch(loginActions.loggedIn());
+        store.dispatch(loginActions.loggingIn());
 
         const { compact } = store.getState();
         expect(compact).to.eql(true);

--- a/src/app/reducers/editingText.js
+++ b/src/app/reducers/editingText.js
@@ -45,7 +45,7 @@ export const DEFAULT_STATE = {};
 export default function(state=DEFAULT_STATE, action={}) {
   switch (action.type) {
     // if you log in / out what you're allowed to edit has changed, clear it
-    case loginActions.LOGGED_IN:
+    case loginActions.LOGGING_IN:
     case loginActions.LOGGED_OUT: {
       return DEFAULT_STATE;
     }

--- a/src/app/reducers/editingText.test.js
+++ b/src/app/reducers/editingText.test.js
@@ -8,7 +8,7 @@ import editingText, { DEFAULT_STATE } from './editingText';
 
 createTest({ reducers: { editingText }}, ({ getStore, expect}) => {
   describe('editingText', () => {
-    describe('LOGGED_IN and LOGGED_OUT', () => {
+    describe('LOGGING_IN and LOGGED_OUT', () => {
       it('should return default on log out', () => {
         const { store } = getStore({
           editingText: {
@@ -28,7 +28,7 @@ createTest({ reducers: { editingText }}, ({ getStore, expect}) => {
           },
         });
 
-        store.dispatch(loginActions.loggedIn());
+        store.dispatch(loginActions.loggingIn());
         const { editingText } = store.getState();
         expect(editingText).to.eql(DEFAULT_STATE);
       });

--- a/src/app/reducers/expandedPosts.js
+++ b/src/app/reducers/expandedPosts.js
@@ -5,7 +5,7 @@ const DEFAULT = {};
 
 export default function(state=DEFAULT, action={}) {
   switch (action.type) {
-    case loginActions.LOGGED_IN:
+    case loginActions.LOGGING_IN:
     case loginActions.LOGGED_OUT: {
       return DEFAULT;
     }

--- a/src/app/reducers/expandedPosts.test.js
+++ b/src/app/reducers/expandedPosts.test.js
@@ -6,13 +6,13 @@ import * as postActions from 'app/actions/posts';
 
 createTest({ reducers: { expandedPosts }}, ({ getStore, expect }) => {
   describe('expandedPosts', () => {
-    describe('LOGGED_IN and LOGGED_OUT', () => {
+    describe('LOGGING_IN and LOGGED_OUT', () => {
       it('should return the default on log in', () => {
         const { store } = getStore({
           expandedPosts: { t3_asdf: true },
         });
 
-        store.dispatch(loginActions.loggedIn());
+        store.dispatch(loginActions.loggingIn());
         const { expandedPosts } = store.getState();
         expect(expandedPosts).to.eql({});
       });

--- a/src/app/reducers/hiddenRequests.js
+++ b/src/app/reducers/hiddenRequests.js
@@ -8,7 +8,7 @@ const DEFAULT = {};
 
 export default function (state=DEFAULT, action={}) {
   switch (action.type) {
-    case loginActions.LOGGED_IN:
+    case loginActions.LOGGING_IN:
     case loginActions.LOGGED_OUT: {
       return DEFAULT;
     }

--- a/src/app/reducers/hiddenRequests.test.js
+++ b/src/app/reducers/hiddenRequests.test.js
@@ -9,12 +9,12 @@ import * as loginActions from 'app/actions/login';
 
 createTest({ reducers: { hiddenRequests }}, ({ getStore, expect}) => {
   describe('hiddenRequests', () => {
-    describe('LOGGED_IN and LOGGED_OUT', () => {
+    describe('LOGGING_IN and LOGGED_OUT', () => {
       it('should return default on log in', () => {
         const { store } = getStore({
           hidden: { 'request': {} },
         });
-        store.dispatch(loginActions.loggedIn());
+        store.dispatch(loginActions.loggingIn());
 
         const { hiddenRequests } = store.getState();
         expect(hiddenRequests).to.eql({});

--- a/src/app/reducers/mail.js
+++ b/src/app/reducers/mail.js
@@ -20,7 +20,7 @@ export const DEFAULT = [
 
 export default function(state=DEFAULT, action={}) {
   switch (action.type) {
-    case loginActions.LOGGED_IN:
+    case loginActions.LOGGING_IN:
     case loginActions.LOGGED_OUT: {
       return DEFAULT;
     }

--- a/src/app/reducers/mail.test.js
+++ b/src/app/reducers/mail.test.js
@@ -7,7 +7,7 @@ import * as mailActions from 'app/actions/mail';
 
 createTest({ reducers: { mail } }, ({ getStore, expect }) => {
   describe('mail', () => {
-    describe('LOGGED_IN and LOGGED_OUT', () => {
+    describe('LOGGING_IN and LOGGED_OUT', () => {
       it('should return default on log out', () => {
         const { store } = getStore({
           mail: {},
@@ -23,7 +23,7 @@ createTest({ reducers: { mail } }, ({ getStore, expect }) => {
           mail: {},
         });
 
-        store.dispatch(loginActions.loggedIn());
+        store.dispatch(loginActions.loggingIn());
         const { mail } = store.getState();
         expect(mail).to.eql(DEFAULT);
       });

--- a/src/app/reducers/messages.js
+++ b/src/app/reducers/messages.js
@@ -6,7 +6,7 @@ const DEFAULT = {};
 
 export default function messages(state=DEFAULT, action={}) {
   switch (action.type) {
-    case loginActions.LOGGED_IN:
+    case loginActions.LOGGING_IN:
     case loginActions.LOGGED_OUT: {
       return DEFAULT;
     }

--- a/src/app/reducers/messages.test.js
+++ b/src/app/reducers/messages.test.js
@@ -7,7 +7,7 @@ import * as mailActions from 'app/actions/mail';
 
 createTest({ reducers: { messages } }, ({ getStore, expect }) => {
   describe('messages', () => {
-    describe('LOGGED_IN and LOGGED_OUT', () => {
+    describe('LOGGING_IN and LOGGED_OUT', () => {
       it('should return default on log out', () => {
         const { store } = getStore({
           messages: { t4_1: {} },
@@ -23,7 +23,7 @@ createTest({ reducers: { messages } }, ({ getStore, expect }) => {
           messages: { t4_1: {} },
         });
 
-        store.dispatch(loginActions.loggedIn());
+        store.dispatch(loginActions.loggingIn());
         const { messages } = store.getState();
         expect(messages).to.eql({});
       });

--- a/src/app/reducers/moderatingSubreddits.js
+++ b/src/app/reducers/moderatingSubreddits.js
@@ -39,7 +39,7 @@ export default function(state=DEFAULT, action={}) {
       return merge(state, moderatingSubreddits);
     }
 
-    case loginActions.LOGGED_IN:
+    case loginActions.LOGGING_IN:
     case loginActions.LOGGED_OUT: {
       return DEFAULT;
     }

--- a/src/app/reducers/moderatingSubreddits.test.js
+++ b/src/app/reducers/moderatingSubreddits.test.js
@@ -7,7 +7,7 @@ import * as loginActions from 'app/actions/login';
 
 createTest({ reducers: { moderatingSubreddits } }, ({ getStore, expect }) => {
   describe('moderatingSubreddits', () => {
-    describe('LOGGED_IN and LOGGED_OUT', () => {
+    describe('LOGGING_IN and LOGGED_OUT', () => {
       it('should return default on log in', () => {
         const { store } = getStore({
           moderatingSubreddits: {
@@ -16,7 +16,7 @@ createTest({ reducers: { moderatingSubreddits } }, ({ getStore, expect }) => {
             loading: false,
           },
         });
-        store.dispatch(loginActions.loggedIn());
+        store.dispatch(loginActions.loggingIn());
 
         const { moderatingSubreddits } = store.getState();
         expect(moderatingSubreddits).to.eql({

--- a/src/app/reducers/posting.js
+++ b/src/app/reducers/posting.js
@@ -16,7 +16,7 @@ const VALID_TYPES = new Set(['self', 'link']);
 
 export default (state=DEFAULT, action={}) => {
   switch (action.type) {
-    case loginActions.LOGGED_IN:
+    case loginActions.LOGGING_IN:
     case loginActions.LOGGED_OUT: {
       return DEFAULT;
     }

--- a/src/app/reducers/posting.test.js
+++ b/src/app/reducers/posting.test.js
@@ -8,7 +8,7 @@ import * as postingActions from 'app/actions/posting';
 
 createTest({ reducers: { posting }, routes }, ({ getStore, expect }) => {
   describe('posting', () => {
-    describe('LOGGED_IN and LOGGED_OUT', () => {
+    describe('LOGGING_IN and LOGGED_OUT', () => {
       const INITIAL = {
         title: 'a',
         meta: 'b',
@@ -19,7 +19,7 @@ createTest({ reducers: { posting }, routes }, ({ getStore, expect }) => {
 
       it('should return default on log in', () => {
         const { store } = getStore({ posting: INITIAL });
-        store.dispatch(loginActions.loggedIn());
+        store.dispatch(loginActions.loggingIn());
 
         const { posting } = store.getState();
         expect(posting).to.eql({

--- a/src/app/reducers/posts.js
+++ b/src/app/reducers/posts.js
@@ -38,7 +38,7 @@ const preservePostContentPreviews = (state, post) => {
 
 export default function(state=DEFAULT, action={}) {
   switch (action.type) {
-    case loginActions.LOGGED_IN:
+    case loginActions.LOGGING_IN:
     case loginActions.LOGGED_OUT: {
       return DEFAULT;
     }

--- a/src/app/reducers/posts.test.js
+++ b/src/app/reducers/posts.test.js
@@ -20,7 +20,7 @@ import * as modToolActions from 'app/actions/modTools';
 
 createTest({ reducers: { posts } }, ({ getStore, expect }) => {
   describe('posts', () => {
-    describe('LOGGED_IN and LOGGED_OUT', () => {
+    describe('LOGGING_IN and LOGGED_OUT', () => {
       it('should return default on on log out', () => {
         const { store } = getStore({
           posts: { t3_1: {} },
@@ -36,7 +36,7 @@ createTest({ reducers: { posts } }, ({ getStore, expect }) => {
           posts: { t3_1: {} },
         });
 
-        store.dispatch(loginActions.loggedIn());
+        store.dispatch(loginActions.loggingIn());
         const { posts } = store.getState();
         expect(posts).to.eql({});
       });

--- a/src/app/reducers/postsLists.js
+++ b/src/app/reducers/postsLists.js
@@ -17,7 +17,7 @@ const DEFAULT = {};
 
 export default (state=DEFAULT, action={}) => {
   switch (action.type) {
-    case loginActions.LOGGED_IN:
+    case loginActions.LOGGING_IN:
     case loginActions.LOGGED_OUT: {
       return DEFAULT;
     }

--- a/src/app/reducers/postsLists.test.js
+++ b/src/app/reducers/postsLists.test.js
@@ -8,12 +8,12 @@ import * as loginActions from 'app/actions/login';
 
 createTest({ reducers: { postsLists } }, ({ getStore, expect }) => {
   describe('postsLists', () => {
-    describe('LOGGED_IN and LOGGED_OUT', () => {
+    describe('LOGGING_IN and LOGGED_OUT', () => {
       it('should return default on log in', () => {
         const { store } = getStore({
           postsLists: { request: {} },
         });
-        store.dispatch({ type: loginActions.LOGGED_IN });
+        store.dispatch({ type: loginActions.LOGGING_IN });
 
         const { postsLists } = store.getState();
         expect(postsLists).to.eql({});

--- a/src/app/reducers/preferences.js
+++ b/src/app/reducers/preferences.js
@@ -11,7 +11,7 @@ export const DEFAULT = Preferences.fromJSON({});
 
 export default function(state=DEFAULT, action={}) {
   switch (action.type) {
-    case loginActions.LOGGED_IN:
+    case loginActions.LOGGING_IN:
     case loginActions.LOGGED_OUT: {
       return DEFAULT;
     }

--- a/src/app/reducers/preferences.test.js
+++ b/src/app/reducers/preferences.test.js
@@ -10,13 +10,13 @@ import * as preferenceActions from 'app/actions/preferences';
 
 createTest({ reducers: { preferences }}, ({ getStore, expect }) => {
   describe('preferences', () => {
-    describe('LOGGED_IN and LOGGED_OUT', () => {
+    describe('LOGGING_IN and LOGGED_OUT', () => {
       it('should return default on log in', () => {
         const { store } = getStore({
           preferences: DEFAULT.set('over18', true),
         });
 
-        store.dispatch(loginActions.loggedIn());
+        store.dispatch(loginActions.loggingIn());
         const { preferences } = store.getState();
         expect(preferences).to.eql(DEFAULT);
       });

--- a/src/app/reducers/preferencesRequest.js
+++ b/src/app/reducers/preferencesRequest.js
@@ -11,7 +11,7 @@ export const DEFAULT = {
 
 export default function(state=DEFAULT, action={}) {
   switch (action.type) {
-    case loginActions.LOGGED_IN:
+    case loginActions.LOGGING_IN:
     case loginActions.LOGGED_OUT: {
       return DEFAULT;
     }

--- a/src/app/reducers/preferencesRequest.test.js
+++ b/src/app/reducers/preferencesRequest.test.js
@@ -6,7 +6,7 @@ import * as preferenceActions from 'app/actions/preferences';
 
 createTest({ reducers: { preferencesRequest }}, ({ getStore, expect }) => {
   describe('preferencesRequest', () => {
-    describe('LOGGED_IN and LOGGED_OUT', () => {
+    describe('LOGGING_IN and LOGGED_OUT', () => {
       it('should return default on log in', () => {
         const { store } = getStore({
           preferencesRequest: {
@@ -16,7 +16,7 @@ createTest({ reducers: { preferencesRequest }}, ({ getStore, expect }) => {
           },
         });
 
-        store.dispatch(loginActions.loggedIn());
+        store.dispatch(loginActions.loggingIn());
         const { preferencesRequest } = store.getState();
         expect(preferencesRequest).to.eql(DEFAULT);
       });

--- a/src/app/reducers/recentSubreddits.js
+++ b/src/app/reducers/recentSubreddits.js
@@ -8,7 +8,7 @@ const DEFAULT = [];
 
 export default (state=DEFAULT, action={}) => {
   switch (action.type) {
-    case loginActions.LOGGED_IN:
+    case loginActions.LOGGING_IN:
     case loginActions.LOGGED_OUT: {
       return DEFAULT;
     }

--- a/src/app/reducers/recentSubreddits.test.js
+++ b/src/app/reducers/recentSubreddits.test.js
@@ -7,7 +7,7 @@ import recentSubreddits from './recentSubreddits';
 
 createTest({ reducers: { recentSubreddits } }, ({ expect, getStore }) => {
   describe('recentSubreddits', () => {
-    describe('LOGGED_IN and LOGGED_OUT', () => {
+    describe('LOGGING_IN and LOGGED_OUT', () => {
       it('should return default on log out', () => {
         const { store } = getStore({
           recentSubreddits: ['a', 'b', 'c'],
@@ -23,7 +23,7 @@ createTest({ reducers: { recentSubreddits } }, ({ expect, getStore }) => {
           recentSubreddits: ['a', 'b', 'c'],
         });
 
-        store.dispatch(loginActions.loggedIn());
+        store.dispatch(loginActions.loggingIn());
         const { recentSubreddits } = store.getState();
         expect(recentSubreddits).to.eql([]);
       });

--- a/src/app/reducers/replying.js
+++ b/src/app/reducers/replying.js
@@ -7,7 +7,7 @@ export const DEFAULT = {};
 
 export default function (state=DEFAULT, action={}) {
   switch (action.type) {
-    case loginActions.LOGGED_IN:
+    case loginActions.LOGGING_IN:
     case loginActions.LOGGED_OUT: {
       return DEFAULT;
     }

--- a/src/app/reducers/savedRequests.js
+++ b/src/app/reducers/savedRequests.js
@@ -8,7 +8,7 @@ const DEFAULT = {};
 
 export default function (state=DEFAULT, action={}) {
   switch (action.type) {
-    case loginActions.LOGGED_IN:
+    case loginActions.LOGGING_IN:
     case loginActions.LOGGED_OUT: {
       return DEFAULT;
     }

--- a/src/app/reducers/savedRequests.test.js
+++ b/src/app/reducers/savedRequests.test.js
@@ -8,12 +8,12 @@ import * as loginActions from 'app/actions/login';
 
 createTest({ reducers: { savedRequests }}, ({ getStore, expect}) => {
   describe('savedRequests', () => {
-    describe('LOGGED_IN and LOGGED_OUT', () => {
+    describe('LOGGING_IN and LOGGED_OUT', () => {
       it('should return default on log in', () => {
         const { store } = getStore({
           savedRequests: { request: {} },
         });
-        store.dispatch(loginActions.loggedIn());
+        store.dispatch(loginActions.loggingIn());
 
         const { savedRequests } = store.getState();
         expect(savedRequests).to.eql({});

--- a/src/app/reducers/scrollPositions.js
+++ b/src/app/reducers/scrollPositions.js
@@ -5,7 +5,7 @@ export const DEFAULT = {};
 
 export default function(state=DEFAULT, action={}) {
   switch (action.type) {
-    case loginActions.LOGGED_IN:
+    case loginActions.LOGGING_IN:
     case loginActions.LOGGED_OUT: {
       return DEFAULT;
     }

--- a/src/app/reducers/scrollPositions.test.js
+++ b/src/app/reducers/scrollPositions.test.js
@@ -6,7 +6,7 @@ import * as scrollPositionActions from 'app/actions/scrollPosition';
 
 createTest({ reducers: { scrollPositions }}, ({ getStore, expect }) => {
   describe('scrollPositions', () => {
-    describe('LOGGED_IN and LOGGED_OUT', () => {
+    describe('LOGGING_IN and LOGGED_OUT', () => {
       it('should return default on log out', () => {
         const { store } = getStore({
           scrollPositions: {
@@ -26,7 +26,7 @@ createTest({ reducers: { scrollPositions }}, ({ getStore, expect }) => {
           },
         });
 
-        store.dispatch(loginActions.loggedIn());
+        store.dispatch(loginActions.loggingIn());
         const { scrollPositions } = store.getState();
         expect(scrollPositions).to.eql(DEFAULT);
       });

--- a/src/app/reducers/searchRequests.js
+++ b/src/app/reducers/searchRequests.js
@@ -18,7 +18,7 @@ const DEFAULT = {};
 
 export default (state=DEFAULT, action={}) => {
   switch (action.type) {
-    case loginActions.LOGGED_IN:
+    case loginActions.LOGGING_IN:
     case loginActions.LOGGED_OUT: {
       return DEFAULT;
     }

--- a/src/app/reducers/searchRequests.test.js
+++ b/src/app/reducers/searchRequests.test.js
@@ -8,12 +8,12 @@ import * as loginActions from 'app/actions/login';
 
 createTest({ reducers: { searchRequests } }, ({ getStore, expect }) => {
   describe('searchRequests', () => {
-    describe('LOGGED_IN and LOGGED_OUT', () => {
+    describe('LOGGING_IN and LOGGED_OUT', () => {
       it('should return default on log in', () => {
         const { store } = getStore({
           searchRequests: { request: {} },
         });
-        store.dispatch(loginActions.loggedIn());
+        store.dispatch(loginActions.loggingIn());
 
         const { searchRequests } = store.getState();
         expect(searchRequests).to.eql({});

--- a/src/app/reducers/smartBanner.js
+++ b/src/app/reducers/smartBanner.js
@@ -62,7 +62,7 @@ export default function(state=DEFAULT, action={}) {
       return state;
     }
 
-    case loginActions.LOGGED_IN: {
+    case loginActions.LOGGING_IN: {
       if (state.loginRequired) {
         markBannerClosed();
         return merge(state, {

--- a/src/app/reducers/subredditRequests.js
+++ b/src/app/reducers/subredditRequests.js
@@ -8,7 +8,7 @@ export const DEFAULT = {};
 
 export default (state=DEFAULT, action={}) => {
   switch (action.type) {
-    case loginActions.LOGGED_IN:
+    case loginActions.LOGGING_IN:
     case loginActions.LOGGED_OUT: {
       return DEFAULT;
     }

--- a/src/app/reducers/subredditRequests.test.js
+++ b/src/app/reducers/subredditRequests.test.js
@@ -8,12 +8,12 @@ createTest({ reducers: { subredditRequests } }, ({ getStore, expect }) => {
   describe('subredditRequests', () => {
     const NAME = 'foo';
 
-    describe('LOGGED_IN and LOGGED_OUT', () => {
+    describe('LOGGING_IN and LOGGED_OUT', () => {
       it('should return default on log in', () => {
         const { store } = getStore({
           subredditRequests: { request: {} },
         });
-        store.dispatch(loginActions.loggedIn());
+        store.dispatch(loginActions.loggingIn());
 
         const { subredditRequests } = store.getState();
         expect(subredditRequests).to.eql({});

--- a/src/app/reducers/subreddits.js
+++ b/src/app/reducers/subreddits.js
@@ -11,7 +11,7 @@ const DEFAULT = {};
 
 export default function(state=DEFAULT, action={}) {
   switch (action.type) {
-    case loginActions.LOGGED_IN:
+    case loginActions.LOGGING_IN:
     case loginActions.LOGGED_OUT: {
       return DEFAULT;
     }

--- a/src/app/reducers/subreddits.test.js
+++ b/src/app/reducers/subreddits.test.js
@@ -11,7 +11,7 @@ import * as subscribedSubredditsActions from 'app/actions/subscribedSubreddits';
 
 createTest({ reducers: { subreddits }}, ({ getStore, expect }) => {
   describe('subreddits', () => {
-    describe('LOGGED_IN and LOGGED_OUT', () => {
+    describe('LOGGING_IN and LOGGED_OUT', () => {
       it('should return default on log ou', () => {
         const { store } = getStore({
           subreddits: {
@@ -31,7 +31,7 @@ createTest({ reducers: { subreddits }}, ({ getStore, expect }) => {
           },
         });
 
-        store.dispatch(loginActions.loggedIn());
+        store.dispatch(loginActions.loggingIn());
         const { subreddits } = store.getState();
         expect(subreddits).to.eql({});
       });

--- a/src/app/reducers/subscribedSubreddits.js
+++ b/src/app/reducers/subscribedSubreddits.js
@@ -37,7 +37,7 @@ const updateStateFromSubreddits = (state, subreddits) => {
 
 export default(state=DEFAULT, action={}) => {
   switch (action.type) {
-    case loginActions.LOGGED_IN:
+    case loginActions.LOGGING_IN:
     case loginActions.LOGGED_OUT: {
       return DEFAULT;
     }

--- a/src/app/reducers/subscribedSubreddits.test.js
+++ b/src/app/reducers/subscribedSubreddits.test.js
@@ -8,12 +8,12 @@ import { newSubscribedSubredditsModel } from 'app/models/SubscribedSubreddits';
 
 createTest({ reducers: { subscribedSubreddits } }, ({ getStore, expect }) => {
   describe('subscribedSubreddits', () => {
-    describe('LOGGED_IN and LOGGED_OUT', () => {
+    describe('LOGGING_IN and LOGGED_OUT', () => {
       it('should return default on log in', () => {
         const { store } = getStore({
           subscribedSubreddits: { 'foobar': 't5_12345' },
         });
-        store.dispatch(loginActions.loggedIn());
+        store.dispatch(loginActions.loggingIn());
 
         const { subscribedSubreddits } = store.getState();
         expect(subscribedSubreddits).to.eql(newSubscribedSubredditsModel());

--- a/src/app/reducers/theme.js
+++ b/src/app/reducers/theme.js
@@ -7,7 +7,7 @@ export const DEFAULT = themes.DAYMODE;
 
 export default (state=DEFAULT, action={}) => {
   switch (action.type) {
-    case loginActions.LOGGED_IN:
+    case loginActions.LOGGING_IN:
     case loginActions.LOGGED_OUT: {
       return DEFAULT;
     }

--- a/src/app/reducers/theme.test.js
+++ b/src/app/reducers/theme.test.js
@@ -7,10 +7,10 @@ import * as loginActions from 'app/actions/login';
 
 createTest({ reducers: { theme } }, ({ getStore, expect }) => {
   describe('theme', () => {
-    describe('LOGGED_IN and LOGGED_OUT', () => {
+    describe('LOGGING_IN and LOGGED_OUT', () => {
       it('should return default on log in', () => {
         const { store } = getStore({ theme: themes.NIGHTMODE });
-        store.dispatch(loginActions.loggedIn());
+        store.dispatch(loginActions.loggingIn());
 
         const { theme } = store.getState();
         expect(theme).to.eql(themes.DAYMODE);

--- a/src/app/reducers/unblurredPosts.js
+++ b/src/app/reducers/unblurredPosts.js
@@ -5,7 +5,7 @@ export const DEFAULT = {};
 
 export default function(state=DEFAULT, action={}) {
   switch (action.type) {
-    case loginActions.LOGGED_IN:
+    case loginActions.LOGGING_IN:
     case loginActions.LOGGED_OUT: {
       return DEFAULT;
     }

--- a/src/app/reducers/unblurredPosts.test.js
+++ b/src/app/reducers/unblurredPosts.test.js
@@ -6,7 +6,7 @@ import * as postActions from 'app/actions/posts';
 
 createTest({ reducers: { unblurredPosts } }, ({ getStore, expect }) => {
   describe('unblurredPosts', () => {
-    describe('LOGGED_IN and LOGGED_OUT', () => {
+    describe('LOGGING_IN and LOGGED_OUT', () => {
       it('should return default on log in', () => {
         const { store } = getStore({
           unblurredPosts: {
@@ -14,7 +14,7 @@ createTest({ reducers: { unblurredPosts } }, ({ getStore, expect }) => {
           },
         });
 
-        store.dispatch(loginActions.loggedIn());
+        store.dispatch(loginActions.loggingIn());
         const { unblurredPosts } = store.getState();
         expect(unblurredPosts).to.eql(DEFAULT);
       });

--- a/src/app/reducers/user.js
+++ b/src/app/reducers/user.js
@@ -11,7 +11,7 @@ export const DEFAULT = {
 
 export default function(state=DEFAULT, action={}) {
   switch (action.type) {
-    case loginActions.LOGGED_IN:
+    case loginActions.LOGGING_IN:
     case loginActions.LOGGED_OUT: {
       return DEFAULT;
     }

--- a/src/app/reducers/user.test.js
+++ b/src/app/reducers/user.test.js
@@ -6,8 +6,8 @@ import * as loginActions from 'app/actions/login';
 
 createTest({ reducers: { user } }, ({ getStore, expect }) => {
   describe('user', () => {
-    describe('LOGGED_IN and LOGGED_OUT', () => {
-      it('should return default on log in', () => {
+    describe('LOGGING_IN and LOGGED_OUT', () => {
+      it('should return default on logged out', () => {
         const { store } = getStore({
           user: {
             ...DEFAULT,
@@ -20,14 +20,14 @@ createTest({ reducers: { user } }, ({ getStore, expect }) => {
         expect(user).to.eql(DEFAULT);
       });
 
-      it('should return default on log out', () => {
+      it('should return default on logging in', () => {
         const { store } = getStore({
           user: {
             ...DEFAULT,
             name: 'tester',
           },
         });
-        store.dispatch(loginActions.loggedIn());
+        store.dispatch(loginActions.loggingIn());
 
         const { user } = store.getState();
         expect(user).to.eql(DEFAULT);

--- a/src/app/reducers/wikiRequests.js
+++ b/src/app/reducers/wikiRequests.js
@@ -8,7 +8,7 @@ const DEFAULT = {};
 
 export default function (state=DEFAULT, action={}) {
   switch (action.type) {
-    case loginActions.LOGGED_IN:
+    case loginActions.LOGGING_IN:
     case loginActions.LOGGED_OUT: {
       return DEFAULT;
     }

--- a/src/app/reducers/wikis.js
+++ b/src/app/reducers/wikis.js
@@ -6,7 +6,7 @@ const DEFAULT = {};
 
 export default function(state=DEFAULT, action={}) {
   switch (action.type) {
-    case loginActions.LOGGED_IN:
+    case loginActions.LOGGING_IN:
     case loginActions.LOGGED_OUT: {
       return DEFAULT;
     }

--- a/src/app/reducers/wikis.test.js
+++ b/src/app/reducers/wikis.test.js
@@ -6,7 +6,7 @@ import * as loginActions from 'app/actions/login';
 
 createTest({ reducers: { wikis } }, ({ getStore, expect }) => {
   describe('wikis', () => {
-    describe('LOGGED_IN and LOGGED_OUT', () => {
+    describe('LOGGING_IN and LOGGED_OUT', () => {
       it('should return default on log out', () => {
         const { store } = getStore({
           wikis: {
@@ -26,7 +26,7 @@ createTest({ reducers: { wikis } }, ({ getStore, expect }) => {
           },
         });
 
-        store.dispatch(loginActions.loggedIn());
+        store.dispatch(loginActions.loggingIn());
         const { wikis } = store.getState();
         expect(wikis).to.eql({});
       });

--- a/src/app/reduxMiddleware/trackXPromoEvents.js
+++ b/src/app/reduxMiddleware/trackXPromoEvents.js
@@ -7,7 +7,7 @@ export default function xpromoEventTracker() {
     const state = store.getState();
     if (action.type === xpromoActions.TRACK_XPROMO_EVENT) {
       trackXPromoEvent(state, action.eventType, action.data);
-    } else if (action.type === loginActions.LOGGED_IN && state.smartBanner.loginRequired) {
+    } else if (action.type === loginActions.LOGGING_IN && state.smartBanner.loginRequired) {
       trackXPromoEvent(state, XPROMO_DISMISS, { dismiss_type: 'logged_in' });
     }
     return next(action);

--- a/src/app/router/handlers/Login.js
+++ b/src/app/router/handlers/Login.js
@@ -3,8 +3,8 @@ import * as platformActions from '@r/platform/actions';
 import { errors } from '@r/api-client';
 
 import Session from 'app/models/Session';
-import * as sessionActions from 'app/actions/session';
 import * as loginActions from 'app/actions/login';
+import * as sessionActions from 'app/actions/session';
 import { getEventTracker } from 'lib/eventTracker';
 import { getBasePayload, trackPageEvents } from 'lib/eventUtils';
 
@@ -22,10 +22,8 @@ export default class Login extends BaseHandler {
     try {
       const newSession = await Session.fromLogin(username, password);
       dispatch(sessionActions.setSession(newSession));
-      dispatch(loginActions.loggedIn());
-
-      // This is awaited to guarantee the user is loaded for event logging
-      await dispatch(platformActions.redirect(redirectTo));
+      await dispatch(loginActions.login());
+      dispatch(platformActions.redirect(redirectTo));
     } catch (e) {
       successful = false;
       if (e instanceof errors.ValidationError && e.errors && e.errors[0]) {

--- a/src/app/router/handlers/Register.js
+++ b/src/app/router/handlers/Register.js
@@ -23,10 +23,8 @@ export default class Register extends BaseHandler {
       const newSession = await registerUser(username, password, email,
                                             newsletter, gRecaptchaResponse);
       dispatch(sessionActions.setSession(newSession));
-      dispatch(loginActions.loggedIn());
-
-      // This is awaited to guarantee the user is loaded for event logging
-      await dispatch(platformActions.navigateToUrl(METHODS.GET, '/'));
+      await dispatch(loginActions.login());
+      dispatch(platformActions.navigateToUrl(METHODS.GET, '/'));
 
     } catch (e) {
       successful = false;


### PR DESCRIPTION
So we discovered a race condition with the login flow. The race condition has to do with the expectations of the `LOGGED_IN` event. You would expect that when that event fires, the user is logged in. Not the case. In fact when the event fires, nobody is logged in. You don't even have a loid. `LOGGED_IN` really means this bizarre indeterminate state after we logged out (kind of) and we are waiting to fetch the new user's data. 

I changed meaning of `LOGGED_IN` to mean after you've loaded the logged in users data. The bizarre indeterminate state is now called `LOGGING_IN`

just to give you an idea of what the old flow looked like, it used to be like:

1) set the session data in state.
2) fire the LOGGED_IN event 
3) this triggers most of state to refresh to a default value, including account/user data.
4) We then redirect
5) As a side effect of the redirect we notice that we have no account/user data and we fetch it.

1) set the session data in state.
2) fire the LOGGING_IN event
3) this triggers most of state to refresh to a default value, including account/user data.
4) We then fetch the user's data.
5) fire the LOGGED_IN event
6) redirect. (note unlike last time, the side effect of fetching the user data doesn't happen.)

There is a better way to code this I believe. We can fetch the new users data, while also holding on to the old user's data. Then we drop the old data when it the fetch succeeds. This would mean that we can always assume that the user/account exists. My code makes the window a lot smaller, but it still exists.  

I would recommend reading this commit by commit. 

👓 : @uzi @schwers @arjunb023 @prashtx 