### PR TITLE
Fixing of "current" key-param in a Comments page

### DIFF
--- a/src/app/pages/UserActivity/index.jsx
+++ b/src/app/pages/UserActivity/index.jsx
@@ -65,9 +65,7 @@ export const UserActivityPage = connect(mapStateToProps)(props => {
       <PostAndCommentList
         requestLocation='activitiesRequests'
         requestId={ activitiesId }
-        thingProps={ {
-          userActivityPage: true,
-        } }
+        thingProps={ {userActivityPage: true} }
       />
     </div>
   );

--- a/src/lib/getSubredditFromState.js
+++ b/src/lib/getSubredditFromState.js
@@ -1,6 +1,11 @@
 export default function getSubreddit(state) {
+
   if (state.platform.currentPage.urlParams.subredditName) {
     return state.platform.currentPage.urlParams.subredditName;
+  }
+
+  if (!state.platform.currentPage.urlParams.postId) {
+    return null;
   }
 
   const current = state.commentsPages.data.current;


### PR DESCRIPTION
The problem appears after navigation from the comments page (to index page,
for example). In this case, when you request a subreddit name, it will be
returned from the last visited comment page.