### PR TITLE
Prevent all gifs from loading on sub reddit open.

### DIFF
--- a/src/app/components/Post/PostContent/index.jsx
+++ b/src/app/components/Post/PostContent/index.jsx
@@ -270,7 +270,7 @@ function buildImagePreview(previewImage, imageURL, linkDescriptor, callback,
     }
 
     const html5sources = gifToHTML5Sources(imageURL, previewImage.url);
-    if (html5sources) {
+    if (isPlaying && html5sources) {
       const { width, height } = previewImage;
       const aspectRatio = getAspectRatio(single, width, height);
 


### PR DESCRIPTION
Gifs should only load video when isPlaying is true, otherwise we load the preview image.