### PR TITLE
Add link to rules from community details

### DIFF
--- a/src/app/components/SubredditAbout/index.js
+++ b/src/app/components/SubredditAbout/index.js
@@ -28,12 +28,19 @@ function SubredditAbout(props) {
   return (
     <div className='SubredditAbout'>
     { subreddit
-      ? <RedditLinkHijacker>
-          <div
-            className='SubredditAbout__description'
-            dangerouslySetInnerHTML={ { __html: subreddit.descriptionHTML } }
-          />
-        </RedditLinkHijacker>
+      ? <div className="SubredditAbout__content">
+          <div className="SubredditAbout__community-rules-link">
+            <Anchor href={ `/r/${subredditName}/about/rules` }>
+              View this community&rsquo;s rules
+            </Anchor>
+          </div>
+          <RedditLinkHijacker>
+            <div
+              className='SubredditAbout__description'
+              dangerouslySetInnerHTML={ { __html: subreddit.descriptionHTML } }
+            />
+          </RedditLinkHijacker>
+        </div>
       
     : subredditRequest && subredditRequest.failed 
       ? <div className='SubredditAbout__loading-error'>

--- a/src/app/components/SubredditAbout/index.js
+++ b/src/app/components/SubredditAbout/index.js
@@ -9,41 +9,68 @@ import { Anchor } from '@r/platform/components';
 import Loading from 'app/components/Loading';
 import RedditLinkHijacker from 'app/components/RedditLinkHijacker';
 
-const subredditDescription = descriptionHTML => (
-  <RedditLinkHijacker>
-    <div
-      className='SubredditAbout__description'
-      dangerouslySetInnerHTML={ { __html: descriptionHTML } }
-    />
-  </RedditLinkHijacker>
-);
+const T = React.PropTypes;
 
-const tryLoggingIn = () => (
-  <div className='SubredditAbout__try-logging-in'>
-    You may need to try <Anchor href='/login'>logging in</Anchor> to view this community
-  </div>
-);
-
-const subredditLoadingError = (subredditName, user) => (
-  <div className='SubredditAbout__loading-error'>
-    Sorry, there was an error loading&nbsp;
-    <Anchor href={ `/r/${subredditName}` }>
-      { `r/${subredditName}` }
-    </Anchor>
-    { user.loggedOut && tryLoggingIn() }
-  </div>
-);
-
-const SubredditAbout = (props) => {
-  const { subreddit, subredditRequest, user, subredditName } = props;
-
+/**
+ * Component for rendering the "About this community" page.
+ * @function
+ * @param {Object} props
+ * @returns React.Component
+ */
+function SubredditAbout(props) {
+  const {
+    subreddit,
+    subredditName,
+    subredditRequest,
+    user,
+  } = props;
+  
   return (
     <div className='SubredditAbout'>
-      { subreddit ? subredditDescription(subreddit.descriptionHTML)
-        : subredditRequest && subredditRequest.failed ? subredditLoadingError(subredditName, user)
-        : <Loading /> }
+    { subreddit
+      ? <RedditLinkHijacker>
+          <div
+            className='SubredditAbout__description'
+            dangerouslySetInnerHTML={ { __html: subreddit.descriptionHTML } }
+          />
+        </RedditLinkHijacker>
+      
+    : subredditRequest && subredditRequest.failed 
+      ? <div className='SubredditAbout__loading-error'>
+          Sorry, there was an error loading&nbsp;
+          <Anchor href={ `/r/${subredditName}` }>
+            { `r/${subredditName}` }
+          </Anchor>
+          { user.loggedOut &&
+              <div className='SubredditAbout__try-logging-in'>
+                You may need to try <Anchor href='/login'>logging in</Anchor> to view this community
+              </div>
+          }
+        </div>
+        
+      : <Loading />
+    }
     </div>
   );
+}
+
+SubredditAbout.propTypes = {
+  subreddit: T.shape({
+    descriptionHTML: T.string.isRequired,
+  }),
+  subredditName: T.string.isRequired,
+  subredditRequest: T.shape({
+    failed: T.bool.isRequired,
+  }),
+  user: T.shape({
+    loggedOut: T.bool.isRequired,
+  }),
+};
+
+SubredditAbout.defaultProps = {
+  subreddit: null,
+  subredditRequest: null,
+  user: null,
 };
 
 const mapStateToProps = createSelector(

--- a/src/app/components/SubredditAbout/styles.less
+++ b/src/app/components/SubredditAbout/styles.less
@@ -12,4 +12,10 @@
   &__try-logging-in {
     margin-top: 2 * @grid-size;
   }
+
+  &__community-rules-link {
+    line-height: 4 * @grid-size;
+    margin-bottom: @grid-size;
+    text-align: right;
+  }
 }


### PR DESCRIPTION
For [**CE-497**](https://reddit.atlassian.net/browse/CE-497)

5cbfd7f is purely a refactor, inlining the 3 local render functions into the main component body makes it easier to reason about how props affect the rendering, as well as reduce the size of the component overall (the increased line count comes from the addition of jsdoc comment, propTypes, defaultProps, etc).

9875acb actually adds in the link.  It's positioned for consistency with the "About this community" link that exists on the subreddit listing view

subreddit listing | about page
---|---
<img width="376" alt="screen shot 2017-02-08 at 1 33 52 pm" src="https://cloud.githubusercontent.com/assets/2260961/22753543/79dfb27c-ee0a-11e6-8213-0ca47d709fc9.png"> | <img width="377" alt="screen shot 2017-02-08 at 1 34 01 pm" src="https://cloud.githubusercontent.com/assets/2260961/22753544/79e19560-ee0a-11e6-8c19-a648e5b46e9e.png">

While this doesn't _strictly_ depend on #984, it should not go out before it (otherwise the new link would just go to a 404 page).

👓 @scarow @birakattack 
