### PR TITLE
Check and load HLS video if initial load failed (expando/hidden etc.) + UI bugfixes

### DIFF
--- a/src/app/components/HTML5StreamPlayer/index.jsx
+++ b/src/app/components/HTML5StreamPlayer/index.jsx
@@ -136,7 +136,8 @@ class HTML5StreamPlayer extends React.Component {
 
       const video = this.refs.HTML5StreamPlayerVideo;
       if (this.props.postData.videoPlaytime > 0) {
-        this.setState({videoLoaded: true,
+        this.setState({
+          videoLoaded: true,
           totalServedTime: this.props.postData.videoPlaytime * 1000.0,
           totalTime: this.secondsToMinutes(video.duration),
           videoWasInView: false,
@@ -144,7 +145,8 @@ class HTML5StreamPlayer extends React.Component {
         this.sendTrackVideoEvent(VIDEO_EVENT.CHANGED_PAGETYPE, this.getPercentServed());
         video.currentTime = this.props.postData.videoPlaytime;
       } else {
-        this.setState({videoLoaded: true,
+        this.setState({
+          videoLoaded: true,
           totalTime: this.secondsToMinutes(video.duration),
           videoWasInView: false,
         });
@@ -553,7 +555,7 @@ class HTML5StreamPlayer extends React.Component {
               { !this.props.isGif &&
                 <div className = 'HTML5StreamPlayer__control__fullscreen'>
                   <button
-                    className = 'HTML5StreamPlayer__control'
+                    className = 'HTML5StreamPlayer__control__button'
                     onClick={ this.state.videoFullScreen ?
                       this.exitFullscreen
                       : this.enterFullScreen
@@ -570,7 +572,7 @@ class HTML5StreamPlayer extends React.Component {
               }
 
               <div className = 'HTML5StreamPlayer__control__mute'>
-                <button className = 'HTML5StreamPlayer__control' onClick = { this.muteVideo }>
+                <button className = 'HTML5StreamPlayer__control__button' onClick = { this.muteVideo }>
                   { this.renderMute() }
                 </button>
               </div>

--- a/src/app/components/HTML5StreamPlayer/index.jsx
+++ b/src/app/components/HTML5StreamPlayer/index.jsx
@@ -21,6 +21,7 @@ class HTML5StreamPlayer extends React.Component {
     onUpdatePostPlaytime: T.func.isRequired,
     scrubberThumbSource: T.string.isRequired,
     isGif: T.bool.isRequired,
+    isVertical: T.bool.isRequired,
     posterImage: T.string.isRequired,
   };
 
@@ -617,17 +618,15 @@ class HTML5StreamPlayer extends React.Component {
 
   buildBaseEventData() {
     const video = this.refs.HTML5StreamPlayerVideo;
-    const { postData } = this.props;
+    const { postData, isVertical, isGif } = this.props;
 
     let currentTime = 0;
     let durationTime = 0;
-    let isVertical = false;
     let pageType = this.state.videoFullScreen ? 'full_screen' : 'listing';
 
     if (video) {
       currentTime = parseInt(video.currentTime * 1000);
       durationTime = parseInt(video.duration * 1000);
-      isVertical = (video.height > video.width);
 
       if (isCommentsPage(this.props.currentPage) === true) {
         pageType = 'comments';
@@ -658,7 +657,7 @@ class HTML5StreamPlayer extends React.Component {
       target_id: parseInt(postData.id, 36),
       target_url: postData.cleanUrl,
       target_url_domain: postData.domain,
-      target_type: (this.state.isGif ? 'gif':'video'),
+      target_type: (isGif ? 'gif':'video'),
       sr_name: postData.subreddit,
       sr_fullname: postData.subredditId,
       sr_id: parseInt(subredditShortID, 36),

--- a/src/app/components/HTML5StreamPlayer/styles.less
+++ b/src/app/components/HTML5StreamPlayer/styles.less
@@ -222,7 +222,7 @@
       align-items: center;
       height: 25px;
       width: auto;
-      margin-top: 8px;
+      margin-top: @track-height;
       margin-left: 35px;
       margin-right: 35px;
     }

--- a/src/app/components/HTML5StreamPlayer/styles.less
+++ b/src/app/components/HTML5StreamPlayer/styles.less
@@ -126,6 +126,16 @@
       width:100%;
     }
 
+    &__button {
+      outline: none;
+      padding-top: 0px;
+      padding-bottom: 0px;
+      height: 100%;
+      width: 100%;
+      padding-left: 5vw;
+      padding-right: 5vw;
+    }
+
     &__play:hover .HTML5StreamPlayer__playback-action-circle{
       opacity: 0.8;
       background-color: #0DD3BB;
@@ -136,11 +146,8 @@
       height: 45px;
       left: 0;
       bottom: 0;
-      max-width: 100vw;
-      width: 100vw;
-      padding-top: 20px;
-      padding-left: @track-button-spacing;
-      padding-right: @track-button-spacing;
+      right: 0;
+      width: auto;
       background: -moz-linear-gradient(top, rgba(0,0,0,0) 0%, rgba(0,0,0,0.65) 100%); /* FF3.6-15 */
       background: -webkit-linear-gradient(top, rgba(0,0,0,0) 0%,rgba(0,0,0,0.65) 100%); /* Chrome10-25,Safari5.1-6 */
       background: linear-gradient(to bottom, rgba(0,0,0,0) 0%,rgba(0,0,0,0.65) 100%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
@@ -150,22 +157,15 @@
     &__fullscreen {
       outline: none;
       float: right;
-      margin-right: @track-button-spacing;
-      height: 25px;
-      width: 25px;
-      font-size: 25px;
     }
 
     &__mute {
       outline: none;
-      position: absolute;
-      left: 0;
-      height: 25px;
-      width: 25px;
-      font-size: 25px;
+      float: left;
     }
 
     &__barMargin {
+      margin-top: 20px;
       margin-left: @track-margin-width;
       margin-right: @track-margin-width;
     }
@@ -220,11 +220,11 @@
       position: relative;
       justify-content: center;
       align-items: center;
-      height: 25px;
       width: auto;
+      height: 45px;
       margin-top: @track-height;
-      margin-left: 35px;
-      margin-right: 35px;
+      margin-left: 15vw;
+      margin-right: 15vw;
     }
 
     &__scrubBar {
@@ -319,30 +319,29 @@
       outline: none;
       width: 25px;
       height: 25px;
+      font-size: 25px;
       color: #0DD3BB;
     }
   }
 
   &__playback-full-screen-collapse {
     outline: none;
-    width: 25px;
-    height: 25px;
+    width: auto;
+    height: auto;
     &.icon-full-screen-collapse {
       outline: none;
-      width: 25px;
-      height: 25px;
+      font-size: 25px;
       color: #0DD3BB;
     }
   }
 
   &__playback-mute {
     outline: none;
-    width: 25px;
-    height: 25px;
+    width: auto;
+    height: auto;
     &.icon-mute {
       outline: none;
-      width: 25px;
-      height: 25px;
+      font-size: 25px;
       color: #0DD3BB;
     }
   }
@@ -350,12 +349,11 @@
 
   &__playback-unmute {
     outline: none;
-    width: 25px;
-    height: 25px;
+    width: auto;
+    height: auto;
     &.icon-unmute {
       outline: none;
-      width: 25px;
-      height: 25px;
+      font-size: 25px;
       color: #0DD3BB;
     }
   }

--- a/src/app/components/Post/PostContent/index.jsx
+++ b/src/app/components/Post/PostContent/index.jsx
@@ -430,7 +430,7 @@ function renderVideo(videoSpec, posterImage, aspectRatio, props) {
     } else {
       aspectRatio = getAspectRatio(false, videoSpec.width, videoSpec.height);
     }
-
+    
     return (
       <HTML5StreamPlayer
         postData = { post }
@@ -439,6 +439,7 @@ function renderVideo(videoSpec, posterImage, aspectRatio, props) {
         hlsSource = { videoSpec.hls }
         mpegDashSource = { videoSpec.dash }
         isGif = { videoSpec.isGif }
+        isVertical = { (videoSpec.height > videoSpec.width) }
         posterImage = { posterImage.url }
         scrubberThumbSource = { videoSpec.scrubberThumbSource }
       />

--- a/src/app/components/Post/PostContent/index.jsx
+++ b/src/app/components/Post/PostContent/index.jsx
@@ -430,7 +430,7 @@ function renderVideo(videoSpec, posterImage, aspectRatio, props) {
     } else {
       aspectRatio = getAspectRatio(false, videoSpec.width, videoSpec.height);
     }
-    
+
     return (
       <HTML5StreamPlayer
         postData = { post }

--- a/src/app/components/Post/PostContent/index.jsx
+++ b/src/app/components/Post/PostContent/index.jsx
@@ -439,6 +439,7 @@ function renderVideo(videoSpec, posterImage, aspectRatio, props) {
         hlsSource = { videoSpec.hls }
         mpegDashSource = { videoSpec.dash }
         isGif = { videoSpec.isGif }
+        posterImage = { posterImage.url }
         scrubberThumbSource = { videoSpec.scrubberThumbSource }
       />
     );


### PR DESCRIPTION
Initialize scrub thumb position on HTML5StreamPlayer scrub start.
Reduce state dependencies in the HTML5StreamPlayer component (state updates occur as needed but current state is retrieved from video tag where possible).
Add additional loading checks incase initial load fails.
Align scrub track to player buttons