### PR TITLE
Gracefully handle failed accounts and invalid loidCreated.

### DIFF
--- a/src/app/actions/accounts.js
+++ b/src/app/actions/accounts.js
@@ -1,6 +1,5 @@
 import { apiOptionsFromState } from 'lib/apiOptionsFromState';
 import AccountsEndpoint from 'apiClient/apis/AccountsEndpoint';
-import ResponseError from 'apiClient/errors/ResponseError';
 
 export const FETCHING_ACCOUNT = 'FETCHING_ACCOUNT';
 // options is for the accounts endpoint, its properties are
@@ -38,10 +37,6 @@ export const fetch = options => async (dispatch, getState) => {
     const apiResponse = await AccountsEndpoint.get(apiOptionsFromState(state), query);
     dispatch(received(options, apiResponse));
   } catch (e) {
-    if (e instanceof ResponseError) {
-      dispatch(failed(options, e));
-    } else {
-      throw e;
-    }
+    dispatch(failed(options, e));
   }
 };

--- a/src/app/models/AccountRequest.js
+++ b/src/app/models/AccountRequest.js
@@ -1,4 +1,0 @@
-export const newAccountRequest = (name) => ({
-  id: name,
-  loading: true,
-});

--- a/src/app/reducers/accountRequests.js
+++ b/src/app/reducers/accountRequests.js
@@ -1,9 +1,15 @@
 import merge from 'platform/merge';
 import * as accountActions from 'app/actions/accounts';
-import { newAccountRequest } from 'app/models/AccountRequest';
 import * as loginActions from 'app/actions/login';
 
 const DEFAULT = {};
