### PR TITLE
Convert extraneous lodash imports to lodash-es.

### DIFF
--- a/src/app/reducers/visitedPosts.js
+++ b/src/app/reducers/visitedPosts.js
@@ -1,7 +1,7 @@
-import { take, uniq } from 'lodash/array';
+import take from 'lodash/take';
+import uniq from 'lodash/uniq';
 
 import * as commentsPageActions from 'app/actions/commentsPage';
-
 import { VISITED_POSTS_COUNT } from 'app/constants';
 
 const DEFAULT = [];

--- a/src/app/reducers/visitedPosts.test.js
+++ b/src/app/reducers/visitedPosts.test.js
@@ -1,4 +1,4 @@
-import { range } from 'lodash/util';
+import range from 'lodash/range';
 import createTest from '@r/platform/createTest';
 
 import { VISITED_POSTS_COUNT } from 'app/constants';

--- a/src/lib/getDeviceFromState.js
+++ b/src/lib/getDeviceFromState.js
@@ -1,4 +1,4 @@
-import { find } from 'lodash/collection';
+import find from 'lodash/find';
 
 export const ANDROID = 'Android';
 export const IPHONE = 'iPhone';

--- a/src/lib/getSubredditFromState.js
+++ b/src/lib/getSubredditFromState.js
@@ -1,4 +1,4 @@
-import { has } from 'lodash/object';
+import has from 'lodash/has';
 
 export default function getSubreddit(state) {
   if (state.platform.currentPage.urlParams.subredditName) {


### PR DESCRIPTION
This removes some unneeded lodash code in the payload.
Before and After (from Chrome Network tab):
* 985KB         -> 967KB
* 255KB gzipped -> 250KB gzipped


👓  @curioussavage 