### PR TITLE
Redirect requests for profile subreddits

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "lint": "eslint src --ext .js,.jsx",
     "lint-errors-only": "eslint src --ext .js,.jsx --quiet",
     "lint-fixup": "eslint src --ext .js,.jsx --fix",
+    "lint-unstaged": "LIST=`git diff-index --name-only HEAD | grep -f *.js | grep -v json;`; if [ \"$LIST\" ]; then eslint $LIST; fi",
+    "lint-diff": "LIST=`git diff-index --name-only 2X | grep -f *.js | grep -v json;`; if [ \"$LIST\" ]; then eslint $LIST; fi",
     "fonts": "webfonts",
     "test": "blueprints -t",
     "test:watch": "npm run test -- -w"


### PR DESCRIPTION
If users or bots make a request for a profile subreddit, we want to
redirect them to the corresponding profile. The underlying subreddit is
just an implementation detail and should not be exposed via the UI.

For bots, we need to issue a 30x redirect status code, so crawlers know
that this is not meant to be an indexed page. We are defaulting to 302
right now but should probably change this to 301 in the future, so we
send a stronger signal that the content should not be indexed at the
original "subreddit" URL.

For regular browser requests and in-app navigation, we will know that
this is a user subreddit on the client, so we issue an in-app navigation
to the corresponding profile page URL.