### PR TITLE
Fix linter errors in CommunityOverlayMenu

### DIFF
--- a/src/app/components/CommunityOverlayMenu/index.jsx
+++ b/src/app/components/CommunityOverlayMenu/index.jsx
@@ -79,7 +79,7 @@ export const CommunityOverlayMenu = (props) => {
             text='All'
             href='/r/all'
             icon='icon-bar-chart orangered-circled-xl'
-          />
+          />,
         ])
         : React.Children.toArray([
           <LinkRow
@@ -93,7 +93,7 @@ export const CommunityOverlayMenu = (props) => {
             text='All'
             href='/r/all'
             icon='icon-bar-chart orangered-circled-xl'
-          />
+          />,
         ])
       }
 


### PR DESCRIPTION
Looks like 0242da273fa20fe6a2f491590a308a0b3e581e7a introduced some linter errors that are causing new builds to fail linting (e.g. https://travis-ci.org/reddit/reddit-mobile/jobs/213859601)

👓 @luisatlive 