### PR TITLE
Fix horizontal overflow caused by modtools icons

### DIFF
--- a/src/app/components/Post/PostHeader/styles.less
+++ b/src/app/components/Post/PostHeader/styles.less
@@ -74,7 +74,7 @@
     overflow: hidden;
     position: relative;
     vertical-align: middle;
-    flex: 1 1 100%;
+    flex: 1 0;
 
     .themeify({
       color: @theme-meta-text-color;
@@ -120,7 +120,7 @@
   }
 
   &__metadata {
-    flex: 0 1 0;
+    flex: 0 0 auto;
     padding: 5 5 0 0;
   }
 


### PR DESCRIPTION
for [CE-550](https://reddit.atlassian.net/browse/CE-550)

Seems like the flex attributes just weren't _quite_ right here.  These seem to work in the iOS simulator, and they make a bit more sense.

1. The `post-descriptor-line` element _only_ sets the `flex-grow` property to `1`.
2. The `metadata` element _only_ sets the `flex-basis` property to `auto`.

With these settings, the `metadata` element should only ever take up as much space on the line as it needs to given its contents (no growing, no shrinking), and the `post-descriptor-line` element should grow to take up the rest of the available space.

👓 @scarow 
