### PR TITLE
PostContent: render selftext using the selfTextHTML property on Post

### DIFF
--- a/src/app/components/Post/PostContent/index.jsx
+++ b/src/app/components/Post/PostContent/index.jsx
@@ -121,7 +121,7 @@ function buildSelfTextContent(props) {
 
   if (!post.selfTextHTML) { return; }
 
-  const mobileSelfText = mobilify(post.expandedContent);
+  const mobileSelfText = mobilify(post.selfTextHTML);
   return (
     <RedditLinkHijacker>
       <div


### PR DESCRIPTION
This fixes an issue with a new ads feature that allows embeds and selftext in the same post.
The embed has priority so it is set as the expandedContent property on the model and we were
relying on the expandedContent property to contain the self text.

👓  @schwers  

cc @zeantsoi 