### PR TITLE
Use eventUtils to generate user info on bucketing events

### DIFF
--- a/src/app/featureFlags.js
+++ b/src/app/featureFlags.js
@@ -2,14 +2,16 @@ import Flags from '@r/flags';
 import omitBy from 'lodash/omitBy';
 import isNull from 'lodash/isNull';
 import sha1 from 'sha1';
+import url from 'url';
+
 
 import { flags as flagConstants } from 'app/constants';
 import getSubreddit from 'lib/getSubredditFromState';
 import getRouteMetaFromState from 'lib/getRouteMetaFromState';
 import getContentId from 'lib/getContentIdFromState';
-import url from 'url';
 import { extractUser, getExperimentData } from 'lib/experiments';
 import { getEventTracker } from 'lib/eventTracker';
+import { getBasePayload } from 'lib/eventUtils';
 import { getDevice, IPHONE, IOS_DEVICES, ANDROID } from 'lib/getDeviceFromState';
 
 const {
@@ -266,7 +268,6 @@ flags.addRule('variant', function (name) {
   const experimentData = getExperimentData(this.state, experiment_name);
   if (experimentData) {
     const { variant, experiment_id, owner } = experimentData;
-    const { user } = this.state;
 
     // we only want to bucket the user once per session for any given experiment.
     // to accomplish this, we're going to use the fact that featureFlags is a
@@ -277,13 +278,10 @@ flags.addRule('variant', function (name) {
 
       const eventTracker = getEventTracker();
       const payload = {
+        ...getBasePayload(this.state),
         experiment_id,
         experiment_name,
         variant,
-        user_id: !user.loggedOut ? parseInt(user.id, 36) : null,
-        user_name: !user.loggedOut ? user.name : null,
-        loid: user.loggedOut ? this.state.loid.loid : null,
-        loidcreated: user.loggedOut ? this.state.loid.loidCreated : null,
         owner: owner || null,
       };
 


### PR DESCRIPTION
In testing https://github.com/reddit/node-api-client/pull/187, I noticed what seems to be a bug in bucketing events. `app/featureFlags` was adding a `user_id` field on its events, but it's not using any of the common event payload code. As a sideffect, it's not generating the save `user_id` value as the other events are. 

This patch pulls in `getUserInfoOrLoid` to do that work. I'm not sure what fields are expected on the `bucketing` events, but it might be better to use `getBasePayload`

👓  @telaviv @nramadas @curioussavage 