### PR TITLE
Fix a few comments bugs from state and seo.

### DIFF
--- a/src/apiClient/apiBase/Model.js
+++ b/src/apiClient/apiBase/Model.js
@@ -211,8 +211,8 @@ export default class Model {
         obj[key] = this[key];
       }
     });
-
-    obj.__type = this.type;
+    obj.uuid = this.uuid;
+    obj.type = this.type;
     return obj;
   }
 }

--- a/src/app/actions/commentsPage.js
+++ b/src/app/actions/commentsPage.js
@@ -55,7 +55,7 @@ export const visitedCommentsPage = (postId) => ({
 export const fetchCommentsPage = commentsPageParams => async (dispatch, getState) => {
   const state = getState();
   const commentsPageId = paramsToCommentsPageId(commentsPageParams);
-  const commentsPage = state.commentsPages[commentsPageId];
+  const commentsPage = state.commentsPages.api[commentsPageId];
 
   if (commentsPage) { return; }
 

--- a/src/app/components/CommentTree/index.jsx
+++ b/src/app/components/CommentTree/index.jsx
@@ -100,8 +100,8 @@ const renderNode = (props, depth, data, isHidden) => {
     isSubredditModerator,
     commentDispatchers,
     reports,
-    postPermalink,
   } = props;
+  const postPermalink = post.cleanPermalink;
   const uuid = data.name;
   const authorType = determineAuthorType(data, user, post.author || '');
   const editObject = thingsBeingEdited[uuid];
@@ -170,7 +170,7 @@ function renderDots(count) {
   return <div className='CommentHeader__dots'>{ content }</div>;
 }
 
-const renderContinueThread = (onContinueThread, data, isTopLevel, dotsNum, postPermalink) => {
+const renderContinueThread = (onLoadMore, data, isTopLevel, dotsNum, postPermalink) => {
   const isPending = data.isPending;
   const isLoadMore = data.type === COMMENT_LOAD_MORE;
   const label = isLoadMore ?
@@ -182,7 +182,13 @@ const renderContinueThread = (onContinueThread, data, isTopLevel, dotsNum, postP
   return (
     <Anchor
       className='CommentTree__continueThread'
-      onClick={ onContinueThread }
+      onClick={ e => {
+        // If this is a real continue thread link, let the normal page navigation
+        // from Anchor handle this
+        if (isLoadMore) {
+          onLoadMore(e);
+        }
+      } }
       href={ url }
     >
       { renderDots(dotsNum) }

--- a/src/app/pages/Comments.jsx
+++ b/src/app/pages/Comments.jsx
@@ -116,7 +116,10 @@ const stateProps = createSelector(
   },
   state => {
     const subredditName = getSubreddit(state);
-    const subreddit = state.subreddits[subredditName];
+    if (!subredditName) {
+      return false;
+    }
+    const subreddit = state.subreddits[subredditName.toLowerCase()];
     return subreddit ? subreddit.spoilersEnabled : false;
   },
   state => state.platform.currentPage,

--- a/src/app/reducers/helpers/stickyCommentsFromState.js
+++ b/src/app/reducers/helpers/stickyCommentsFromState.js
@@ -10,11 +10,11 @@ export default function(state) {
   const { commentsPages } = state;
   if (!commentsPages) { return []; }
 
-  const activePage = commentsPages[commentsPages.current];
-  if (!(activePage && activePage.results.length)) { return []; }
+  const activePage = commentsPages.data[commentsPages.data.current];
+  if (!(activePage && activePage.length)) { return []; }
   
-  const stickiedComments = activePage.results.map(r => modelFromThingId(r.uuid, state))
-                                             .filter(r => r.stickied);
+  const stickiedComments = activePage.map(r => modelFromThingId(r.uuid, state))
+                                     .filter(r => r.stickied);
 
   return stickiedComments;
 }

--- a/src/lib/getContentIdFromState.js
+++ b/src/lib/getContentIdFromState.js
@@ -3,18 +3,21 @@ import has from 'lodash/has';
 export default function getContentId(state) {
   // Use post ID for comments pages and comment permalinks
   if (has(state, ['platform', 'currentPage', 'urlParams', 'postId']) &&
-      has(state, ['commentsPages', 'current'])) {
+      has(state, ['commentsPages', 'data', 'current'])) {
     // Vanilla comments page and comment permalink pages will have an entry in
     // state.commentsPages
-    const commentsPage = state.commentsPages[state.commentsPages.current];
+    const commentsPage = state.commentsPages.data[state.commentsPages.data.current];
     return commentsPage.postId;
   }
 
   // Use the subreddit fullname for subreddit listings
   if (has(state, ['platform', 'currentPage', 'urlParams', 'subredditName'])) {
-    const subreddit = state.platform.currentPage.urlParams.subredditName;
-    if (subreddit) {
-      return state.subreddits[subreddit].name;
+    const subredditName = state.platform.currentPage.urlParams.subredditName;
+    if (subredditName) {
+      const subreddit = state.subreddits[subredditName.toLowerCase()];
+      if (subreddit) {
+        return subreddit.name;
+      }
     }
   }
 

--- a/src/lib/getSubredditFromState.js
+++ b/src/lib/getSubredditFromState.js
@@ -1,25 +1,19 @@
-import has from 'lodash/has';
-
 export default function getSubreddit(state) {
   if (state.platform.currentPage.urlParams.subredditName) {
     return state.platform.currentPage.urlParams.subredditName;
   }
 
-  if (!has(state, ['commentsPages', 'current'])) {
+  const current = state.commentsPages.data.current;
+  if (!current) {
     return null;
   }
 
-  const current = state.commentsPages.current;
-  if (!has(state, ['commentsPages', current, 'results'])) {
+  const currentResults = state.commentsPages.data[current];
+  if (!currentResults || currentResults.length === 0) {
     return null;
   }
 
-  const results = state.commentsPages[current].results;
-  if (results.length === 0) {
-    return null;
-  }
-
-  const comment = state.comments[results[0].uuid];
+  const comment = state.comments.data[currentResults[0].uuid];
   if (!comment) {
     return null;
   }

--- a/test/lib/getContentIdFromState.test.js
+++ b/test/lib/getContentIdFromState.test.js
@@ -30,8 +30,8 @@ describe('lib: getContentIdFromState', () => {
     set(sampleState, 'platform.currentPage.urlParams.subredditName', 'pics');
     set(sampleState, 'platform.currentPage.urlParams.postId', 'foo');
     set(sampleState, 'subreddits.pics.name', 't5_2qh0u');
-    set(sampleState, 'commentsPages.current', 'deadbeef');
-    set(sampleState, 'commentsPages.deadbeef.postId', 't3_foo');
+    set(sampleState, 'commentsPages.data.current', 'deadbeef');
+    set(sampleState, 'commentsPages.data.deadbeef.postId', 't3_foo');
     expect(getContentId(sampleState)).to.equal('t3_foo');
   });
 

--- a/test/lib/getSubredditFromState.test.js
+++ b/test/lib/getSubredditFromState.test.js
@@ -11,7 +11,11 @@ describe('lib: getSubredditFromState', () => {
   it('is a function', () => {
     expect(getSubreddit).to.be.a('function');
   });
-  const sampleState = {};
+  const sampleState = {
+    commentsPages: {
+      data: {},
+    },
+  };
 
   it('null on empty object', () => {
     set(sampleState, 'platform.currentPage.urlParams.subredditName', null);
@@ -25,19 +29,19 @@ describe('lib: getSubredditFromState', () => {
 
   it('null on commentsPages.current.results being null', () => {
     set(sampleState, 'platform.currentPage.urlParams.subredditName', null);
-    set(sampleState, 'commentsPages.current', 'pics');
-    set(sampleState, 'commentsPages.pics.results', []);
+    set(sampleState, 'commentsPages.data.current', 'pics');
+    set(sampleState, 'commentsPages.data.pics', []);
     expect(getSubreddit(sampleState)).to.equal(null);
   });
 
   it('null on commentsPages.current.results being null', () => {
-    set(sampleState, 'commentsPages.pics.results[0].uuid', 't3_foobar');
-    set(sampleState, 'comments.t3_foobar', undefined);
+    set(sampleState, 'commentsPages.data.pics[0].uuid', 't3_foobar');
+    set(sampleState, 'comments.data.t3_foobar', undefined);
     expect(getSubreddit(sampleState)).to.equal(null);
   });
 
   it('null on commentsPages.current.results being null', () => {
-    set(sampleState, 'comments.t3_foobar.subreddit', 'gifs');
+    set(sampleState, 'comments.data.t3_foobar.subreddit', 'gifs');
     expect(getSubreddit(sampleState)).to.equal('gifs');
   });
 


### PR DESCRIPTION
Noteable changes:
  * Updates access to `state.comments` and `state.commentsPages`
  * Fix api model toJSON serialization that was causing some
      Javascript errors on full (seo) renders. `uuid` and `type`
      weren't being serialized properly. This could affect
      SEO crawlers that run JavaScript.
  * Fix `undefined` in href's on continue thread / more comments
      links
   * Fixes tests