### PR TITLE
Fix content-clipping bug in firefox

### DIFF
--- a/src/app/components/DualPartInterstitial/styles.less
+++ b/src/app/components/DualPartInterstitial/styles.less
@@ -28,6 +28,7 @@
   &__content {
     width: 100%;
     height: 100vh;
+    overflow: hidden;
   }
 
   &__common {


### PR DESCRIPTION
👓  @curioussavage @tomsoir 

This fixes a bug in firefox, where the dual part interstitials duplicate listing is not being clipped. This results in a second listing being rendered without a background, offset from the pages primary listing. 

e.g.
![image](https://cloud.githubusercontent.com/assets/307983/24012651/f4c7225c-0a3b-11e7-9c4d-2bc561a68526.png)



[source](https://www.reddit.com/r/softwaregore/comments/5zinoy/great_new_mobile_reddit_feature_get_twice_the/)