### PR TITLE
Fix page width issue with wide tables

### DIFF
--- a/src/app/less/mixins/table.less
+++ b/src/app/less/mixins/table.less
@@ -2,6 +2,9 @@
   table {
     margin: 1em 0;
     width: 100%;
+    display: inline-block;
+    overflow-x: scroll;
+    max-width: 100%;
   }
 
   td, th {


### PR DESCRIPTION
This sets tables to display in inline-block mode so we
can set a max width. Tables will scroll horizontally now