### PR TITLE
Add amazon a9 header bidding

### DIFF
--- a/src/app/components/BannerAd/index.jsx
+++ b/src/app/components/BannerAd/index.jsx
@@ -28,6 +28,7 @@ class BannerAd extends React.Component {
       properties,
       sizes,
       shouldCollapse,
+      a9,
     } = this.props;
 
     this.destroySlot();
@@ -38,15 +39,12 @@ class BannerAd extends React.Component {
       properties,
       shouldCollapse,
       sizes,
-    }).then((adSlot) => { this.adSlot = adSlot; });
+      a9,
+    });
   }
 
   destroySlot() {
-    if (this.adSlot) {
-      destroySlot(this.adSlot);
-
-      this.adSlot = null;
-    }
+    destroySlot(this.props.slot);
   }
 
   componentDidMount() {
@@ -60,13 +58,13 @@ class BannerAd extends React.Component {
   componentWillReceiveProps(nextProps) {
     const compactChanged = nextProps.compact !== this.props.compact;
     const themeChanged = nextProps.theme !== this.props.theme;
-    if (this.adSlot && (compactChanged || themeChanged)) {
+    if (compactChanged || themeChanged) {
       this.destroySlot();
     }
   }
 
   componentWillUnmount() {
-    this.destroySlot(this.adSlot);
+    this.destroySlot();
   }
 
   shouldComponentUpdate(nextProps) {
@@ -99,6 +97,7 @@ BannerAd.propTypes = {
   shouldCollapse: T.bool,
   sizes: T.array,
   slot: T.string,
+  a9: T.bool,
 };
 
 const subredditSelector = (state) => {

--- a/src/app/pages/Comments.jsx
+++ b/src/app/pages/Comments.jsx
@@ -63,6 +63,7 @@ function CommentsPage(props) {
           id='comments-banner'
           shouldCollapse
           listingName='comments'
+          a9
         />
       }
       <RecommendedPosts

--- a/src/lib/dfp.js
+++ b/src/lib/dfp.js
@@ -3,6 +3,8 @@ import isFakeSubreddit from 'lib/isFakeSubreddit';
 
 const FRONTPAGE_NAME = 'frontpage';
 
+const adSlots = {};
+
 export const getSlotId = (listingName, subredditName) => {
   const parts = [config.dfpSlotPrefix];
 
@@ -23,14 +25,23 @@ export const defineSlot = (element, {
   properties,
   shouldCollapse,
   sizes,
+  a9 = false,
 }) => {
   const googletag = (window.googletag = window.googletag || {});
   googletag.cmd = googletag.cmd || [];
   return new Promise(resolve => {
     googletag.cmd.push(function() {
+      // make sure we don't try to create the same ad slot twice.
+      destroySlot(slot);
+
       const adSlot = googletag
         .defineSlot(slot, sizes, id)
         .addService(googletag.pubads());
+
+      // save a reference so we can look this up later.
+      // outside of this closure we should always be using this
+      // reference, not `adSlot`.
+      adSlots[slot] = adSlot;
 
       if (shouldCollapse) {
         adSlot.setCollapseEmptyDiv(true);
@@ -40,20 +51,61 @@ export const defineSlot = (element, {
         adSlot.setTargeting(key, properties[key]);
       });
 
-      googletag.display(id);
-      googletag.pubads().refresh([adSlot]);
+      const makeAdRequest = () => {
+        googletag.cmd.push(function() {
+          // slot was destroyed already
+          if (!adSlots[slot]) {
+            return;
+          }
 
-      resolve(adSlot);
+          googletag.display(id);
+          googletag.pubads().refresh([adSlots[slot]]);
+        });
+        resolve();
+      };
+
+      if (a9) {
+        window.apstag.fetchBids({
+          slots: [{
+            slotID: id,
+            sizes,
+          }],
+          timeout: 2e3,
+        }, (bids) => {
+          googletag.cmd.push(function() {
+            // slot was destroyed already
+            if (!adSlots[slot]) {
+              return;
+            }
+
+            // we only request a single bid.
+            const bid = bids[0];
+            ['amznbid', 'amzniid'].forEach(function(key) {
+              adSlots[slot].setTargeting(key, bid[key]);
+            });
+          });
+
+          makeAdRequest();
+        });
+      } else {
+        makeAdRequest();
+      }
     });
   });
 };
 
-export const destroySlot = (slot) => {
+export const destroySlot = (slotId) => {
+  const adSlot = adSlots[slotId];
+  if (!adSlot) {
+    return;
+  }
+
   const googletag = (window.googletag = window.googletag || {});
   googletag.cmd = googletag.cmd || [];
 
   googletag.cmd.push(function() {
-    googletag.destroySlots([slot]);
+    googletag.destroySlots([adSlot]);
+    delete adSlots[slotId];
   });
 };
 
@@ -77,5 +129,16 @@ export const setupGoogleTag = () => {
   googletag.cmd.push(function() {
     googletag.pubads().disableInitialLoad();
     googletag.enableServices();
+  });
+
+  // amazon a9
+  // eslint-disable-next-line
+  !function(a9,a,p,s,t,A,g){if(a[a9])return;function q(c,r){a[a9]._Q.push([c,r])}a[a9]={init:function(){q('i',arguments)},fetchBids:function(){q('f',arguments)},_Q:[]};A=p.createElement(s);A.async=!0;A.src=t;g=p.getElementsByTagName(s)[0];g.parentNode.insertBefore(A,g)}('apstag',window,document,'script','//c.amazon-adsystem.com/aax2/apstag.js');
+
+  // this is defined in the above IIF
+  window.apstag.init({
+    pubID: '3379',
+    adServer: 'googletag',
+    bidTimeout: 2e3,
   });
 };


### PR DESCRIPTION
ticket: https://reddit.atlassian.net/browse/ADS-1909

Currently this doesn't have support for some params that r2 uses (`subreddit`, `SIS_category`, etc.), but the docs amazon passed me seem incomplete and I'm not sure how we're supposed to do that with a SPA. r2 passes them via `apstag.init`, which can only be called once. I'll reach out and fix that up if possible. This should still work however.