### PR TITLE
Fix toggling subscription

### DIFF
--- a/src/apiClient/models/Subreddit.js
+++ b/src/apiClient/models/Subreddit.js
@@ -142,6 +142,12 @@ export default class Subreddit extends RedditModel {
   // display_name field for that mapping of URL -> state ID for vanilla
   // subreddits and for profile post subreddits.
   makeUUID(data) {
+    // We may pass this an already formed model which will have "displayName"
+    // instead of "display_name". So if we already have a uuid, just use that.
+    if (data.uuid) {
+      return data.uuid;
+    }
+
     const { display_name } = data;
     return Subreddit.cleanName(display_name);
   }


### PR DESCRIPTION
makeUUID() can be called from a few places. In some cases,
we have the server response, and in others an already
cleaned object.  Unfortunately, there's a difference
between "display_name" and "displayName", which was
causing us to set the model's uuid to `undefined`
whenever we'd toggle the subscription.  Instead, if
we already have a uuid, just use that.

👓  @schwers @prashtx 