### PR TITLE
Pass the edgebucket cookie along with API requests.

### DIFF
--- a/src/app/actions/loid.js
+++ b/src/app/actions/loid.js
@@ -7,3 +7,10 @@ export const setLOID = ({ loid, loidCookie, loidCreated, loidCreatedCookie }) =>
   loidCreated,
   loidCreatedCookie,
 });
+
+export const SET_EDGE_BUCKET = 'SET_EDGE_BUCKET';
+
+export const setEdgeBucket = ({ edgeBucket }) => ({
+  type: SET_EDGE_BUCKET,
+  edgeBucket,
+});

--- a/src/app/reducers/loid.js
+++ b/src/app/reducers/loid.js
@@ -8,6 +8,7 @@ export const DEFAULT = {
   loidCreated: '',
   loidCookie: '',
   loidCreatedCookie: '',
+  edgeBucket: '',
 };
 
 export default (state=DEFAULT, action={}) => {
@@ -16,7 +17,7 @@ export default (state=DEFAULT, action={}) => {
       const { loid, loidCookie, loidCreated, loidCreatedCookie } = action;
 
       if (!loid) { return DEFAULT; }
-      return { loid, loidCookie, loidCreated, loidCreatedCookie };
+      return { ...state, loid, loidCookie, loidCreated, loidCreatedCookie };
     }
     case accountActions.RECEIVED_ACCOUNT: {
       const { apiResponse } = action;
@@ -48,6 +49,13 @@ export default (state=DEFAULT, action={}) => {
       }
 
       return state;
+    }
+
+    case loidActions.SET_EDGE_BUCKET: {
+      const { edgeBucket } = action;
+
+      if (!edgeBucket) { return state; }
+      return { ...state, edgeBucket };
     }
 
     default: return state;

--- a/src/app/reducers/loid.test.js
+++ b/src/app/reducers/loid.test.js
@@ -97,5 +97,50 @@ createTest({ reducers: { loid } }, ({ getStore, expect }) => {
         expect(loidCreated).to.equal(CREATED);
       });
     });
+
+    describe('SET_EDGE_BUCKET', () => {
+      it('should update the edgebucket cookie', () => {
+        const LOID = 'EbxVm9pOhRDdk0Ck7S';
+        const CREATED = '2016-05-27T05:05:49.012Z';
+        const EDGEBUCKET = 'foo';
+
+        const { store } = getStore();
+        store.dispatch(loidActions.setLOID({
+          loid: LOID,
+          loidCookie: LOID,
+          loidCreated: CREATED,
+          loidCreatedCookie: CREATED,
+        }));
+
+        store.dispatch(loidActions.setEdgeBucket({
+          edgeBucket: EDGEBUCKET,
+        }));
+
+        const { loid: { loid, loidCreated, edgeBucket } } = store.getState();
+        expect(loid).to.equal(LOID);
+        expect(loidCreated).to.equal(CREATED);
+        expect(edgeBucket).to.equal(EDGEBUCKET);
+      });
+
+      it('should be a noop when there is no edgebucket value', () => {
+        const LOID = 'EbxVm9pOhRDdk0Ck7S';
+        const CREATED = '2016-05-27T05:05:49.012Z';
+
+        const { store } = getStore();
+        store.dispatch(loidActions.setLOID({
+          loid: LOID,
+          loidCookie: LOID,
+          loidCreated: CREATED,
+          loidCreatedCookie: CREATED,
+        }));
+
+        store.dispatch(loidActions.setEdgeBucket({}));
+
+        const { loid: { loid, loidCreated, edgeBucket } } = store.getState();
+        expect(loid).to.equal(LOID);
+        expect(loidCreated).to.equal(CREATED);
+        expect(edgeBucket).to.equal('');
+      });
+    });
   });
 });

--- a/src/lib/apiOptionsFromState.js
+++ b/src/lib/apiOptionsFromState.js
@@ -35,7 +35,7 @@ export const apiOptionsFromState = state => {
   // grab loids if we have them, and set the cookie if on the server
   const {
     apiRequestHeaders,
-    loid: { loidCookie, loidCreatedCookie },
+    loid: { loidCookie, loidCreatedCookie, edgeBucket },
     meta,
   } = state;
 
@@ -48,6 +48,10 @@ export const apiOptionsFromState = state => {
 
     if (loidCreatedCookie) {
       cookieHeaders.push(`loidcreated=${loidCreatedCookie}`);
+    }
+
+    if (edgeBucket) {
+      cookieHeaders.push(`edgebucket=${edgeBucket}`);
     }
 
     return merge(options, {

--- a/src/server/initialState/dispatchInitialUser.js
+++ b/src/server/initialState/dispatchInitialUser.js
@@ -8,6 +8,7 @@ export const dispatchInitialUser = async (ctx, dispatch, getState) => {
   // the lack of camel casing on the 'loidcreated' cookie name is intentional.
   const loidCookie = ctx.cookies.get('loid');
   const loidCreatedCookie = ctx.cookies.get('loidcreated');
+  const edgeBucket = ctx.cookies.get('edgebucket');
 
   if (loidCookie && loidCookie.includes('.')) {
     // If there's a `.`, we have the new format of loids,
@@ -25,6 +26,12 @@ export const dispatchInitialUser = async (ctx, dispatch, getState) => {
       loidCookie,
       loidCreated: loidCreatedCookie,
       loidCreatedCookie,
+    }));
+  }
+
+  if (edgeBucket) {
+    dispatch(loidActions.setEdgeBucket({
+      edgeBucket,
     }));
   }
 


### PR DESCRIPTION
We need the API to have any edgebucket cookie we may have received
upstream, which it will use along with the loid cookie, if present.