### PR TITLE
Record more status codes

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -62,7 +62,8 @@ const getUserAgentAndURL = () => ({
 });
 
 // We hang on to this so we can call it after we add our own onerror callback.
-const sentryOnError = window.onerror;
+const noOp = () => {}; // no-op for debug-mode when sentry isn't enabled
+const sentryOnError = window.onerror || noOp;
 
 // register `window.onerror` and `window.onunhandledrejection` handlers
 // asap to start logging any errors that come through.

--- a/src/app/actions/ads.js
+++ b/src/app/actions/ads.js
@@ -92,6 +92,11 @@ const nextAdId = () => (uniqueId('ad_'));
 // is more explicit and safer if the page were to change while we await.
 export const fetchNewAdForPostsList = (postsListId, pageParams) =>
   async (dispatch, getState) => {
+    // don't render ads for SEO crawlers
+    if (process.env.ENV !== 'client') {
+      return;
+    }
+
     const state = getState();
     const adRequest = state.adRequests[postsListId];
     if (adRequest && adRequest.loading) { return; }
@@ -122,7 +127,7 @@ export const fetchNewAdForPostsList = (postsListId, pageParams) =>
     await fetchAddBasedOnResults(dispatch, loadedState, adId, postsList, pageParams);
   };
 
-export const fetchSpecificAd = async (dispatch, state, adId, specificAd) => {
+const fetchSpecificAd = async (dispatch, state, adId, specificAd) => {
   try {
     const byIdRequest = PostsEndpoint.get(apiOptionsFromState(state), { id: specificAd });
     const ad = byIdRequest.getModelFromRecord(byIdRequest.results[0]);
@@ -136,7 +141,7 @@ export const fetchSpecificAd = async (dispatch, state, adId, specificAd) => {
   }
 };
 
-export const fetchAddBasedOnResults = async (dispatch, state, adId, postsList, pageParams) => {
+const fetchAddBasedOnResults = async (dispatch, state, adId, postsList, pageParams) => {
   // I don't know what dt stands for but its the thingId's of all the posts
   // on the page.
   const dt = postsList.results.map(record => record.uuid);

--- a/src/app/actions/commentsPage.js
+++ b/src/app/actions/commentsPage.js
@@ -69,11 +69,7 @@ export const fetchCommentsPage = commentsPageParams => async (dispatch, getState
     const apiResponse = await CommentsEndpoint.get(apiOptions, commentsPageParams);
     dispatch(received(commentsPageId, apiResponse));
   } catch (e) {
-    if (e instanceof ResponseError) {
-      dispatch(failed(commentsPageId, e));
-    } else {
-      throw e;
-    }
+    dispatch(failed(commentsPageId, e));
   }
 };
 

--- a/src/app/actions/postsList.js
+++ b/src/app/actions/postsList.js
@@ -2,7 +2,6 @@ import { apiOptionsFromState } from 'lib/apiOptionsFromState';
 import { paramsToPostsListsId } from 'app/models/PostsList';
 
 import PostsEndpoint from 'apiClient/apis/PostsEndpoint';
-import ResponseError from 'apiClient/errors/ResponseError';
 
 export const FETCHING_POSTS_LIST = 'FETCHING_POSTS_LIST';
 export const fetching = (postsListId, postsParams) => ({
@@ -39,10 +38,6 @@ export const fetchPostsFromSubreddit = postsParams => async (dispatch, getState)
     const apiResponse = await PostsEndpoint.get(apiOptions, postsParams);
     dispatch(received(postsListId, apiResponse));
   } catch (e) {
-    if (e instanceof ResponseError) {
-      dispatch(failed(postsListId, e));
-    } else {
-      throw e;
-    }
+    dispatch(failed(postsListId, e));
   }
 };

--- a/src/app/reducers/commentsPages/api/index.js
+++ b/src/app/reducers/commentsPages/api/index.js
@@ -31,17 +31,21 @@ export default (state=DEFAULT, action={}) => {
         },
       };
     }
+
     case commentsPageActions.FAILED: {
       const { commentsPageId, error } = action.payload;
+      const responseCode = error && error.status ? error.status : 500;
+
       return {
         ...state,
         [commentsPageId]: {
+          responseCode,
           errors: error,
           pending: false,
-          responseCode: error.status,
         },
       };
     }
+
     case commentsPageActions.FETCHING_COMMENTS_PAGE: {
       const { commentsPageId } = action.payload;
       return {

--- a/src/app/reducers/postsLists.js
+++ b/src/app/reducers/postsLists.js
@@ -50,10 +50,12 @@ export default (state=DEFAULT, action={}) => {
       const currentPostsList = state[postsListId];
       if (!currentPostsList) { return state; }
 
+      const responseCode = error && error.status ? error.status : 500;
+
       return merge(state, {
         [postsListId]: {
+          responseCode,
           loading: false,
-          responseCode: error.status,
         },
       });
     }

--- a/src/app/reduxMiddleware/errorLogger.js
+++ b/src/app/reduxMiddleware/errorLogger.js
@@ -118,6 +118,10 @@ const checkForSpecificErrors = action => {
       if (error) {
         return error;
       }
+
+      if (action.payload && action.payload.error) {
+        return action.payload.error;
+      }
     }
   }
 };

--- a/src/app/router/handlers/CommentsPage.js
+++ b/src/app/router/handlers/CommentsPage.js
@@ -91,11 +91,15 @@ export default class CommentsPage extends BaseHandler {
       fetchSimilarPosts(state, dispatch, post);
       fetchRecommendedSubredditsByPost(state, dispatch, post);
       fetchRecommendedSubredditsToPostsByPost(state, dispatch, post);
+      dispatch(setTitle(this.buildTitle(post)));
     }
 
-    dispatch(setStatus(getState().commentsPages.api[commentsPageId].responseCode));
+    const apiRequest = getState().commentsPages.api[commentsPageId];
+    const statusCode = apiRequest && apiRequest.responseCode
+      ? apiRequest.responseCode
+      : 500;
 
-    dispatch(setTitle(this.buildTitle(post)));
+    dispatch(setStatus(statusCode));
 
     const latestState = getState();
     trackPageEvents(latestState, buildAdditionalEventData(latestState));

--- a/src/app/router/handlers/PostsFromSubreddit.js
+++ b/src/app/router/handlers/PostsFromSubreddit.js
@@ -64,7 +64,12 @@ export default class PostsFromSubreddit extends BaseHandler {
       queryParams: this.queryParams,
     }));
 
