### PR TITLE
Prevent previously opened reddit videos from expanding in compact mode

### DIFF
--- a/src/app/components/Post/index.jsx
+++ b/src/app/components/Post/index.jsx
@@ -200,9 +200,12 @@ export function Post(props, context) {
     );
   }
 
+  //Rddit videos without expando button (no thubmnails) should not be re-expanded
+  let hidePreviouslExpandedVideo = (post.media && post.media.reddit_video) && !post.thumbnail;
+
   const isPromotedUserPost = post.promoted && post.originalLink;
   let contentOrNil;
-  if (!displayCompact || hasExpandedCompact) {
+  if (!displayCompact || (hasExpandedCompact && !hidePreviouslExpandedVideo)) {
     contentOrNil = (
       <PostContent
         post={ post }


### PR DESCRIPTION
If no thumbnail is available then the reddit video should not expand due to user history in the feed, it can instead be viewed in the comments section.

https://reddit.atlassian.net/browse/MEDIA-410