### PR TITLE
Set reddit native video to ignore thumbnail user setting

### DIFF
--- a/src/app/components/HTML5StreamPlayer/index.jsx
+++ b/src/app/components/HTML5StreamPlayer/index.jsx
@@ -22,7 +22,6 @@ class HTML5StreamPlayer extends React.Component {
     scrubberThumbSource: T.string.isRequired,
     isGif: T.bool.isRequired,
     isVertical: T.bool.isRequired,
-    posterImage: T.string.isRequired,
   };
 
   constructor(props) {
@@ -291,7 +290,7 @@ class HTML5StreamPlayer extends React.Component {
   enterFullScreen = () => {
     //Default to standard video controls in fullscreen for iOS
     let video = this.refs.HTML5StreamPlayerVideo;
-    
+
     if (this.isAndroid()) {
       video = this.refs.HTML5StreamPlayerContainer;
     }

--- a/src/app/components/Post/PostContent/index.jsx
+++ b/src/app/components/Post/PostContent/index.jsx
@@ -231,7 +231,7 @@ function buildMediaContent(post, linkDescriptor, props) {
     return buildMediaPreview(post, sourceURL, oembed, single);
   }
 
-  if (previewImage) {
+  if (previewImage || (post.media && post.media.reddit_video)) {
     const callback = (isNSFW || isSpoiler) ? e => {
       if (interceptListingClick(e, LISTING_CLICK_TYPES.CONTENT)) {
         return;
@@ -254,7 +254,7 @@ function buildImagePreview(previewImage, imageURL, linkDescriptor, callback,
   if (isPlaying || !needsObfuscating) {
     //locally hosted video
     if (post.media && post.media.reddit_video) {
-      const { width, height } = previewImage;
+      const { width, height } = post.media.reddit_video;
       const aspectRatio = getAspectRatio(single, width, height);
 
       const generatedSrc = {
@@ -262,10 +262,9 @@ function buildImagePreview(previewImage, imageURL, linkDescriptor, callback,
         hls: post.media.reddit_video.hls_url,
         scrubberThumbSource: post.media.reddit_video.scrubber_media_url,
         isGif: post.media.reddit_video.is_gif,
-        width: previewImage.width,
-        height: previewImage.height,
+        width: width,
+        height: height,
       };
-
       return renderVideo(generatedSrc, previewImage, aspectRatio, props);
     }
 
@@ -421,7 +420,6 @@ function renderIframe(src, aspectRatio) {
 
 function renderVideo(videoSpec, posterImage, aspectRatio, props) {
   const { post, onUpdatePostPlaytime } = props;
-
   if (videoSpec.hls || videoSpec.dash) {
     //video limited to 16:9 as specced, will be letterboxed if different reservation.
     let aspectRatio;
@@ -440,7 +438,7 @@ function renderVideo(videoSpec, posterImage, aspectRatio, props) {
         mpegDashSource = { videoSpec.dash }
         isGif = { videoSpec.isGif }
         isVertical = { (videoSpec.height > videoSpec.width) }
-        posterImage = { posterImage.url }
+        posterImage = { (posterImage !== null && posterImage !== undefined) ? posterImage.url : null }
         scrubberThumbSource = { videoSpec.scrubberThumbSource }
       />
     );

--- a/src/app/components/Post/PostContent/index.jsx
+++ b/src/app/components/Post/PostContent/index.jsx
@@ -328,9 +328,18 @@ function renderImage(previewImage, imageURL, linkDescriptor, onClick,
     obfuscatedNode = renderWarning(isThumbnail, post);
   }
 
+  const linkTarget = showLinksInNewTab ? '_blank' : null;
+
+  if ((previewImage === null || previewImage === undefined) && post.media && post.media.reddit_video) {
+    //Ensure reddit_videos receive a nsfw image even if no poster image available.
+    return renderImageWithAspectRatio(null, imageURL, linkDescriptor,
+                                    aspectRatio, onClick, isThumbnail,
+                                    playbackControlNode, obfuscatedNode, linkTarget,
+                                    post.outboundLink, forceHTTPS, isPlaying);
+  }
+
   const aspectRatio = getAspectRatio(single, previewImage.width,
                                      previewImage.height);
-  const linkTarget = showLinksInNewTab ? '_blank' : null;
 
   if (previewImage && previewImage.url && !aspectRatio) {
     return renderImageOfUnknownSize(
@@ -375,14 +384,14 @@ function renderImageWithAspectRatio(previewImage, imageURL, linkDescriptor,
 
   const style = {};
 
-  if (previewImage.url && !isPlaying) {
+  if (previewImage && previewImage.url && !isPlaying) {
     const giphyPosterHref = posterForHrefIfGiphyCat(imageURL);
     const backgroundImage = giphyPosterHref && !obfuscatedNode ?
       giphyPosterHref : previewImage.url;
     style.backgroundImage = `url("${forceProtocol(backgroundImage, forceHTTPS)}")`;
   }
 
-  let linkClass = baseImageLinkClass(previewImage.url, !!obfuscatedNode);
+  let linkClass = baseImageLinkClass(previewImage ? previewImage.url : null, !!obfuscatedNode);
   if (!isThumbnail) {
     linkClass += ` ${aspectRatioClass(aspectRatio)}`;
   }

--- a/src/app/components/Post/postUtils.js
+++ b/src/app/components/Post/postUtils.js
@@ -12,7 +12,7 @@ export function postShouldRenderMediaFullbleed(post) {
   const postHint = post.postHint;
   const media = post.media;
   return !!(postHint && postHint !== 'link' && postHint !== 'self' ||
-    media && media.oembed && media.oembed.type !== 'rich' ||
+    media && ((media.oembed && media.oembed.type !== 'rich') || media.reddit_video) ||
     rootDomain(post.cleanUrl) === 'imgur.com' && post.preview);
 }
 


### PR DESCRIPTION
Show the reddit video player even if user has ‘Don't show thumbnails next to links’
Remove the fullscreen custom controls and instead let android native controls take place (Makes the app simpler for third party apps to view).

Provides a fix for issue MEDIA-388:
https://reddit.atlassian.net/browse/MEDIA-388