### PR TITLE
Switch to /notification/ URLs for inbox 

### DIFF
--- a/default.vcl
+++ b/default.vcl
@@ -29,6 +29,7 @@ sub vcl_recv {
       || req.url ~ "^/comments/?"
       || req.url ~ "^/login/?$"
       || req.url ~ "^/message/"
+      || req.url ~ "^/notification/"
       || req.url ~ "^/r/"
       || req.url ~ "^/register/?$"
       || req.url ~ "/search/?$"

--- a/src/app/components/Messages/Nav.jsx
+++ b/src/app/components/Messages/Nav.jsx
@@ -6,10 +6,10 @@ import { Anchor } from 'platform/components';
 const T = React.PropTypes;
 
 const TYPES = [
-  { type: 'messages', text: 'MESSAGES', icon: 'icon-message' },
-  { type: 'comments', text: 'COMMENTS', icon: 'icon-comment' },
-  { type: 'selfreply', text: 'POST REPLIES', icon: 'icon-post' },
-  { type: 'mentions', text: 'MENTIONS', icon: 'icon-crown' },
+  { type: 'messages', basepath: 'message', text: 'MESSAGES', icon: 'icon-message' },
+  { type: 'comments', basepath: 'notification', text: 'COMMENTS', icon: 'icon-comment' },
+  { type: 'selfreply', basepath: 'notification', text: 'POST REPLIES', icon: 'icon-post' },
+  { type: 'mentions', basepath: 'notification', text: 'MENTIONS', icon: 'icon-crown' },
 ];
 
 export default function MessagesNav(props) {
@@ -24,10 +24,10 @@ MessagesNav.propTypes = {
   currentMailType: T.string.isRequired,
 };
 
-const renderNavItem = ({ type, text, icon }, currentType) => (
+const renderNavItem = ({ type, text, icon, basepath }, currentType) => (
   <Anchor
     className={ `MessagesNav__item ${ type === currentType ? 'm-selected' : '' }` }
-    href={ `/message/${ type }` }
+    href={ `/${basepath}/${ type }` }
   >
     <div className={ `MessagesNav__icon icon ${ icon }` }/>
     <div className='MessagesNav__text'>{ text }</div>

--- a/src/app/pages/AppMain.jsx
+++ b/src/app/pages/AppMain.jsx
@@ -158,6 +158,7 @@ const AppMain = props => {
         />
         <Page url='/message/compose' component={ FramedDirectMessage } />
         <Page url='/message/:mailType' component={ FramedMessages } />
+        <Page url='/notification/:mailType' component={ FramedMessages } />
       </UrlSwitch>
       { showDropdownCover ? <DropdownCover /> : null }
       { isToasterOpen ? <Toaster /> : null }

--- a/src/app/router/index.js
+++ b/src/app/router/index.js
@@ -61,6 +61,7 @@ export default [
   ['/message/compose', DirectMessage],
   ['/message/:mailType', Messages],
   ['/message/messages/:threadId', Messages],
+  ['/notification/:mailType', Messages],
   ['/r/:subredditName/submit', PostSubmitHandler, { name: 'submit' }],
   ['/submit', PostSubmitHandler],
   ['/submit/to_community', PostSubmitCommunityHandler],

--- a/src/server/meta/index.js
+++ b/src/server/meta/index.js
@@ -120,6 +120,7 @@ export default (router, apiOptions) => {
       Disallow: /search
       Disallow: /r/*/search
       Disallow: /u/*
+      Disallow: /notification/*
       Disallow: /message/*
       Disallow: /submit*
       Disallow: /r/*/submit/*

--- a/test/test_vcl.py
+++ b/test/test_vcl.py
@@ -100,6 +100,7 @@ WHITELISTED_ROUTES = [
     '/comments/',
     '/login',
     '/message/',
+    '/notification/',
     '/r/nba',
     '/register/',
     '/report',


### PR DESCRIPTION
Context: desktop will soon redirect `/message/{where}` to `/notification/{where}` for comment-reply notification feeds
