### PR TITLE
Fix top content padding in XPromo post preview

### DIFF
--- a/src/app/components/DualPartInterstitial/Header/styles.less
+++ b/src/app/components/DualPartInterstitial/Header/styles.less
@@ -13,6 +13,7 @@
   &__childContainer {
     height: 100%;
     overflow: hidden;
+    padding-top: @top-nav-height;
   }
 }
 


### PR DESCRIPTION
<img width="701" alt="screen shot 2017-06-01 at 3 14 51 pm" src="https://cloud.githubusercontent.com/assets/301881/26703281/b5d5349c-46dd-11e7-8059-c7115cab5f2f.png">
(right pic. is correct)