### PR TITLE
Begin payload reduction

### DIFF
--- a/blueprints.config.js
+++ b/blueprints.config.js
@@ -13,6 +13,36 @@ function generateReleaseVersion() {
   }
 }
 
+function makeBundleAnalyzer(name, port) {
+  var BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
+
+  return new BundleAnalyzerPlugin({
+    // Can be `server`, `static` or `disabled`.
+    // In `server` mode analyzer will start HTTP server to show bundle report.
+    // In `static` mode single HTML file with bundle report will be generated.
+    // In `disabled` mode you can use this plugin to just generate Webpack Stats JSON file by setting `generateStatsFile` to `true`.
+    analyzerMode: 'server',
+    // Port that will be used in `server` mode to start HTTP server.
+    analyzerPort: port,
+    // Path to bundle report file that will be generated in `static` mode.
+    // Relative to bundles output directory.
+    reportFilename: name + '-report.html',
+    // Automatically open report in default browser
+    openAnalyzer: true,
+    // If `true`, Webpack Stats JSON file will be generated in bundles output directory
+    generateStatsFile: true,
+    // Name of Webpack Stats JSON file that will be generated if `generateStatsFile` is `true`.
+    // Relative to bundles output directory.
+    statsFilename: name + '-stats.json',
+    // Options for `stats.toJson()` method.
+    // For example you can exclude sources of your modules from stats file with `source: false` option.
+    // See more options here: https://github.com/webpack/webpack/blob/webpack-1/lib/Stats.js#L21
+    statsOptions: null,
+    // Log level. Can be 'info', 'warn', 'error' or 'silent'.
+    logLevel: 'info',
+  });
+}
+
 module.exports = function(isProduction) {
   var release = generateReleaseVersion();
   var options = {
@@ -55,6 +85,12 @@ module.exports = function(isProduction) {
       }
     }),
   ]);
+
+  if (process.env.ANALYZE_BUILD) {
+    clientConfig.webpack.plugins = clientConfig.webpack.plugins.concat([
+      makeBundleAnalyzer('client', 4000),
+    ]);
+  }
 
   return [ clientConfig, serverConfig ];
 };

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "autoprefixer": "6.3.6",
     "babel-polyfill": "^6.7.4",
     "cluster": "^0.7.7",
+    "crypto-js": "3.1.8",
     "event-tracker": "git://github.com/reddit/event-tracker.git#28bc2dd9ce3b80540fdf189e1b003f8264cd0d08",
     "js-cookie": "^2.1.1",
     "json-stable-stringify": "^1.0.1",
@@ -49,7 +50,6 @@
     "react-redux": "4.4.5",
     "redux": "3.5.2",
     "reselect": "2.5.1",
-    "sha1": "^1.1.1",
     "source-map-support": "^0.4.0",
     "statsd-client": "^0.2.2",
     "superagent": "1.8.3"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "watch": "npm run fonts && NODE_ENV=development blueprints -w",
     "dev-build": "NODE_ENV=development blueprints",
     "dev-server": "NODE_ENV=development nodemon ./bin/Server.js",
+    "analyze": "ANALYZE_BUILD=true npm run build",
     "lint": "eslint src --ext .js,.jsx",
     "lint-fixup": "eslint src --ext .js,.jsx --fix",
     "fonts": "webfonts",
@@ -61,6 +62,7 @@
     "eslint-plugin-babel": "^3.2.0",
     "eslint-plugin-react": "^5.1.1",
     "mocha": "2.4.5",
-    "sinon-chai": "2.8.0"
+    "sinon-chai": "2.8.0",
+    "webpack-bundle-analyzer": "^2.2.1"
   }
 }

--- a/src/app/featureFlags.js
+++ b/src/app/featureFlags.js
@@ -1,9 +1,8 @@
 import Flags from '@r/flags';
 import omitBy from 'lodash/omitBy';
 import isNull from 'lodash/isNull';
-import sha1 from 'sha1';
+import sha1 from 'crypto-js/sha1';
 import url from 'url';
-
 
 import { flags as flagConstants } from 'app/constants';
 import getSubreddit from 'lib/getSubredditFromState';
@@ -13,6 +12,7 @@ import { extractUser, getExperimentData } from 'lib/experiments';
 import { getEventTracker } from 'lib/eventTracker';
 import { getBasePayload } from 'lib/eventUtils';
 import { getDevice, IPHONE, IOS_DEVICES, ANDROID } from 'lib/getDeviceFromState';
