### PR TITLE
Add notification modal component for the OptOut menu link

### DIFF
--- a/src/app/actions/optOuts.js
+++ b/src/app/actions/optOuts.js
@@ -1,0 +1,14 @@
+import * as overlayActions from './overlay';
+import { OPT_OUT_XPROMO_INTERSTITIAL_MENU } from 'app/constants';
+
+export const OPTOUT_SET = 'OPTOUT__SET';
+export const setFlag = (flag, message) => ({
+  type: OPTOUT_SET,
+  message,
+  flag,
+});
+
+export const setXPromoOptout = () => async (dispatch) => {
+  dispatch(setFlag(OPT_OUT_XPROMO_INTERSTITIAL_MENU, 'Updated Preference'));
+  dispatch(overlayActions.closeOverlay());
+};

--- a/src/app/components/SettingsOverlayMenu/index.jsx
+++ b/src/app/components/SettingsOverlayMenu/index.jsx
@@ -11,8 +11,8 @@ import menuItems from './SettingsOverlayMenuItems';
 import { COLOR_SCHEME } from 'app/constants';
 import { userAccountSelector } from 'app/selectors/userAccount';
 import { showXPromoOptOutMenuLink } from 'app/selectors/xpromo';
+import { setXPromoOptout } from 'app/actions/optOuts';
 import config from 'config';
-
 const { NIGHTMODE } = COLOR_SCHEME;
 
 const DESKTOP_TRACKING_PARAMS = {
@@ -46,12 +46,13 @@ export const renderLoginRow = () => (
   />
 );
 
-const xpromoOptOutLink = () => (
+const xpromoOptOutLink = (props) => (
   <LinkRow
     key='xpromo-off'
     text='Ask To Open In App (On)'
     icon='icon-linkout icon-large blue'
-    href={ '/?no_xpromo_interstitial_menu=true' }
+    noRoute={ true }
+    onClick={ props.dismissedXpromo }
   />
 );
 
@@ -136,7 +137,7 @@ export const SettingsOverlayMenu = (props) => {
         onClick={ props.onGoToDesktop }
       />
       {
-        optOut ? xpromoOptOutLink() : null
+        optOut ? xpromoOptOutLink(props) : null
       }
       <ExpandoRow
         key='about-reddit'
@@ -171,7 +172,7 @@ export const SettingsOverlayMenu = (props) => {
 };
 
 
-const mapStateToProps = createSelector(
+const selector = createSelector(
   state => state.compact,
   state => state.theme,
   state => state.platform.currentPage,
@@ -180,8 +181,13 @@ const mapStateToProps = createSelector(
   (compact, theme, pageData, optOut, user) => ({ compact, theme, pageData, optOut, user }),
 );
 
-const mergeProps = stateProps => ({
+const dispatcher = dispatch => ({
+  dismissedXpromo: () => dispatch(setXPromoOptout()),
+});
+
+const mergeProps = (stateProps, dispatchProps) => ({
   ...stateProps,
+  ...dispatchProps,
   onGoToDesktop: () => {
     // this cookie is telling our CDN, "when you see the www url, do NOT
     // direct user to the mweb experience"
@@ -192,4 +198,4 @@ const mergeProps = stateProps => ({
   },
 });
 
-export default connect(mapStateToProps, null, mergeProps)(SettingsOverlayMenu);
+export default connect(selector, dispatcher, mergeProps)(SettingsOverlayMenu);

--- a/src/app/reducers/optOuts.js
+++ b/src/app/reducers/optOuts.js
@@ -13,6 +13,7 @@
 
 import merge from 'platform/merge';
 import * as platformActions from 'platform/actions';
+import * as optOuts from 'app/actions/optOuts';
 import { OPT_OUT_FLAGS } from 'app/constants';
 
 export const DEFAULT = {};
@@ -37,6 +38,11 @@ export default function (state=DEFAULT, action={}) {
         return merge(state, {[STORE_KEY]: undefined});
       }
       // Enable the optOut flag (for all other cases)
+      return merge(state, {[STORE_KEY]: true });
+    }
+
+    case optOuts.OPTOUT_SET: {
+      const { STORE_KEY } = action.flag;
       return merge(state, {[STORE_KEY]: true });
     }
 

--- a/src/app/reducers/optOuts.test.js
+++ b/src/app/reducers/optOuts.test.js
@@ -1,9 +1,10 @@
+import routes from 'app/router';
 import createTest from 'platform/createTest';
 import { METHODS } from 'platform/router';
 import * as platformActions from 'platform/actions';
-import routes from 'app/router';
-import { OPT_OUT_XPROMO_INTERSTITIAL } from '../../app/constants';
+import * as optOutsAction from 'app/actions/optOuts';
 import optOuts, { DEFAULT } from './optOuts';
+import { OPT_OUT_XPROMO_INTERSTITIAL } from '../../app/constants';
 
 const { URL_FLAG, STORE_KEY } = OPT_OUT_XPROMO_INTERSTITIAL;
 
@@ -36,6 +37,13 @@ createTest({ reducers: { optOuts }, routes }, ({ getStore, expect }) => {
         const { optOuts } = store.getState();
         expect(optOuts[STORE_KEY]).to.eql(undefined);
       });
+    });
+
+    it('if setting up the new flag', () => {
+      const { store } = getStore({ optOuts: DEFAULT });
+      store.dispatch(optOutsAction.setFlag(OPT_OUT_XPROMO_INTERSTITIAL));
+      const { optOuts } = store.getState();
+      expect(optOuts[STORE_KEY]).to.eql(true);
     });
   });
 });

--- a/src/app/reducers/toaster.js
+++ b/src/app/reducers/toaster.js
@@ -10,6 +10,7 @@ import * as reportingActions from 'app/actions/reporting';
 import * as mailActions from 'app/actions/mail';
 import * as modToolsActions from 'app/actions/modTools';
 import * as votingActions from 'app/actions/vote';
+import * as optOuts from 'app/actions/optOuts';
 
 const DEFAULT = {
   isOpen: false,
@@ -50,6 +51,7 @@ export default function(state=DEFAULT, action={}) {
       });
     }
 
+    case optOuts.OPTOUT_SET:
     case replyActions.SUCCESS: {
       return merge(state, {
         isOpen: true,


### PR DESCRIPTION
https://reddit.atlassian.net/browse/CHAN-673
In additional: 
— a new menu notification component that is displayed when clicking the OptOuts link.
— now this option optOut works without any URL parameters (?)

PS to toggle the OptOut flag you can use this url-flag:
http://localhost:4444/?no_xpromo_interstitial_menu=false