### PR TITLE
Serve amphtml link data for all self posts

### DIFF
--- a/src/app/featureFlags.js
+++ b/src/app/featureFlags.js
@@ -373,13 +373,7 @@ const config = {
       ] },
     ],
   },
-  [SHOW_AMP_LINK]: {
-    url: 'showamplink',
-    pageBucketPercent: {
-      seed: 'showamplink',
-      percentage: 2,
-    },
-  },
+  [SHOW_AMP_LINK]: true,
   [VARIANT_DEFAULT_SRS_TUTORIAL]: {
     url: 'experimentdefaultsrstutorial',
     and: [{


### PR DESCRIPTION
Render the amphtml link tag for all self post comments pages rather than
just 2%.  By doing the same on desktop, we will let crawlers find and
index the AMP version of all of our self post comments pages.