### PR TITLE
Remove raven middleware from client and server applications

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -18,7 +18,6 @@ import { setupGoogleTag } from 'lib/dfp';
 import routes from 'app/router';
 import reducers from 'app/reducers';
 import reduxMiddleware from 'app/reduxMiddleware';
-import ravenMiddleware from 'app/reduxMiddleware/raven';
 import { sendTimings, onHandlerCompleteTimings } from 'lib/timing';
 import Session from 'app/models/Session';
 import Preferences from 'apiClient/models/Preferences';
@@ -110,7 +109,7 @@ window.onunhandledrejection = rejection => {
 const client = Client({
   routes,
   reducers,
-  reduxMiddleware: [ravenMiddleware(Raven)].concat(reduxMiddleware),
+  reduxMiddleware,
   modifyData: data => {
     // TODO if we start not using shell rendering in a serious way,
     // we'll need to unserialize all of the api models. This should

--- a/src/Server.js
+++ b/src/Server.js
@@ -15,7 +15,6 @@ import routes from 'app/router';
 import main from 'server/templates/main';
 import reducers from 'app/reducers';
 import reduxMiddleware from 'app/reduxMiddleware';
-import ravenMiddleware from 'app/reduxMiddleware/raven';
 import loginproxy from 'server/session/loginproxy';
 import logoutproxy from 'server/session/logoutproxy';
 import registerproxy from 'server/session/registerproxy';
@@ -96,7 +95,7 @@ export function startServer() {
     routes,
     template: main,
     reducers,
-    reduxMiddleware: [ravenMiddleware(Raven)].concat(reduxMiddleware),
+    reduxMiddleware,
     dispatchBeforeNavigation: async (ctx, dispatch, getState) => {
       dispatchInitialShell(ctx, dispatch);
       dispatchAPIPassThroughHeaders(ctx, dispatch);


### PR DESCRIPTION
This disables mobile-web error reporting to Sentry. The goal
was to make the smallest change necessary to make sure errors
weren't being reported anymore as mobile-web is currently not
being actively worked on and existing errors, which make up
a disproportional amount of error-reporting traffic, are not
being addressed. This should allow for quick re-enabling in the
future if desired.

:eyeglasses: @phil303 @curioussavage 