### PR TITLE
Add support for arbitrary trackers

### DIFF
--- a/src/apiClient/models/PostModel.js
+++ b/src/apiClient/models/PostModel.js
@@ -77,6 +77,7 @@ export default class PostModel extends RedditModel {
     suggestedSort: T.string,
     thirdPartyTracking: T.string,
     thirdPartyTracking2: T.string,
+    thirdPartyTrackers: T.string,
     userReports: T.array,
 
     // derived
@@ -119,6 +120,7 @@ export default class PostModel extends RedditModel {
     sendreplies: 'sendReplies',
     third_party_tracking: 'thirdPartyTracking',
     third_party_tracking_2: 'thirdPartyTracking2',
+    third_party_trackers: 'thirdPartyTrackers',
     url: 'cleanUrl',
     user_reports: 'userReports',
   };

--- a/src/app/actions/ads.js
+++ b/src/app/actions/ads.js
@@ -64,13 +64,18 @@ const IMPRESSION_PROPS = [
   'adserverImpPixel',
   'thirdPartyTracking',
   'thirdPartyTracking2',
+  'thirdPartyTrackers',
 ];
-const trackAdPost = post => {
-  IMPRESSION_PROPS.forEach(prop => {
-    const pixel = new Image();
-    pixel.src = post[prop];
-  });
+
+const firePixel = (src) => {
+  const pixel = new Image();
+  pixel.src = src;
 };
+
+const trackAdPost = post => IMPRESSION_PROPS
+  .map(prop => post[prop] || [])
+  .reduce((acc, cur) => acc.concat(cur), [])
+  .forEach(firePixel);
 
 // Used by Rendered Ads if they detect that adblock has hidden
 // they're content node. This only a thunk'd action because


### PR DESCRIPTION
👓  @jamesmaa 

Already added support for this on r2 desktop. This adds it for mweb.