### PR TITLE
a9: Ensure all targeting kvps are passed to gpt

### DIFF
--- a/src/lib/dfp.js
+++ b/src/lib/dfp.js
@@ -80,7 +80,7 @@ export const defineSlot = (element, {
 
             // we only request a single bid.
             const bid = bids[0];
-            ['amznbid', 'amzniid'].forEach(function(key) {
+            window.apstag.targetingKeys().forEach((key) => {
               adSlots[slot].setTargeting(key, bid[key]);
             });
           });


### PR DESCRIPTION
👓 @griffinmichl 

from mike:

> Since you are not using setdisplaybids and are manually managing the bids, you need to pass the amznsz value to us. The DFP LI is expecting amznsz=320x50 so right now we are not passing any bid values.
> Please make a small code change on your end to handle the new amznsz param (to handle the new orders). This is what you have currently:
> ["amznbid", "amzniid"].forEach(function(e) {
> Please change that to:
> apstag.targetingKeys().forEach(function(e) {