+
+const newAccountRequest = name => ({
+  id: name,
+  loading: true,
+  failed: false,
+  error: null,
+});
 
 export default function (state=DEFAULT, action={}) {
   switch (action.type) {
@@ -36,6 +42,18 @@ export default function (state=DEFAULT, action={}) {
 
       return merge(state, {
         [name]: { loading: false },
+      });
+    }
+
+    case accountActions.FAILED: {
+      const { error, options: { name } } = action;
+
+      return merge(state, {
+        [name]: {
+          error,
+          loading: false,
+          failed: true,
+        },
       });
     }
 

--- a/src/app/reducers/accountRequests.test.js
+++ b/src/app/reducers/accountRequests.test.js
@@ -3,7 +3,7 @@ import accountRequests from './accountRequests';
 import * as accountActions from 'app/actions/accounts';
 import * as loginActions from 'app/actions/login';
 
-const REQUIRED_KEYS = ['id', 'loading' ];
+const REQUIRED_KEYS = ['id', 'loading', 'failed', 'error'];
 
 createTest({ reducers: { accountRequests } }, ({ getStore, expect }) => {
   describe('accountRequests', () => {
@@ -34,7 +34,12 @@ createTest({ reducers: { accountRequests } }, ({ getStore, expect }) => {
 
     describe('FETCHING_ACCOUNT', () => {
       it('should add an account optimistically', () => {
-        const ACCOUNT = { id: 'foobar', loading: true };
+        const ACCOUNT = {
+          id: 'foobar',
+          loading: true,
+          failed: false,
+          error: null,
+        };
 
         const { store } = getStore();
         store.dispatch(accountActions.fetching({ name: 'foobar' }));
@@ -49,6 +54,12 @@ createTest({ reducers: { accountRequests } }, ({ getStore, expect }) => {
     describe('RECEIVED_ACCOUNT', () => {
       it('should update an account when request is finished', () => {
         const RESULT = { type: 'account', uuid: 'me' };
+        const ACCOUNT = {
+          id: 'foobar',
+          loading: false,
+          failed: false,
+          error: null,
+        };
 
         const { store } = getStore();
         store.dispatch(accountActions.received({ name: 'foobar' }, RESULT));
@@ -56,6 +67,28 @@ createTest({ reducers: { accountRequests } }, ({ getStore, expect }) => {
         const { accountRequests } = store.getState();
         expect(accountRequests).to.have.keys('foobar');
         expect(accountRequests.foobar).to.have.all.keys(REQUIRED_KEYS);
+        expect(accountRequests.foobar).to.eql(ACCOUNT);
+      });
+    });
+
+    describe('FAILED_ACCOUNT', () => {
+      it('should update an account request when it fails', () => {
+        const ERROR = new Error('failed account');
+        const ACCOUNT = {
+          id: 'foobar',
+          loading: false,
+          failed: true,
+          error: ERROR,
+        };
+
+        const { store } = getStore();
+        store.dispatch(accountActions.fetching({ name: 'foobar' }));
+        store.dispatch(accountActions.failed({ name: 'foobar' }, ERROR));
+
+        const { accountRequests } = store.getState();
+        expect(accountRequests).to.have.keys('foobar');
+        expect(accountRequests.foobar).to.have.all.keys(REQUIRED_KEYS);
+        expect(accountRequests.foobar).to.eql(ACCOUNT);
       });
     });
   });

--- a/src/app/reducers/loid.js
+++ b/src/app/reducers/loid.js
@@ -1,5 +1,3 @@
-import pick from 'lodash/pick';
-
 import * as accountActions from 'app/actions/accounts';
 import * as loidActions from 'app/actions/loid';
 
@@ -9,14 +7,26 @@ export default (state=DEFAULT, action={}) => {
   switch (action.type) {
     case loidActions.SET_LOID: {
       const { loid, loidCreated } = action;
-      
+
       if (!loid) { return DEFAULT; }
       return { loid, loidCreated };
     }
     case accountActions.RECEIVED_ACCOUNT: {
       const { apiResponse } = action;
-      return pick(apiResponse.accounts.me, ['loid', 'loidCreated']);
+      if (apiResponse.accounts.me) {
+        // We only want to use the loid/loidcreated values that come
+        // back from the current user's account
+        const { loid, loidCreated } = apiResponse.accounts.me;
+        if (!loid) {
+          return state;
+        }
+
+        return { loid, loidCreated };
+      }
+
+      return state;
     }
+
     default: return state;
   }
 };

--- a/src/app/reducers/loid.test.js
+++ b/src/app/reducers/loid.test.js
@@ -18,7 +18,7 @@ createTest({ reducers: { loid } }, ({ getStore, expect }) => {
         expect(loidCreated).to.equal(CREATED);
       });
 
-      it('should set loids when a new user account is fetched', () => {
+      it('should set loids when the current user account is fetched', () => {
         const LOID = 'EbxVm9pOhRDdk0Ck7S';
         const CREATED = '2016-05-27T05:05:49.012Z';
         const API_RESPONSE = {
@@ -28,6 +28,24 @@ createTest({ reducers: { loid } }, ({ getStore, expect }) => {
         };
 
         const { store } = getStore();
+        store.dispatch(accountActions.received({}, API_RESPONSE));
+
+        const { loid: { loid, loidCreated } } = store.getState();
+        expect(loid).to.equal(LOID);
+        expect(loidCreated).to.equal(CREATED);
+      });
+
+      it('should not set loids when a different user account is received', () => {
+        const LOID = 'EbxVm9pOhRDdk0Ck7S';
+        const CREATED = '2016-05-27T05:05:49.012Z';
+        const API_RESPONSE = {
+          accounts: {
+            some_other_account: { loid: 'foobar', loidCreated: '12341234000' },
+          },
+        };
+
+        const { store } = getStore();
+        store.dispatch(loidActions.setLOID(LOID, CREATED));
         store.dispatch(accountActions.received({}, API_RESPONSE));
 
         const { loid: { loid, loidCreated } } = store.getState();

--- a/src/lib/eventUtils.js
+++ b/src/lib/eventUtils.js
@@ -74,7 +74,7 @@ export function getListingName(state) {
 export function getUserInfoOrLoid(state) {
   const user = state.user;
   const userInfo = state.accounts[user.name];
-  if (!user.loggedOut) {
+  if (userInfo && !user.loggedOut) {
     return {
       'user_id': convertId(userInfo.id),
       'user_name': user.name,


### PR DESCRIPTION
There's a fairly frequent 'invalid time' exception being thrown in
`dispatchInitialUser`, that has the effect of returning no content
and issuing 404s. This seems to be often be associated with a
`FAILED_ACCOUNT` action on the redux stack for Googlebot.
So it's possible they're coming in with an invalid loidcreated cookie
that's causing `Date` to throw.

This patch:
* tracks account request failure status, and doesn't set loid
cookies when there was a failure.
* doesn't set loid cookies if the `me` account request failed
* adds try/catch w/logging when doing loidcreated conversion
* fixes a bug in reducers/loid that was using 'loid' and 'loidcreated'
from any recevied account (it should only be checking accounts.me)

👓  @prashtx @curioussavage 