### PR TITLE
Add crosspost data to screenview events

### DIFF
--- a/src/apiClient/models/PostModel.js
+++ b/src/apiClient/models/PostModel.js
@@ -21,6 +21,7 @@ export default class PostModel extends RedditModel {
     brandSafe: T.bool,
     cleanPermalink: T.link,
     cleanUrl: T.link,
+    crosspostParent: T.string,
     distinguished: T.string,
     domain: T.string,
     downs: T.number,
@@ -83,6 +84,8 @@ export default class PostModel extends RedditModel {
     videoPlaytime: T.number,
 
     // derived
+    crosspostIds: T.nop,
+    crosspostParentObj: T.nop,
     expandable: T.bool,
     expandedContent: T.html,
     preview: T.nop, // it's in data as well but we want to transform it
@@ -96,6 +99,7 @@ export default class PostModel extends RedditModel {
     banned_by: 'bannedBy',
     brand_safe: 'brandSafe',
     created_utc: 'createdUTC',
+    crosspost_parent: 'crosspostParent',
     disable_comments: 'disableComments',
     hide_score: 'hideScore',
     imp_pixel: 'impPixel',
@@ -200,6 +204,28 @@ export default class PostModel extends RedditModel {
 
     thumbnail(data) {
       return cleanThumbnail(data.thumbnail);
+    },
+
+    crosspostParentObj(data) {
+      // Note: ultimately we'll want to store this as a top level post in
+      // the redux store and reference via crosspostIds.
+      if (data.crosspostParentObj) {
+        return data.crosspostParentObj;
+      }
+      if (data.crosspost_parent_list && data.crosspost_parent_list.length) {
+        return data.crosspost_parent_list[0];
+      }
+      return null;
+    },
+
+    crosspostIds(data) {
+      if (data.crosspostIds) {
+        return data.crosspostIds;
+      }
+      if (data.crosspost_parent_list && data.crosspost_parent_list.length) {
+        return data.crosspost_parent_list.map(post => post.name);
+      }
+      return null;
     },
   };
 

--- a/src/app/router/handlers/CommentsPage.js
+++ b/src/app/router/handlers/CommentsPage.js
@@ -163,16 +163,33 @@ export function buildAdditionalEventData(state) {
     return null;
   }
 
+  let target_type;
+  let crosspost_info = {};
+  if (post.crosspostParent) {
+    target_type = 'crosspost';
+    // Note: info in post.crosspostParentObj is not processed
+    const target_root_type = post.crosspostParentObj.is_self ? 'self' : 'link';
+    crosspost_info = {
+      target_root_fullname: post.crosspostParent,
+      target_parent_fullname: post.crosspostParent,
+      target_crosspost_depth: post.crosspostIds.length,
+      target_root_type,
+    };
+  } else {
+    target_type = post.isSelf ? 'self' : 'link';
+  }
+
   return cleanObject({
     target_fullname: fullName,
     nsfw: post.over18,
     post_fullname: fullName,
     spoiler: post.spoiler,
     target_id: convertId(post.id),
-    target_type: post.isSelf ? 'self' : 'link',
+    target_type,
     target_sort: queryParams.sort || 'confidence',
     target_url: post.cleanUrl,
     target_filter_time: queryParams.sort === 'top' ? (queryParams.time || 'all') : null,
     target_created_ts: post.createdUTC * 1000,
+    ...crosspost_info,
   });
 }

--- a/src/lib/getSubredditFromState.js
+++ b/src/lib/getSubredditFromState.js
@@ -5,8 +5,13 @@ export default function getSubreddit(state) {
     return state.platform.currentPage.urlParams.subredditName;
   }
 
-  if (!state.platform.currentPage.urlParams.postId) {
+  const { postId } = state.platform.currentPage.urlParams;
+  if (!postId) {
     return null;
+  }
+
+  if (state.posts[`t3_${postId}`]) {
+    return state.posts[`t3_${postId}`].subreddit;
   }
 
   const current = state.commentsPages.data.current;


### PR DESCRIPTION
Fetch a bit of the crosspost data info into the
Post model. For now in the interest of time, we're
not bothering to process the data.

If said data exists, then we add it to the screenview
event when viewing a post comments page.

👓  @prashtx @schwers @nramadas 