### PR TITLE
Profile screenviews

### DIFF
--- a/src/apiClient/apis/AccountsEndpoint.js
+++ b/src/apiClient/apis/AccountsEndpoint.js
@@ -1,5 +1,6 @@
 import apiRequest from '../apiBase/apiRequest';
 import Account from '../models/Account';
+import Subreddit from '../models/Subreddit';
 
 const getPath = (query) => {
   if (query.loggedOut) {
@@ -15,14 +16,21 @@ const parseGetBody = apiResponse => {
   const { body } = apiResponse.response;
 
   if (body) {
-    const data = {
+    const account = {
       name: 'me', // me is reserved, this should only stay me in the logged out case
       loid: body.loid,
       loid_created: body.loid_created,
       ...(body.data || body),
     };
 
-    apiResponse.addResult(Account.fromJSON(data));
+    apiResponse.addResult(Account.fromJSON(account));
+
+    // Contributor profiles will have a profile subreddit in the account data
+    const subreddit = body.data ? body.data.subreddit : undefined;
+
+    if (subreddit) {
+      apiResponse.addResult(Subreddit.fromJSON(subreddit));
+    }
   }
 
   return apiResponse;

--- a/src/app/components/SortAndTimeSelector/index.jsx
+++ b/src/app/components/SortAndTimeSelector/index.jsx
@@ -92,13 +92,13 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
   const sort = urlParams.sort || queryParams.sort || SORTS.HOT;
   const time = ownProps.time || listingTime(queryParams, sort);
   const { navigateToUrl } = dispatchProps;
-  const { userName } = urlParams;
+  const { userName, commentsOrSubmitted } = urlParams;
 
   let onSortChange;
 
   if (userName) {
     onSortChange = sort =>
-      navigateToUrl(`/user/${userName}/submitted`, {
+      navigateToUrl(`/user/${userName}/${commentsOrSubmitted}`, {
         queryParams: { ...queryParams, sort },
       });
   } else {

--- a/src/app/reducers/subreddits.js
+++ b/src/app/reducers/subreddits.js
@@ -1,5 +1,6 @@
 import mergeAPIModels from './helpers/mergeAPIModels';
 import mergeUpdatedModel from './helpers/mergeUpdatedModel';
+import * as accountActions from 'app/actions/accounts';
 import * as loginActions from 'app/actions/login';
 import * as recommendedSubredditsActions from 'app/actions/recommendedSubreddits';
 import * as subredditsByPostActions from 'app/actions/subredditsByPost';
@@ -16,6 +17,7 @@ export default function(state=DEFAULT, action={}) {
       return DEFAULT;
     }
 
+    case accountActions.RECEIVED_ACCOUNT:
     case recommendedSubredditsActions.RECEIVED_RECOMMENDED_SUBREDDITS:
     case searchActions.RECEIVED_SEARCH_REQUEST:
     case subredditsByPostActions.RECEIVED_SUBREDDITS_BY_POST:

--- a/src/app/reducers/subreddits.test.js
+++ b/src/app/reducers/subreddits.test.js
@@ -1,5 +1,6 @@
 import createTest from 'platform/createTest';
 import subreddits from './subreddits';
+import * as accountActions from 'app/actions/accounts';
 import * as loginActions from 'app/actions/login';
 import * as searchActions from 'app/actions/search';
 import * as subredditActions from 'app/actions/subreddits';
@@ -136,6 +137,38 @@ createTest({ reducers: { subreddits }}, ({ getStore, expect }) => {
           POST_ID,
           { subreddits: {[SUBREDDIT.uuid]: SUBREDDIT}, response: { status: 200 } },
         ));
+
+        const { subreddits } = store.getState();
+        expect(subreddits).to.eql({
+          [SUBREDDIT.uuid]: SUBREDDIT,
+        });
+      });
+    });
+
+
+    describe('RECEIVED_ACCOUNT', () => {
+      it('should consume subreddits from contributor accounts', () => {
+        const ACCOUNT = {
+          uuid: 't2_0001',
+          name: 'FooBar',
+        };
+        const SUBREDDIT = {
+          uuid: 'u_foobar',
+          name: 't5_1',
+        };
+
+        const { store } = getStore();
+        store.dispatch(accountActions.received({
+          name: ACCOUNT.name,
+          loggedOut: true,
+        }, {
+          accounts: {
+            [ACCOUNT.name]: ACCOUNT,
+          },
+          subreddits: {
+            [SUBREDDIT.uuid]: SUBREDDIT,
+          },
+        }));
 
         const { subreddits } = store.getState();
         expect(subreddits).to.eql({

--- a/src/app/router/handlers/UserActivity.js
+++ b/src/app/router/handlers/UserActivity.js
@@ -2,9 +2,11 @@ import { BaseHandler, METHODS } from 'platform/router';
 import { cleanObject } from 'lib/cleanObject';
 import { SORTS } from 'app/sortValues';
 import { COMMENTS_ACTIVITY, POSTS_ACTIVITY } from 'app/actions/activities';
+import * as accountActions from 'app/actions/accounts';
 import * as activitiesActions from 'app/actions/activities';
 import { fetchUserBasedData } from './handlerCommon';
 import { listingTime } from 'lib/listingTime';
+import { trackPageEvents, buildProfileData } from 'lib/eventUtils';
 
 export default class UserActivityHandler extends BaseHandler {
   static activityUrl(userName, activity) {
@@ -42,7 +44,21 @@ export default class UserActivityHandler extends BaseHandler {
     this.queryParams.activity = urlParams.commentsOrSubmitted;
     const activitiesParams = UserActivityHandler.pageParamsToActivitiesParams(this);
 
-    dispatch(activitiesActions.fetch(activitiesParams));
-    fetchUserBasedData(dispatch);
+    await Promise.all([
+      dispatch(activitiesActions.fetch(activitiesParams)),
+      dispatch(accountActions.fetch({ name: activitiesParams.user })),
+      fetchUserBasedData(dispatch),
+    ]);
+
+    const latestState = getState();
+    const screen_name = activitiesParams.activity === POSTS_ACTIVITY
+      ? 'profile_posts'
+      : 'profile_comments';
+
+    trackPageEvents(latestState, buildProfileData(latestState, {
+      screen_name,
+      target_sort: activitiesParams.sort,
+      target_filter_time: activitiesParams.t,
+    }));
   }
 }

--- a/src/app/router/handlers/UserProfile.js
+++ b/src/app/router/handlers/UserProfile.js
@@ -1,9 +1,7 @@
-import find from 'lodash/find';
-
 import { BaseHandler, METHODS } from 'platform/router';
 import * as accountActions from 'app/actions/accounts';
 import { fetchUserBasedData } from './handlerCommon';
-import { convertId, trackPageEvents } from 'lib/eventUtils';
+import { trackPageEvents, buildProfileData } from 'lib/eventUtils';
 
 export default class UserProfilerHandler extends BaseHandler {
   async [METHODS.GET](dispatch, getState) {
@@ -18,30 +16,8 @@ export default class UserProfilerHandler extends BaseHandler {
     ]);
 
     const latestState = getState();
-    trackPageEvents(latestState, buildAdditionalEventData(latestState));
+    trackPageEvents(latestState, buildProfileData(latestState, {
+      screen_name: 'profile_about',
+    }));
   }
-}
-
-function buildAdditionalEventData(state) {
-  const { userName: name } = state.platform.currentPage.urlParams;
-
-  // if a user doesn't exist, this check will catch it. We may want to track
-  // this in the future.
-  if (!name) {
-    return null;
-  }
-
-  const user = find(state.accounts, (_, k) => k.toLowerCase() === name.toLowerCase());
-
-  // another thing to track in the future -- if the user somehow isn't in our state
-  if (!user) {
-    return null;
-  }
-
-  return {
-    target_name: user.name,
-    target_fullname: user.id,
-    target_type: 'account',
-    target_id: convertId(user.id),
-  };
 }

--- a/src/lib/eventUtils.js
+++ b/src/lib/eventUtils.js
@@ -1,3 +1,4 @@
+import find from 'lodash/find';
 import omit from 'lodash/omit';
 import values from 'lodash/values';
 import url from 'url';
@@ -61,6 +62,33 @@ export function buildSubredditData(state) {
   return {
     sr_id: convertId(subreddit.name),
     sr_name: subreddit.displayName,
+  };
+}
+
+export function buildProfileData(state, extraPayload) {
+  const { userName: name } = state.platform.currentPage.urlParams;
+
+  // if a user doesn't exist, this check will catch it. We may want to track
+  // this in the future.
+  if (!name) {
+    return null;
+  }
+
+  const user = find(state.accounts, (_, k) => k.toLowerCase() === name.toLowerCase());
+
+  // another thing to track in the future -- if the user somehow isn't in our state
+  if (!user) {
+    return null;
+  }
+
+
+  return {
+    target_name: user.name,
+    target_fullname: `t2_${user.id}`,
+    target_type: 'account',
+    target_id: convertId(user.id),
+    is_contributor: !!state.subreddits[`u_${user.name.toLowerCase()}`],
+    ...extraPayload,
   };
 }
 


### PR DESCRIPTION
Call out to track page events for the profile posts-activity and
comments-activity screens.

Capture the profile-subreddit data that arrives via account requests.

Add target_sort, target_filter_time, is_contributor, and screen_name
fields to the profile screenview payloads.

Fix the navigation targets for the comments-activity sort selector.

Add the `t2_` prefix for profile (account) screenview target_fullname
values.