-    dispatch(setStatus(getState().postsLists[postsListId].responseCode));
+    const apiRequest = getState().postsLists[postsListId];
+    const statusCode = apiRequest && apiRequest.responseCode
+      ? apiRequest.responseCode
+      : 500;
+
+    dispatch(setStatus(statusCode));
     dispatch(setTitle(this.buildTitle(getState(), subredditName)));
 
     const latestState = getState();

--- a/src/lib/adblock.js
+++ b/src/lib/adblock.js
@@ -2,6 +2,12 @@ import { isHidden } from 'lib/dom';
 import { ADBLOCK_TEST_ID } from 'app/constants';
 
 export const hasAdblock = () => {
+  // Now that this is used in events tracking, add a check to ensure we're
+  // executing on the client
+  if (process.env.ENV !== 'client') {
+    return false;
+  }
+
   const adblockTester = document.getElementById(ADBLOCK_TEST_ID);
   // If the div has been removed, they have adblock
   if (!adblockTester) { return true; }


### PR DESCRIPTION
We've seen an increase in 404's, and bug reports of 'not found' pages. 404's are now down in grafana after https://github.com/reddit/reddit-mobile/pull/1030 was merged. But there are continued reports of bad pages. 

Noteable fixes:
* listing and comments pages should now always dispatch `success` or `failed`, this should ensure we always update the status code properly.
* errorLogger middleware is updated to ensure we properly log comments page failures
* ads requests  aren't made on the server, and as failsafe the adblock check shortcircuits on the server. (this came up in testing SEO renders)
* client's sentryOnError is defaulted to a no-op for dev mode

👓 @curioussavage @prashtx @dwick 