+
 
 const {
   BETA,
@@ -363,7 +363,7 @@ flags.addRule('notOptedOut', function (flag) {
 flags.addRule('pageBucketPercent', function(config) {
   const { seed, percentage } = config;
   const contentId = getContentId(this.state);
-  const hashed = sha1(`${seed}${contentId}`);
+  const hashed = sha1(`${seed}${contentId}`).toString();
 
   // hashed is a 160-bit number expressed as a hex string.
   // We want to find (hashed % 1000), so we can map the hash to bucket sizes

--- a/src/lib/eventTracker.js
+++ b/src/lib/eventTracker.js
@@ -1,5 +1,6 @@
-import crypto from 'crypto';
 import EventTracker from 'event-tracker';
+import HmacSHA256 from 'crypto-js/hmac-sha256';
+import { atob } from 'Base64';
 
 import config from 'config';
 import makeRequest from 'lib/makeRequest';
@@ -7,12 +8,7 @@ import { objectToHash } from 'lib/objectToHash';
 import { DEFAULT_API_TIMEOUT } from 'app/constants';
 
 function calculateHash(key, string) {
-  const hmac = crypto.createHmac('sha256', key);
-  hmac.setEncoding('hex');
-  hmac.write(string);
-  hmac.end();
-
-  return hmac.read();
+  return HmacSHA256(string, key).toString();
 }
 
 function post({url, data, query, headers, done}) {
@@ -56,7 +52,7 @@ export function getEventTracker() {
 
   if (!tracker) {
     const sendEvent = process.env.NODE_ENV === 'production' ? post : stubbedPost;
-    const base64Secret = new Buffer(trackerClientSecret, 'base64').toString();
+    const base64Secret = atob(trackerClientSecret);
 
     tracker = new EventTracker(
       trackerKey,

--- a/src/lib/objectToHash.js
+++ b/src/lib/objectToHash.js
@@ -1,6 +1,6 @@
-import sha1 from 'sha1';
+import sha1 from 'crypto-js/sha1';
 import stableJSONStringify from 'json-stable-stringify';
 
 export const objectToHash = (obj = {}) => {
-  return sha1(stableJSONStringify(obj) || '');
+  return sha1(stableJSONStringify(obj) || '').toString();
 };

--- a/src/server/meta/index.js
+++ b/src/server/meta/index.js
@@ -1,5 +1,5 @@
-import crypto from 'crypto';
-
+import { atob } from 'Base64';
+import HmacSha1 from 'crypto-js/hmac-sha1';
 import superagent from 'superagent';
 
 import { formatLogJSON } from 'lib/errorLog';
@@ -196,16 +196,8 @@ export default (router, apiOptions) => {
       return;
     }
 
-    const secret = (new Buffer(apiOptions.actionNameSecret, 'base64')).toString();
-    const algorithm = 'sha1';
-
-    const hmac = crypto.createHmac(algorithm, secret);
-    hmac.setEncoding('hex');
-    hmac.write(timings.actionName);
-    hmac.end();
-
-    const hash = hmac.read();
-
+    const secret = atob(apiOptions.actionNameSecret);
+    const hash = HmacSha1(timings.actionName, secret).toString();
     timings.verification = hash;
 
     superagent


### PR DESCRIPTION
This is the first in a series of payload optimizations. 

For an overview (@madbook, this should help explain @curioussavage's patch) please see: https://github.com/schwers/reddit-mobile/pull/3 
* note: these numbers are somewhat outdated as there has since been additional commits to mweb, and we're now including raven. 

👓  @curioussavage (cc @madbook, @birakattack)

### Commits
The first commit in this patch sets us up to do analysis step by step, and have a visualization to guide our efforts.

The second commit is "the low hanging fruit" of potential optimizations we can make.

### Results
Before and After:
* 357 KB gzipped -> 264 KB gzipped
* 1.3 MB -> 1017 KB

This work, and the rest of the work in the bundle audit can be visualized with `webpack-bundle-analyzer`. With the first commit you can run `npm run analyze` to generate interactive visualizations locally. The sizing information it prints, is slightly different than the numbers you'll see in chrome. The number's I'm referencing in the these results are from gzipping `ProductionClient` and running `npm run start`, and using the stats from Chrome's `Network` tab.

Before this patch, you can see a large chunks of: `elliptic`, `bn`(big nums), `browserify-aes`, `asn1`, `parse-asn1`, `hash`, `sha`, `des`, `diffie-hellmen`, node's `Buffer`

![image](https://cloud.githubusercontent.com/assets/307983/22759067/f9b9cf32-ee05-11e6-9669-6e493a968470.png)

After this patch's second commit, that bulk is removed:

![image](https://cloud.githubusercontent.com/assets/307983/22759210/70a94b9a-ee06-11e6-8c68-61667b3448e5.png)

 


