### PR TITLE
Use subreddit details only when available

### DIFF
--- a/src/apiClient/apis/SavedAndHiddenCommon.js
+++ b/src/apiClient/apis/SavedAndHiddenCommon.js
@@ -24,7 +24,10 @@ const parseBody = (res, apiResponse) => {
 };
 
 const formatQuery = (query) => {
-  return omit(query, 'user');
+  return omit({
+    ...query,
+    sr_detail: 'true',
+  }, 'user');
 };
 
 const validator = (data) => {

--- a/src/apiClient/apis/SearchEndpoint.js
+++ b/src/apiClient/apis/SearchEndpoint.js
@@ -19,6 +19,8 @@ const formatQuery = (query) => {
     delete query.subreddit;
   }
 
+  query.sr_detail = 'true';
+
   return query;
 };
 

--- a/src/app/components/Post/PostHeader/index.jsx
+++ b/src/app/components/Post/PostHeader/index.jsx
@@ -98,8 +98,7 @@ function isValidKeyColorForRendering(keyColor) {
   return keyColor !== '#efefed' && keyColor !== '#222222';
 }
 
-function subredditLabelIfNeeded(sr_detail, subreddit, hideSubredditLabel,
-    interceptListingClick) {
+function subredditLabelIfNeeded(sr_detail, subreddit, hideSubredditLabel, interceptListingClick) {
   if (hideSubredditLabel || !subreddit) { return; }
 
   const keyColorStyle = {};
@@ -110,14 +109,17 @@ function subredditLabelIfNeeded(sr_detail, subreddit, hideSubredditLabel,
     }
   }
 
+  const url = sr_detail ? sr_detail.url : `/r/${subreddit}`;
+  const displayLabel = sr_detail ? sr_detail.display_name_prefixed : `r/${subreddit}`;
+
   return (
     <Anchor
       className='PostHeader__subreddit-link'
-      href={ sr_detail.url }
+      href={ url }
       style={ keyColorStyle }
       onClick={ e => interceptListingClick(e, LISTING_CLICK_TYPES.SUBREDDIT) }
     >
-      { sr_detail.display_name_prefixed }
+      { displayLabel }
     </Anchor>
   );
 }


### PR DESCRIPTION
We recently started using the post model's subredditDetail object to
generate subreddit/profile links and labels for PostHeader. If the post
doesn't have a subredditDetail object, we fall back to the prior method
of using the subreddit name that gets passed in.

Include the `sr_detail=true` parametery on a couple of more API
requests, so that we have access to the subreddit details when possible.