### PR TITLE
Update branch.io lib for better support of iOS11 deep links

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "Base64": "1.0.0",
     "autoprefixer": "6.3.6",
     "babel-polyfill": "^6.7.4",
-    "branch-sdk": "^2.22.1",
+    "branch-sdk": "^2.25.2",
     "cluster": "^0.7.7",
     "crypto-js": "3.1.8",
     "dashjs": "^2.4.1",


### PR DESCRIPTION
👓 @arjunb023 @mlburgos 
cc @wting 

https://reddit.atlassian.net/browse/GROW-828
> However, we noticed that you have a cached version of our web SDK on your own servers. We’d politely ask that you update your cache with the latest version of our SDK found here: https://cdn.branch.io/branch-latest.min.js. If you don’t update, you could potentially jeopardize the value of Branch substantially if you’re still using the old version of the SDK when iOS 11 is released in the second week of September.

They have this lib in npm package already, so woohoo
The change is one liner and I double check branch-latest.min.js has the same web2.25.2 lib inside and there were no API change on new versions of the lib.