### PR TITLE
Use author.toLowerCase when comparing against logged in username.

### DIFF
--- a/src/app/components/Comment/CommentDropdown/index.jsx
+++ b/src/app/components/Comment/CommentDropdown/index.jsx
@@ -35,7 +35,7 @@ export default function CommentDropdown(props) {
     reports,
   } = props;
 
-  const userIsAuthor = commentAuthor === username;
+  const userIsAuthor = commentAuthor.toLowerCase() === username;
 
   const modalContent = [
     userIsAuthor

--- a/src/app/components/MessageThread/index.jsx
+++ b/src/app/components/MessageThread/index.jsx
@@ -160,7 +160,9 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
 
   // Find the most recent reply that's not from the user.
   // If one isn't found, they can't reply, plain and simple.
-  const replyMessageId = recentMessageIds.find(id => messages[id].author !== user.name);
+  const replyMessageId = recentMessageIds.find(id => {
+    return messages[id].author.toLowerCase() !== user.name;
+  });
 
   return {
     ...stateProps,

--- a/src/app/components/Post/PostFooter/index.jsx
+++ b/src/app/components/Post/PostFooter/index.jsx
@@ -97,7 +97,7 @@ export default class PostFooter extends React.Component {
     } = props;
 
     const isLoggedIn = user && !user.loggedOut;
-    const canModify = single && isLoggedIn && user.name === post.author;
+    const canModify = single && isLoggedIn && user.name === post.author.toLowerCase();
 
     return (
       <PostDropdown
@@ -127,7 +127,7 @@ export default class PostFooter extends React.Component {
         showModModal={ showModModal }
         modModalId={ modModalId }
         distinguishType={ post.distinguished }
-        isMine={ user && user.name === post.author }
+        isMine={ user && user.name === post.author.toLowerCase() }
         reports={ reports }
         reportModalId={ reportModalId }
       />


### PR DESCRIPTION
A recent patch (c249ea6fe21efc5630b4ae8f01e5000cb73d083b),
changed account uuids to be lowercased, to fix some
issues when comparing the url name to the received account name.
As a side-effect this disabled editing and deleting of comments
for some accounts, and a few other edge cases.
This patch simply calls toLowerCase for those comparisons.
Adding to lowercase in the models would break username display.

👓  @madbook @prashtx 