### PR TITLE
Search sort

### DIFF
--- a/src/app/components/SortAndTimeSelector/index.jsx
+++ b/src/app/components/SortAndTimeSelector/index.jsx
@@ -101,6 +101,15 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
       navigateToUrl(`/user/${userName}/${commentsOrSubmitted}`, {
         queryParams: { ...queryParams, sort },
       });
+  } else if (/\/search$/.test(url)) {
+    onSortChange = sort => {
+      if (sort === SORTS.HOT || sort === SORTS.NEW) {
+        delete queryParams.t;
+      }
+      navigateToUrl(url, {
+        queryParams: { ...queryParams, sort },
+      });
+    };
   } else {
     onSortChange = sort => {
       const { subredditName } = urlParams;

--- a/src/app/components/SortAndTimeSelector/index.jsx
+++ b/src/app/components/SortAndTimeSelector/index.jsx
@@ -103,6 +103,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
       });
   } else if (/\/search$/.test(url)) {
     onSortChange = sort => {
+      // remove time filter if "hot" or "new"
       if (sort === SORTS.HOT || sort === SORTS.NEW) {
         delete queryParams.t;
       }


### PR DESCRIPTION
Currently, when viewing a search page, if you select a sort option, you get redirected back to the main subreddit view. This change will look for "/search" in the URL, and, if found, the sort query will be added allowing for a sortable search.

(This is my first time working with Redux, so any feedback is welcome. I was initially trying to pass in an onSortChange function to the SortAndTimeSelector in the search page component. I wasn't quite sure how to set everything up, so I ended up just putting this block here.)