### PR TITLE
Fix origin for postMessage on place

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -96,7 +96,7 @@ const config = () => ({
   // Note that this is a public key, so this can be shared.
   recaptchaSitekey: process.env.RECAPTCHA_SITEKEY || '6LeTnxkTAAAAAN9QEuDZRpn90WwKk_R1TRW_g-JC',
 
-  placeDomain: process.env.PLACE_DOMAIN || 'https://reddit.com',
+  placeDomain: process.env.PLACE_DOMAIN || 'https://www.reddit.com',
 });
 
 export default config();


### PR DESCRIPTION
Had to add the `www` to the placeDomain for use in the place postMessage.

:eyeglasses: @schwers