### PR TITLE
Support comments page paths for profile posts

### DIFF
--- a/src/apiClient/models/Subreddit.js
+++ b/src/apiClient/models/Subreddit.js
@@ -136,9 +136,14 @@ export default class Subreddit extends RedditModel {
   // a permalink url with the subredddit name or someone types in a subreddit name
   // in the goto field we can look-up the subreddit in our cache without converting
   // the name to a thing_id.
+  // We use a special type of subreddit to handle profile posts, and as an
+  // interim measure, we want to handle permalinks that include the display
+  // name for those subreddits (u_profilename). We can safely use the
+  // display_name field for that mapping of URL -> state ID for vanilla
+  // subreddits and for profile post subreddits.
   makeUUID(data) {
-    const { url } = data;
-    return Subreddit.cleanName(url);
+    const { display_name } = data;
+    return Subreddit.cleanName(display_name);
   }
 
   makePaginationId(data) {

--- a/src/app/pages/AppMain.jsx
+++ b/src/app/pages/AppMain.jsx
@@ -141,6 +141,14 @@ const AppMain = props => {
           component={ SavedAndHiddenPage }
         />
         <FramedPage url='/user/:userName/' component={ UserProfilePage } />
+        <FramedPage
+          url='/user/:userName/comments/:postId/:postTitle/:commentId'
+          component={ CommentsPage }
+        />
+        <FramedPage
+          url='/user/:userName/comments/:postId/:postTitle?'
+          component={ CommentsPage }
+        />
         <FramedPage url='/message/compose' component={ DirectMessage } />
         <FramedPage url='/message/:mailType' component={ Messages } />
       </UrlSwitch>

--- a/src/app/router/index.js
+++ b/src/app/router/index.js
@@ -49,6 +49,8 @@ export default [
   ['/user/:userName/:savedOrHidden(saved|hidden)', SavedAndHiddenHandler],
   ['/user/:userName/:commentsOrSubmitted(comments|submitted)', UserActivityHandler],
   ['/user/:userName', UserProfilerHandler, { name: 'user' }],
+  ['/user/:userName/comments/:postId/:postTitle/:commentId', CommentsPageHandler, { name: 'comments' }],
+  ['/user/:userName/comments/:postId/:postTitle?', CommentsPageHandler, { name: 'comments' }],
   ['/live/*', LiveRedirectHandler ],
   ['/login', Login],
   ['/register', Register],


### PR DESCRIPTION
We need to support comments pages that start with `/user/:username/`. We
also need to support subreddits that may have a different visible naming
convention than what appears in the URL for traditional `/r/:subreddit/`
paths.