### PR TITLE
Fix branch links to support android deep linking

### DIFF
--- a/src/lib/smartBannerState.js
+++ b/src/lib/smartBannerState.js
@@ -43,6 +43,9 @@ export function getBranchLink(state, payload={}) {
     userId = userAccount.id;
   }
 
+
+  const path = window.location.href.split(window.location.host)[1];
+
   const basePayload = {
     channel: 'mweb_branch',
     feature: 'xpromo',
@@ -53,7 +56,9 @@ export function getBranchLink(state, payload={}) {
     // Pass in data you want to appear and pipe in the app,
     // including user token or anything else!
     '$og_redirect': window.location.href,
-    '$deeplink_path': window.location.href.split(window.location.host)[1],
+    '$deeplink_path': path,
+    // android deep links expect reddit/ prefixed urls
+    '$android_deeplink_path': `reddit${path}`,
     mweb_loid: loid,
     mweb_loid_created: loidCreated,
     mweb_user_id36: userId,


### PR DESCRIPTION
The Reddit Android app expects `reddit://` url scheme links to start with `reddit`. Adding a new `$android_deeplink_path` attr to our branch links with that prefix makes the deep links work as expected.

There's a test version of this with comments xpromo enabled at: https://android-deeplinks.mobile.staging.snooguts.net/

👓 @prashtx