### PR TITLE
Comments: use relative link for continue thread redirect

### DIFF
--- a/src/app/components/CommentTree/index.jsx
+++ b/src/app/components/CommentTree/index.jsx
@@ -22,7 +22,6 @@ import Loading from 'app/components/Loading';
 import { COMMENT_LOAD_MORE } from 'apiClient/models/thingTypes';
 
 import PostModel from 'apiClient/models/PostModel';
-import config from 'config';
 
 const T = React.PropTypes;
 
@@ -247,7 +246,7 @@ const dispatcher = (dispatch, { pageId, post }) => ({
       dispatch(commentActions.loadMore(data.uuid, pageId, post.uuid));
     } else {
       const id = stripTypePrefix(data.parentId);
-      const url = `${config.origin}${post.cleanPermalink}${id}`;
+      const url = `${post.cleanPermalink}${id}`;
       dispatch(platformActions.redirect(url));
     }
   },


### PR DESCRIPTION
:eyeglasses:  @phil303 


Looks like `process.env.ORIGIN` is not set for the client bundle so it defaults to the dev url. I think it makes more sense not to worry about origins since the platform redirect action handles relative links.  