### PR TITLE
changed message compose page placeholders

### DIFF
--- a/src/app/components/DirectMessage/Composition.jsx
+++ b/src/app/components/DirectMessage/Composition.jsx
@@ -25,13 +25,13 @@ export default function DirectMessageComposition(props) {
       <input
         className='DirectMessageComposition__input'
         name='subject'
-        placeholder='Add an interesting title'
+        placeholder='Subject'
       />
       <textarea
         className='DirectMessageComposition__textarea'
         name='body'
         rows='5'
-        placeholder='Add a dank meme reference'
+        placeholder='Message'
       />
       <button
         className='DirectMessageComposition__submit'


### PR DESCRIPTION
Currently the placeholders are "Add an interesting title" for the subject input and "Add a dank meme reference" for the body. These don't really make sense in this context.

https://www.reddit.com/r/mobileweb/comments/63l6aj/the_compose_a_message_page_contains_some_odd/